### PR TITLE
feat: calorie calculation from TRIMP + user profile (#16)

### DIFF
--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -294,6 +294,12 @@ struct ContentView: View {
                             .frame(width: total > 0 ? geo.size.width * mins(stage) / total : 0)
                     }
                 }
+
+                Section("Settings") {
+                    NavigationLink("User Profile") {
+                        UserProfileSettingsView()
+                    }
+                }
             }
             .frame(height: 12)
             .clipShape(Capsule())

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -48,6 +48,7 @@ final class HealthKitWriter {
         for k in MetricKind.allCases {
             if let t = Self.quantityType(for: k) { set.insert(t) }
         }
+        set.insert(HKQuantityType(.basalEnergyBurned))
         set.insert(HKCategoryType(.sleepAnalysis))
         return set
     }
@@ -65,6 +66,40 @@ final class HealthKitWriter {
         }
         guard !hkSamples.isEmpty else { return }
         try await store.save(hkSamples)
+    }
+
+    func writePassiveCalories(profile: UserProfile, date: Date) async throws {
+        let type = HKQuantityType(.basalEnergyBurned)
+        let quantity = HKQuantity(
+            unit: .kilocalorie(),
+            doubleValue: Calories.bmrKcalPerHour(profile: profile)
+        )
+        let sample = HKQuantitySample(
+            type: type,
+            quantity: quantity,
+            start: date,
+            end: date.addingTimeInterval(3600)
+        )
+        try await store.save(sample)
+    }
+
+    func writeActiveCalories(kcal: Double, date: Date) async throws {
+        guard kcal > 0 else { return }
+        let type = HKQuantityType(.activeEnergyBurned)
+        let quantity = HKQuantity(unit: .kilocalorie(), doubleValue: kcal)
+        let sample = HKQuantitySample(
+            type: type,
+            quantity: quantity,
+            start: date,
+            end: date.addingTimeInterval(3600)
+        )
+        try await store.save(sample)
+    }
+
+    func writeActiveCalories(hrSamples: [HRSample], profile: UserProfile, date: Date) async throws {
+        let maxHR = max(220 - profile.age, 1)
+        let kcal = Calories.activeKcal(hrSamples: hrSamples, maxHR: maxHR)
+        try await writeActiveCalories(kcal: kcal, date: date)
     }
 
     /// Write a night as contiguous sleepAnalysis category samples (mapping notes).

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import OpenRingKit
+
+@MainActor
+struct UserProfileSettingsView: View {
+    @AppStorage("userProfile.age") private var age = 35
+    @AppStorage("userProfile.weightKg") private var weightKg = 70.0
+    @AppStorage("userProfile.heightCm") private var heightCm = 170.0
+    @AppStorage("userProfile.sex") private var sexRaw = BiologicalSex.male.rawValue
+
+    var body: some View {
+        Form {
+            Section("Profile") {
+                Stepper(value: $age, in: 13...120) {
+                    LabeledContent("Age", value: "\(age)")
+                }
+                LabeledContent("Weight") {
+                    TextField("kg", value: $weightKg, format: .number.precision(.fractionLength(1)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                }
+                LabeledContent("Height") {
+                    TextField("cm", value: $heightCm, format: .number.precision(.fractionLength(1)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                }
+                Picker("Sex", selection: $sexRaw) {
+                    ForEach(BiologicalSex.allCases, id: \.rawValue) { sex in
+                        Text(sex.rawValue.capitalized).tag(sex.rawValue)
+                    }
+                }
+            }
+
+            Section("Calories") {
+                LabeledContent("BMR", value: "\(Int(Calories.bmrKcalPerDay(profile: profile).rounded())) kcal/day")
+                LabeledContent("Passive", value: "\(Calories.bmrKcalPerHour(profile: profile), specifier: "%.1f") kcal/hour")
+                LabeledContent("Max HR", value: "\(maxHR) bpm")
+            }
+        }
+        .navigationTitle("User Profile")
+    }
+
+    private var profile: UserProfile {
+        UserProfile(
+            age: age,
+            weightKg: max(weightKg, 1.0),
+            heightCm: max(heightCm, 1.0),
+            sex: BiologicalSex(rawValue: sexRaw) ?? .male
+        )
+    }
+
+    private var maxHR: Int {
+        max(220 - age, 1)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/Calories.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/Calories.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public struct HRSample: Equatable, Codable, Sendable {
+    public let bpm: Int
+    public let start: Date
+    public let end: Date
+
+    public init(bpm: Int, start: Date, end: Date? = nil) {
+        self.bpm = bpm
+        self.start = start
+        self.end = end ?? start
+    }
+}
+
+public enum Calories {
+    public static let trimpKcalFactor = 5.0
+    public static let defaultRestingHR = 60
+
+    public static func bmrKcalPerDay(profile: UserProfile) -> Double {
+        let base = (10.0 * profile.weightKg)
+            + (6.25 * profile.heightCm)
+            - (5.0 * Double(profile.age))
+        switch profile.sex {
+        case .male: return base + 5.0
+        case .female: return base - 161.0
+        }
+    }
+
+    public static func bmrKcalPerHour(profile: UserProfile) -> Double {
+        bmrKcalPerDay(profile: profile) / 24.0
+    }
+
+    public static func activeKcal(hrSamples: [HRSample], maxHR: Int) -> Double {
+        guard let trimp = Strain.edwardsTRIMP(
+            hrSamples: hrSamples,
+            maxHR: maxHR,
+            restingHR: defaultRestingHR
+        ) else {
+            return 0.0
+        }
+        return trimp * trimpKcalFactor
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/Strain.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/Strain.swift
@@ -39,13 +39,43 @@ public struct Strain: Sendable {
     /// Strain for a BPM series sampled every `sampleSeconds`. nil if too few
     /// readings or maxHR ≤ restingHR. Mirrors `StrainCalculator::calculate`.
     public func calculate(bpms: [Int], sampleSeconds: Double = 1.0) -> Double? {
-        guard bpms.count >= Self.minReadings, maxHR > restingHR else { return nil }
+        guard let trimp = Self.edwardsTRIMP(
+            bpms: bpms,
+            maxHR: maxHR,
+            restingHR: restingHR,
+            sampleSeconds: sampleSeconds
+        ) else { return nil }
+        return Self.trimpToStrain(trimp)
+    }
+
+    /// Raw Edwards zone-weighted TRIMP for a BPM series.
+    public static func edwardsTRIMP(
+        bpms: [Int],
+        maxHR: Int,
+        restingHR: Int,
+        sampleSeconds: Double = 1.0
+    ) -> Double? {
+        guard bpms.count >= minReadings, maxHR > restingHR else { return nil }
         let hrReserve = Double(maxHR) - Double(restingHR)
         let sampleMin = sampleSeconds <= 0 ? 1.0 / 60.0 : sampleSeconds / 60.0
-        let trimp = bpms.reduce(0.0) { acc, bpm in
-            acc + sampleMin * Double(Self.zoneWeight(bpm: bpm, restingHR: restingHR, hrReserve: hrReserve))
+        return bpms.reduce(0.0) { acc, bpm in
+            acc + sampleMin * Double(zoneWeight(bpm: bpm, restingHR: restingHR, hrReserve: hrReserve))
         }
-        return Self.trimpToStrain(trimp)
+    }
+
+    /// Raw Edwards zone-weighted TRIMP for timestamped HR samples.
+    public static func edwardsTRIMP(hrSamples: [HRSample], maxHR: Int, restingHR: Int) -> Double? {
+        guard hrSamples.count >= minReadings, maxHR > restingHR else { return nil }
+        let hrReserve = Double(maxHR) - Double(restingHR)
+        return hrSamples.reduce(0.0) { acc, sample in
+            let duration = sample.end.timeIntervalSince(sample.start)
+            let sampleMin = duration > 0 ? duration / 60.0 : 1.0 / 60.0
+            return acc + sampleMin * Double(zoneWeight(
+                bpm: sample.bpm,
+                restingHR: restingHR,
+                hrReserve: hrReserve
+            ))
+        }
     }
 
     static func trimpToStrain(_ trimp: Double) -> Double {

--- a/ios/OpenRingKit/Sources/OpenRingKit/UserProfile.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/UserProfile.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public enum BiologicalSex: String, Codable, CaseIterable, Sendable {
+    case male
+    case female
+}
+
+public struct UserProfile: Equatable, Codable, Sendable {
+    public let age: Int
+    public let weightKg: Double
+    public let heightCm: Double
+    public let sex: BiologicalSex
+
+    public init(age: Int, weightKg: Double, heightCm: Double, sex: BiologicalSex) {
+        self.age = age
+        self.weightKg = weightKg
+        self.heightCm = heightCm
+        self.sex = sex
+    }
+}

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -138,6 +138,22 @@ check(strain.calculate(bpms: Array(repeating: 80, count: 500)) == nil, "too few 
 check(Strain(maxHR: 60, restingHR: 60).calculate(bpms: Array(repeating: 80, count: 600)) == nil,
       "maxHR<=restingHR -> nil")
 
+// Calories (Mifflin-St Jeor BMR + Edwards TRIMP kcal)
+let maleProfile = UserProfile(age: 30, weightKg: 80, heightCm: 180, sex: .male)
+check(Calories.bmrKcalPerDay(profile: maleProfile) == 1780.0, "male BMR Mifflin-St Jeor")
+check(abs(Calories.bmrKcalPerHour(profile: maleProfile) - 74.166_666) < 0.001, "male BMR hourly")
+let femaleProfile = UserProfile(age: 40, weightKg: 65, heightCm: 165, sex: .female)
+check(Calories.bmrKcalPerDay(profile: femaleProfile) == 1320.25, "female BMR Mifflin-St Jeor")
+let hrStart = Date(timeIntervalSince1970: 0)
+let calorieSamples = (0..<600).map { offset in
+    HRSample(
+        bpm: 150,
+        start: hrStart.addingTimeInterval(Double(offset)),
+        end: hrStart.addingTimeInterval(Double(offset + 1))
+    )
+}
+check(abs(Calories.activeKcal(hrSamples: calorieSamples, maxHR: 180) - 150.0) < 0.001, "TRIMP 30 -> 150 kcal")
+
 // Sleep score (integer-ratio model, faithful to openwhoop)
 check(SleepScore.score(durationSeconds: 8 * 3600) == 100.0, "8h sleep -> 100")
 check(SleepScore.score(durationSeconds: 4 * 3600) == 0.0, "4h sleep -> 0 (integer ratio)")

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/AnalyticsTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/AnalyticsTests.swift
@@ -75,6 +75,33 @@ final class AnalyticsTests: XCTestCase {
         XCTAssertEqual(Strain(maxHR: 190, restingHR: 60).calculate(bpms: Array(repeating: 190, count: 86400)), 21.0)
     }
 
+    // MARK: Calories — Mifflin-St Jeor + TRIMP
+
+    func testMaleBMRMifflinStJeor() {
+        let profile = UserProfile(age: 30, weightKg: 80, heightCm: 180, sex: .male)
+        XCTAssertEqual(Calories.bmrKcalPerDay(profile: profile), 1780.0, accuracy: 0.001)
+        XCTAssertEqual(Calories.bmrKcalPerHour(profile: profile), 74.166_666, accuracy: 0.001)
+    }
+
+    func testFemaleBMRMifflinStJeor() {
+        let profile = UserProfile(age: 40, weightKg: 65, heightCm: 165, sex: .female)
+        XCTAssertEqual(Calories.bmrKcalPerDay(profile: profile), 1320.25, accuracy: 0.001)
+    }
+
+    func testActiveCaloriesFromEdwardsTRIMP() {
+        let start = Date(timeIntervalSince1970: 0)
+        let samples = (0..<600).map { offset in
+            HRSample(
+                bpm: 150,
+                start: start.addingTimeInterval(Double(offset)),
+                end: start.addingTimeInterval(Double(offset + 1))
+            )
+        }
+        // maxHR 180, restingHR 60, bpm 150 => 75% HRR => zone weight 3.
+        // 600 one-second samples = 10 min, TRIMP = 30, kcal = 150.
+        XCTAssertEqual(Calories.activeKcal(hrSamples: samples, maxHR: 180), 150.0, accuracy: 0.001)
+    }
+
     // MARK: Sleep score (sleep.rs)
 
     func testSleepScore() {


### PR DESCRIPTION
## Summary

- Adds shared `UserProfile` / `BiologicalSex` models in `OpenRingKit` and `OpenRingConn`
- `Calories` analytics module using Mifflin-St Jeor BMR and TRIMP-to-kcal conversion
- Edwards TRIMP helpers exposed from `Strain` for calorie pipeline use
- `UserProfileSettingsView` (SwiftUI) persisted via `@AppStorage`, linked from `ContentView`
- HealthKit write methods for basal and active calories; max HR derived as `220 - age`
- XCTest coverage for male BMR, female BMR, and TRIMP-to-kcal; matching `RingKitVerify` checks

## Test plan

- [ ] `swift build` in `ios/OpenRingKit` passes
- [ ] `swift run RingKitVerify` passes including calorie checks
- [ ] Profile settings persist across app launches
- [ ] Calorie writes appear in Apple Health after a session

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)