### PR TITLE
feat: background app refresh for live HR (#14)

### DIFF
--- a/ios/OpenRingConn/App.swift
+++ b/ios/OpenRingConn/App.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @main
 struct OpenRingConnApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -1,0 +1,52 @@
+import BackgroundTasks
+import SwiftData
+import UIKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    private let scheduler = BackgroundRefreshScheduler()
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        scheduler.register { task in
+            guard let refreshTask = task as? BGAppRefreshTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            Self.handle(refreshTask)
+        }
+        return true
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        scheduler.schedule()
+    }
+
+    private static func handle(_ task: BGAppRefreshTask) {
+        let scheduler = BackgroundRefreshScheduler()
+        scheduler.schedule()
+
+        let operation = Task { @MainActor in
+            do {
+                let container = try ModelContainer(for: StoredSample.self, StoredCursor.self)
+                let service = RingBackgroundSyncService(
+                    store: LocalStore(container.mainContext),
+                    health: HealthKitWriter()
+                )
+                let synced = try await service.syncLiveHeartRate(timeout: 20)
+                guard !Task.isCancelled else { return }
+                scheduler.schedule()
+                task.setTaskCompleted(success: synced)
+            } catch {
+                guard !Task.isCancelled else { return }
+                scheduler.schedule()
+                task.setTaskCompleted(success: false)
+            }
+        }
+
+        task.expirationHandler = {
+            operation.cancel()
+            scheduler.schedule()
+            task.setTaskCompleted(success: false)
+        }
+    }
+}

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -35,13 +35,23 @@ final class RingScanner: NSObject {
     /// True once the user has connected; keeps us auto-reconnecting if the ring sleeps.
     private var wantConnection = false
 
-    func start() {
+    /// Service filter for background scans. iOS only delivers scan results to a
+    /// backgrounded app when `scanForPeripherals` filters by explicit service UUIDs;
+    /// a `nil` filter (used in the foreground) yields nothing in the background (#14).
+    /// Caveat: this still requires the ring to advertise its data service — if it
+    /// advertises name-only, background reconnection must instead use
+    /// `central.connect(knownPeripheral)` against a persisted identifier.
+    private static let backgroundScanServices = [CBUUID(string: OpenRingKit.Transport.dataServiceUUID)]
+
+    /// Begin scanning. Foreground callers pass no filter: the ring is matched by its
+    /// advertised name (`matchesRingName`) and is not known to advertise its data
+    /// service, so filtering there could miss it. The background path passes
+    /// `backgroundScanServices` because nil-filtered scans are dropped while backgrounded.
+    func start(services: [CBUUID]? = nil) {
         guard central.state == .poweredOn else { return }
         wantConnection = true
         state = .scanning
-        // Discover all services (the ring is reportedly not fully GATT-compatible,
-        // so we don't filter by service UUID — those roles are 🔴 in PROTOCOL.md).
-        central.scanForPeripherals(withServices: nil)
+        central.scanForPeripherals(withServices: services)
     }
 
     func stop() {
@@ -54,6 +64,47 @@ final class RingScanner: NSObject {
     func setLocalStore(_ localStore: LocalStore) {
         self.localStore = localStore
         session?.setLocalStore(localStore)
+    }
+
+    /// Tear down the live link and STOP auto-reconnecting. Clearing `wantConnection`
+    /// before cancelling is essential: otherwise `didDisconnectPeripheral` still wants a
+    /// connection and immediately reconnects, looping forever (#14 fix).
+    func disconnect() {
+        wantConnection = false
+        central.stopScan()
+        if let target {
+            central.cancelPeripheralConnection(target)
+        }
+        session = nil
+        target = nil
+        state = .idle
+    }
+
+    /// Bounded one-shot live-HR read for the background-refresh task: scan/connect,
+    /// start HR monitoring, and return the first reading (or nil on timeout). Always
+    /// disconnects on the way out so the link isn't held open in the background.
+    func readLiveHeartRate(timeout: TimeInterval) async -> Int? {
+        let deadline = Date().addingTimeInterval(timeout)
+        var didStart = false
+        start(services: Self.backgroundScanServices)
+
+        defer { disconnect() }
+
+        while !Task.isCancelled && Date() < deadline {
+            if let session, session.ready {
+                if !didStart {
+                    session.startMonitoring(mode: .hr)
+                    didStart = true
+                }
+                if let liveHR = session.liveHR {
+                    return liveHR
+                }
+            } else if case .idle = state {
+                start(services: Self.backgroundScanServices)
+            }
+            try? await Task.sleep(for: .seconds(1))
+        }
+        return nil
     }
 }
 

--- a/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
+++ b/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
@@ -1,0 +1,52 @@
+import BackgroundTasks
+import Foundation
+
+protocol BGTaskScheduling {
+    func register(forTaskWithIdentifier identifier: String,
+                  using queue: DispatchQueue?,
+                  launchHandler: @escaping (BGTask) -> Void) -> Bool
+    func cancel(taskRequestWithIdentifier identifier: String)
+    func submit(_ taskRequest: BGTaskRequest) throws
+}
+
+extension BGTaskScheduler: BGTaskScheduling {}
+
+struct BackgroundRefreshScheduler {
+    static let identifier = "com.openringconn.app.bgrefresh"
+    static let refreshInterval: TimeInterval = 15 * 60
+
+    private let scheduler: BGTaskScheduling
+    private let now: () -> Date
+
+    init(scheduler: BGTaskScheduling = BGTaskScheduler.shared,
+         now: @escaping () -> Date = Date.init) {
+        self.scheduler = scheduler
+        self.now = now
+    }
+
+    @discardableResult
+    func register(launchHandler: @escaping (BGTask) -> Void) -> Bool {
+        scheduler.register(
+            forTaskWithIdentifier: Self.identifier,
+            using: nil,
+            launchHandler: launchHandler
+        )
+    }
+
+    func makeRequest() -> BGAppRefreshTaskRequest {
+        let request = BGAppRefreshTaskRequest(identifier: Self.identifier)
+        request.earliestBeginDate = now().addingTimeInterval(Self.refreshInterval)
+        return request
+    }
+
+    func schedule() {
+        do {
+            scheduler.cancel(taskRequestWithIdentifier: Self.identifier)
+            try scheduler.submit(makeRequest())
+        } catch {
+            #if DEBUG
+            print("Unable to schedule background refresh: \(error)")
+            #endif
+        }
+    }
+}

--- a/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
+++ b/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
@@ -1,0 +1,29 @@
+import Foundation
+import OpenRingKit
+
+@MainActor
+struct RingBackgroundSyncService {
+    private let store: LocalStore
+    private let health: HealthKitWriter
+
+    init(store: LocalStore, health: HealthKitWriter) {
+        self.store = store
+        self.health = health
+    }
+
+    func syncLiveHeartRate(timeout: TimeInterval = 20) async throws -> Bool {
+        let scanner = RingScanner()
+        guard let hr = await scanner.readLiveHeartRate(timeout: timeout) else {
+            return false
+        }
+
+        let now = Date()
+        let samples = try store.ingest([
+            QuantitySample(kind: .heartRate, start: now, value: Double(hr))
+        ])
+        if HealthKitWriter.isAvailable {
+            try? await health.write(samples)
+        }
+        return true
+    }
+}

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -8,6 +8,9 @@ struct ContentView: View {
     @State private var healthAuthorized = false
     @State private var lastWrite: String?
     @State private var showDebug = false
+    /// Last HR persisted to the store (from a prior session or a background refresh),
+    /// shown on launch before BLE reconnects. #14
+    @State private var lastKnownHR: QuantitySample?
 
     private let health = HealthKitWriter()
 
@@ -35,6 +38,8 @@ struct ContentView: View {
                 // Wire persistence into the scanner/session so the (currently gated)
                 // epoch-sync decoder can persist Layer-A records once enabled. #24
                 scanner.setLocalStore(LocalStore(modelContext))
+                // Surface the last persisted HR immediately, before BLE reconnects. #14
+                loadLaunchSnapshot()
             }
         }
     }
@@ -70,7 +75,9 @@ struct ContentView: View {
     private var hrCard: some View {
         card {
             metricHeader("HEART RATE", icon: "heart.fill", color: .red, active: hrActive())
-            bigReading(session?.liveHR, unit: "BPM", color: .red, active: hrActive())
+            // Fall back to the last persisted reading on launch / before reconnect. #14
+            bigReading(session?.liveHR ?? lastKnownHR.map { Int($0.value) },
+                       unit: "BPM", color: .red, active: hrActive())
 
             if hrActive() {
                 // Optical HR is a windowed average that climbs over ~20–60 s of stillness,
@@ -99,6 +106,9 @@ struct ContentView: View {
                 }
             } else if session?.liveHR != nil {
                 Text("Last reading — tap Measure to refresh.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            } else if lastKnownHR != nil {
+                Text("Last synced reading — connect to refresh.")
                     .font(.caption2).foregroundStyle(.secondary)
             }
 
@@ -382,5 +392,24 @@ struct ContentView: View {
         case .connecting(let n): return "Connecting to \(n)…"
         case .connected(let n): return n
         }
+    }
+
+    // MARK: Background-refresh support (#14)
+
+    /// Load the last persisted HR so the UI can show it immediately on launch.
+    private func loadLaunchSnapshot() {
+        guard let snapshot = try? LaunchSnapshot.load(from: LocalStore(modelContext)) else { return }
+        lastKnownHR = snapshot.lastHeartRate
+    }
+
+    /// One-shot foreground refresh: read a live HR, persist it, and update the snapshot.
+    /// Mirrors what the background task does, for an on-demand pull.
+    private func refreshLiveHeartRate() async {
+        guard let hr = await scanner.readLiveHeartRate(timeout: 10) else { return }
+        let sample = QuantitySample(kind: .heartRate, start: Date(), value: Double(hr))
+        if let fresh = try? LocalStore(modelContext).ingest([sample]) {
+            try? await health.write(fresh)
+        }
+        loadLaunchSnapshot()
     }
 }

--- a/ios/OpenRingConn/Info.plist
+++ b/ios/OpenRingConn/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.openringconn.app.bgrefresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -27,6 +31,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>
+		<string>fetch</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -152,6 +152,16 @@ struct LocalStore {
         return segments
     }
 
+    func latestSample(kind: MetricKind) throws -> QuantitySample? {
+        let kindRaw = kind.rawValue
+        var descriptor = FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == kindRaw },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]
+        )
+        descriptor.fetchLimit = 1
+        return try context.fetch(descriptor).first?.sample
+    }
+
     private func upsertCursor(kind: String, last: Date) {
         let descriptor = FetchDescriptor<StoredCursor>(
             predicate: #Predicate { $0.kindRaw == kind })
@@ -196,5 +206,13 @@ struct LocalStore {
         }
 
         return CumulativeMetricState(previousRawValue: previousRaw)
+    }
+}
+
+struct LaunchSnapshot {
+    let lastHeartRate: QuantitySample?
+
+    static func load(from store: LocalStore) throws -> LaunchSnapshot {
+        LaunchSnapshot(lastHeartRate: try store.latestSample(kind: .heartRate))
     }
 }

--- a/ios/OpenRingConnTests/BackgroundRefreshSchedulerTests.swift
+++ b/ios/OpenRingConnTests/BackgroundRefreshSchedulerTests.swift
@@ -1,0 +1,58 @@
+import BackgroundTasks
+import XCTest
+@testable import OpenRingConn
+
+final class BackgroundRefreshSchedulerTests: XCTestCase {
+    func testRequestUsesExpectedIdentifierAndFifteenMinuteEarliestBeginDate() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let scheduler = BackgroundRefreshScheduler(
+            scheduler: RecordingScheduler(),
+            now: { now }
+        )
+
+        let request = scheduler.makeRequest()
+
+        XCTAssertEqual(request.identifier, BackgroundRefreshScheduler.identifier)
+        XCTAssertEqual(
+            request.earliestBeginDate?.timeIntervalSince1970,
+            now.addingTimeInterval(15 * 60).timeIntervalSince1970
+        )
+    }
+
+    func testScheduleSubmitsRefreshRequest() {
+        let recording = RecordingScheduler()
+        let now = Date(timeIntervalSince1970: 2_000)
+        let scheduler = BackgroundRefreshScheduler(
+            scheduler: recording,
+            now: { now }
+        )
+
+        scheduler.schedule()
+
+        XCTAssertEqual(recording.cancelledIdentifier, BackgroundRefreshScheduler.identifier)
+        XCTAssertEqual(recording.submitted?.identifier, BackgroundRefreshScheduler.identifier)
+        XCTAssertEqual(
+            recording.submitted?.earliestBeginDate?.timeIntervalSince1970,
+            now.addingTimeInterval(15 * 60).timeIntervalSince1970
+        )
+    }
+}
+
+private final class RecordingScheduler: BGTaskScheduling {
+    private(set) var cancelledIdentifier: String?
+    private(set) var submitted: BGTaskRequest?
+
+    func register(forTaskWithIdentifier identifier: String,
+                  using queue: DispatchQueue?,
+                  launchHandler: @escaping (BGTask) -> Void) -> Bool {
+        true
+    }
+
+    func cancel(taskRequestWithIdentifier identifier: String) {
+        cancelledIdentifier = identifier
+    }
+
+    func submit(_ taskRequest: BGTaskRequest) throws {
+        submitted = taskRequest
+    }
+}

--- a/ios/OpenRingConnTests/LocalStoreLaunchTests.swift
+++ b/ios/OpenRingConnTests/LocalStoreLaunchTests.swift
@@ -1,0 +1,31 @@
+import SwiftData
+import XCTest
+@testable import OpenRingConn
+
+@MainActor
+final class LocalStoreLaunchTests: XCTestCase {
+    func testLaunchSnapshotReadsLastKnownHeartRate() throws {
+        let container = try ModelContainer(
+            for: StoredSample.self, StoredCursor.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let context = container.mainContext
+        context.insert(StoredSample(
+            kindRaw: "heartRate",
+            start: Date(timeIntervalSince1970: 100),
+            end: Date(timeIntervalSince1970: 100),
+            value: 71
+        ))
+        context.insert(StoredSample(
+            kindRaw: "heartRate",
+            start: Date(timeIntervalSince1970: 200),
+            end: Date(timeIntervalSince1970: 200),
+            value: 74
+        ))
+        try context.save()
+
+        let snapshot = try LaunchSnapshot.load(from: LocalStore(context))
+
+        XCTAssertEqual(snapshot.lastHeartRate?.value, 74)
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,6 +30,9 @@ targets:
         # Background sync while suspended (docs/HANDOFF_MACOS_IOS.md).
         UIBackgroundModes:
           - bluetooth-central
+          - fetch
+        BGTaskSchedulerPermittedIdentifiers:
+          - com.openringconn.app.bgrefresh
     # HealthKit entitlement intentionally OMITTED for free-team signing (it needs a
     # paid Apple Developer account, and setting CODE_SIGN_ENTITLEMENTS on a free team
     # breaks device launch — see git history). BLE works; HealthKit auth no-ops at
@@ -49,3 +52,15 @@ targets:
         # On-device signing. Xcode fills DEVELOPMENT_TEAM when you pick your team
         # (or set it here to your 10-char Team ID for CLI builds).
         CODE_SIGN_STYLE: Automatic
+
+  OpenRingConnTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: OpenRingConnTests
+    dependencies:
+      - target: OpenRingConn
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openringconn.app.tests
+        SWIFT_VERSION: "5.9"


### PR DESCRIPTION
## Summary

- Registers `BGAppRefreshTask` (`com.openringconn.app.bgrefresh`) and schedules it every 15 minutes via `BackgroundRefreshScheduler`
- `AppDelegate` handles the task with timeout/cancel handling and rescheduling
- `RingBackgroundSyncService` drives a bounded one-shot live HR read over BLE in the background
- `LocalStore.latestSample` and `LaunchSnapshot` persist last-known HR so `ContentView` shows it immediately on launch
- Unit tests for scheduling and `LocalStore` launch read path
- `Info.plist` and `project.yml` updated

## Test plan

- [ ] `plutil -lint ios/OpenRingConn/Info.plist` passes
- [ ] App launches and shows last persisted HR before BLE connects
- [ ] Background refresh fires after 15 min and updates `LocalStore`
- [ ] Cancel path cleans up without crash

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)