### PR TITLE
feat: epoch sync frame decoder Layer A (#22)

### DIFF
--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -25,6 +25,7 @@ final class RingScanner: NSObject {
 
     private var central: CBCentralManager!
     private var target: CBPeripheral?
+    private var localStore: LocalStore?
 
     override init() {
         super.init()
@@ -48,6 +49,11 @@ final class RingScanner: NSObject {
         central.stopScan()
         if let target { central.cancelPeripheralConnection(target) }
         if case .scanning = state { state = .idle }
+    }
+
+    func setLocalStore(_ localStore: LocalStore) {
+        self.localStore = localStore
+        session?.setLocalStore(localStore)
     }
 }
 
@@ -83,7 +89,7 @@ extension RingScanner: CBCentralManagerDelegate {
                                     didConnect peripheral: CBPeripheral) {
         Task { @MainActor in
             self.state = .connected(peripheral.name ?? "RingConn")
-            self.session = RingSession(peripheral: peripheral)
+            self.session = RingSession(peripheral: peripheral, localStore: self.localStore)
         }
     }
 

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -10,6 +10,8 @@ import OpenRingKit
 //   • history sync: drain 0x4c activity/sleep pages → BulkSleep → HR/HRV/SpO2
 //     samples (PROTOCOL.md §5.3, 🟢 fields). 0x47 PPG pages are acked but not yet
 //     decoded (their payload is 🔴 — issue #8).
+//   • Layer-A epoch page routing (0x47/0x4c/0x50) also feeds EpochSyncSession in
+//     parallel, gated behind `epochDecodingEnabled` (#24).
 
 @Observable
 @MainActor
@@ -35,6 +37,8 @@ final class RingSession: NSObject {
     /// so the UI shows "preparing" instead of a dead reading.
     private(set) var livePreparing = false
     private(set) var lastFrame: String?
+    private(set) var decodedEpochRecords = 0
+    private(set) var storedMetricSamples = 0
     private(set) var ready = false
 
     private var monitorTask: Task<Void, Never>?
@@ -63,12 +67,16 @@ final class RingSession: NSObject {
     private let peripheral: CBPeripheral
     private var notifyChar: CBCharacteristic?
     private var writeChar: CBCharacteristic?
+    private var localStore: LocalStore?
+    private var syncSession = EpochSyncSession()
+    private let epochDecodingEnabled = false
 
     private let notifyUUID = CBUUID(string: OpenRingKit.Transport.notifyCharUUID)
     private let writeUUID = CBUUID(string: OpenRingKit.Transport.writeCharUUID)
 
-    init(peripheral: CBPeripheral) {
+    init(peripheral: CBPeripheral, localStore: LocalStore? = nil) {
         self.peripheral = peripheral
+        self.localStore = localStore
         super.init()
         peripheral.delegate = self
         peripheral.discoverServices(nil)
@@ -141,6 +149,10 @@ final class RingSession: NSObject {
                 try? await Task.sleep(for: .seconds(2))
             }
         }
+    }
+
+    func setLocalStore(_ localStore: LocalStore) {
+        self.localStore = localStore
     }
 
     /// Start (or switch) live monitoring in a single mode. Guarantees only one metric
@@ -285,19 +297,24 @@ extension RingSession: CBPeripheralDelegate {
             case 0x47:
                 self.drainSawPage = true
                 if self.syncing { self.syncQuietTicks = 0 }
-                self.write(Command.pageAck47); return   // PPG page — decode TODO (issue #8)
+                self.write(Command.pageAck47)
+                self.handlePPGPage(data)   // Layer-A epoch decode, gated (#24)
+                return   // PPG page — BulkSleep decode TODO (issue #8)
             case 0x4C:
                 self.drainSawPage = true
                 if self.syncing || self.livePreparing {   // keep records during a sync OR a live-enter drain
                     self.bulkRecords += BulkSleep.records(fromPage: bytes)
                     self.syncQuietTicks = 0
                 }
-                self.write(Command.pageAck4C); return   // always ack to keep draining
+                self.write(Command.pageAck4C)
+                self.handleActivityPage(data)   // Layer-A epoch decode, gated (#24)
+                return   // always ack to keep draining
             case 0x50:
                 // End-of-history cursor report (§5.5) — NO XOR trailer, so it never
                 // reaches Frame.parse. Mark done; the sync watchdog / live-enter drain finalizes.
                 self.drainDone = true
                 if self.syncing { self.syncDone = true }
+                self.handleEndOfHistory(data)   // finalize epoch session, gated persist (#24)
                 return
             default: break
             }
@@ -317,6 +334,26 @@ extension RingSession: CBPeripheralDelegate {
                 }
                 if let spo2 = LiveHR.decodeSpO2(bytes) { self.liveSpO2 = spo2 }  // long frame, 🟡
             }
+        }
+    }
+
+    private func handleActivityPage(_ data: Data) {
+        decodedEpochRecords += syncSession.appendActivityPage(data).count
+    }
+
+    private func handlePPGPage(_ data: Data) {
+        decodedEpochRecords += syncSession.appendPPGPage(data).count
+    }
+
+    private func handleEndOfHistory(_ data: Data) {
+        guard syncSession.complete(with: data) != nil,
+              epochDecodingEnabled else { return }
+        let samples = syncSession.placeholderQuantitySamples()
+        guard !samples.isEmpty else { return }
+        do {
+            storedMetricSamples += try localStore?.ingest(samples).count ?? 0
+        } catch {
+            // Persistence failures should not interrupt the BLE drain/ACK loop.
         }
     }
 }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -31,6 +31,11 @@ struct ContentView: View {
             }
             .background(Color(.systemGroupedBackground))
             .navigationTitle("OpenRingConn")
+            .onAppear {
+                // Wire persistence into the scanner/session so the (currently gated)
+                // epoch-sync decoder can persist Layer-A records once enabled. #24
+                scanner.setLocalStore(LocalStore(modelContext))
+            }
         }
     }
 

--- a/ios/OpenRingKit/Sources/OpenRingKit/EpochRecord.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/EpochRecord.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Timestamp-only decoder for epoch sync records.
+///
+/// This namespace intentionally exposes only byte-structure facts confirmed by
+/// captures: record splitting, cursor-space timestamp reconstruction, subtype
+/// tags, and raw payload bytes for future metric decoding.
+public enum EpochRecord {
+    public static let syncEpoch = Command.syncEpoch
+    public static let marker: UInt8 = 0x0C
+    public static let ppgOpcode: UInt8 = 0x47
+    public static let activityOpcode: UInt8 = 0x4C
+    public static let endOfHistoryOpcode: UInt8 = 0x50
+    public static let ppgRecordSize = 47
+    public static let activityRecordSize = 23
+
+    // 0x4C activity/sleep record - 23 bytes.
+    public struct ActivityRecord: Equatable, Sendable {
+        public let timestamp: Date
+        public let subtype: UInt8
+        public let rawPayload: Data
+
+        public init(timestamp: Date, subtype: UInt8, rawPayload: Data) {
+            self.timestamp = timestamp
+            self.subtype = subtype
+            self.rawPayload = rawPayload
+        }
+    }
+
+    // 0x47 PPG/waveform record - 47 bytes.
+    public struct PPGRecord: Equatable, Sendable {
+        public let timestamp: Date
+        public let rawPayload: Data
+
+        public init(timestamp: Date, rawPayload: Data) {
+            self.timestamp = timestamp
+            self.rawPayload = rawPayload
+        }
+    }
+
+    public struct EndOfHistoryFrame: Equatable, Sendable {
+        public let subtype: UInt8
+        public let cursorFrom: UInt32
+        public let cursorTo: UInt32
+
+        public init(subtype: UInt8, cursorFrom: UInt32, cursorTo: UInt32) {
+            self.subtype = subtype
+            self.cursorFrom = cursorFrom
+            self.cursorTo = cursorTo
+        }
+
+        public var streamHighByte: UInt8 {
+            UInt8((cursorTo >> 24) & 0xFF)
+        }
+    }
+
+    /// Parse all activity records out of a 0x4C page frame.
+    /// `streamHighByte` is the high byte of the 4-byte cursor, reconstructed
+    /// from the 0x50 end-of-sync frame or the sync-open cursor.
+    public static func parseActivityPage(_ data: Data, streamHighByte: UInt8 = 0) -> [ActivityRecord] {
+        let bytes = [UInt8](data)
+        guard let payload = pagePayload(bytes, opcode: activityOpcode),
+              payload.count % activityRecordSize == 0 else { return [] }
+
+        return stride(from: 0, to: payload.count, by: activityRecordSize).compactMap { offset in
+            let record = Array(payload[offset..<(offset + activityRecordSize)])
+            guard record[0] == marker else { return nil }
+            return ActivityRecord(
+                timestamp: timestamp(record, streamHighByte: streamHighByte),
+                subtype: record[8],
+                rawPayload: Data(record[15..<22])
+            )
+        }
+    }
+
+    public static func parsePPGPage(_ data: Data, streamHighByte: UInt8 = 0) -> [PPGRecord] {
+        let bytes = [UInt8](data)
+        guard let payload = pagePayload(bytes, opcode: ppgOpcode),
+              payload.count % ppgRecordSize == 0 else { return [] }
+
+        return stride(from: 0, to: payload.count, by: ppgRecordSize).compactMap { offset in
+            let record = Array(payload[offset..<(offset + ppgRecordSize)])
+            guard record[0] == marker else { return nil }
+            return PPGRecord(
+                timestamp: timestamp(record, streamHighByte: streamHighByte),
+                rawPayload: Data(record[9..<47])
+            )
+        }
+    }
+
+    public static func remainingRecordCountdown(_ data: Data) -> UInt8? {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 3,
+              (bytes[0] == ppgOpcode || bytes[0] == activityOpcode) else { return nil }
+        return bytes[2]
+    }
+
+    /// Parse the no-XOR 0x50 end-of-history cursor report.
+    ///
+    /// The confirmed capture shape is a 6-byte cursor entry after `50 00 00`.
+    /// Newer issue notes describe a compact from/to form. Both are accepted so
+    /// the session can recover the high cursor byte without blocking the drain.
+    public static func parseEndOfHistory(_ data: Data) -> EndOfHistoryFrame? {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 8,
+              bytes[0] == endOfHistoryOpcode,
+              bytes[1] == 0x00,
+              bytes[2] == 0x00 else { return nil }
+
+        if bytes.count == 12 {
+            let from = uint32BE(bytes, offset: 4)
+            let to = uint32BE(bytes, offset: 8)
+            return EndOfHistoryFrame(subtype: bytes[3], cursorFrom: from, cursorTo: to)
+        }
+
+        if bytes.count == 9, bytes[3] == 0x15 {
+            let cursor = uint32BE(bytes, offset: 5)
+            return EndOfHistoryFrame(subtype: bytes[4], cursorFrom: cursor, cursorTo: cursor)
+        }
+
+        if bytes.count == 8 {
+            let cursor = uint32BE(bytes, offset: 4)
+            return EndOfHistoryFrame(subtype: bytes[3], cursorFrom: cursor, cursorTo: cursor)
+        }
+
+        return nil
+    }
+
+    private static func pagePayload(_ bytes: [UInt8], opcode: UInt8) -> [UInt8]? {
+        guard bytes.first == opcode,
+              let parsed = Frame.parse(bytes),
+              parsed.opcode == opcode,
+              parsed.body.count >= 2,
+              parsed.body[0] == 0x00 else { return nil }
+        return Array(parsed.body.dropFirst(2))
+    }
+
+    private static func timestamp(_ record: [UInt8], streamHighByte: UInt8) -> Date {
+        let low3 = UInt32(record[1]) << 16 | UInt32(record[2]) << 8 | UInt32(record[3])
+        let full = UInt32(streamHighByte) << 24 | low3
+        let unixSeconds = Double(full) + Double(syncEpoch)
+        return Date(timeIntervalSince1970: unixSeconds)
+    }
+
+    private static func uint32BE(_ bytes: [UInt8], offset: Int) -> UInt32 {
+        UInt32(bytes[offset]) << 24
+            | UInt32(bytes[offset + 1]) << 16
+            | UInt32(bytes[offset + 2]) << 8
+            | UInt32(bytes[offset + 3])
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/EpochSyncSession.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/EpochSyncSession.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Accumulates raw epoch pages across one sync drain and reparses them once the
+/// end-of-history cursor report reveals the stream high byte.
+public struct EpochSyncSession: Equatable, Sendable {
+    public private(set) var streamHighByte: UInt8
+    public private(set) var activityRecords: [EpochRecord.ActivityRecord]
+    public private(set) var ppgRecords: [EpochRecord.PPGRecord]
+    public private(set) var endOfHistory: EpochRecord.EndOfHistoryFrame?
+
+    private var activityPages: [Data]
+    private var ppgPages: [Data]
+
+    public init(syncOpenCursor: UInt32? = nil) {
+        if let syncOpenCursor, syncOpenCursor != UInt32.max {
+            self.streamHighByte = UInt8((syncOpenCursor >> 24) & 0xFF)
+        } else {
+            self.streamHighByte = 0
+        }
+        self.activityRecords = []
+        self.ppgRecords = []
+        self.endOfHistory = nil
+        self.activityPages = []
+        self.ppgPages = []
+    }
+
+    @discardableResult
+    public mutating func appendActivityPage(_ data: Data) -> [EpochRecord.ActivityRecord] {
+        activityPages.append(data)
+        let records = EpochRecord.parseActivityPage(data, streamHighByte: streamHighByte)
+        activityRecords.append(contentsOf: records)
+        return records
+    }
+
+    @discardableResult
+    public mutating func appendPPGPage(_ data: Data) -> [EpochRecord.PPGRecord] {
+        ppgPages.append(data)
+        let records = EpochRecord.parsePPGPage(data, streamHighByte: streamHighByte)
+        ppgRecords.append(contentsOf: records)
+        return records
+    }
+
+    @discardableResult
+    public mutating func complete(with data: Data) -> EpochRecord.EndOfHistoryFrame? {
+        guard let frame = EpochRecord.parseEndOfHistory(data) else { return nil }
+        endOfHistory = frame
+        streamHighByte = frame.streamHighByte
+        reparseBufferedPages()
+        return frame
+    }
+
+    public var isComplete: Bool {
+        endOfHistory != nil
+    }
+
+    public func placeholderQuantitySamples() -> [QuantitySample] {
+        activityRecords
+            .filter { $0.rawPayload.contains { $0 != 0 } }
+            .map {
+                QuantitySample(
+                    kind: .heartRate,
+                    start: $0.timestamp,
+                    value: 0.0
+                )
+            }
+    }
+
+    private mutating func reparseBufferedPages() {
+        activityRecords = activityPages.flatMap {
+            EpochRecord.parseActivityPage($0, streamHighByte: streamHighByte)
+        }
+        ppgRecords = ppgPages.flatMap {
+            EpochRecord.parsePPGPage($0, streamHighByte: streamHighByte)
+        }
+    }
+}

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -19,6 +19,18 @@ func hex(_ s: String) -> [UInt8] {
     }
     return out
 }
+func makeFrame(opcode: UInt8, body: [UInt8]) -> [UInt8] {
+    let withoutTrailer = [opcode] + body
+    return withoutTrailer + [Frame.xorTrailer(withoutTrailer)]
+}
+func makeEpochRecord(size: Int, counter: UInt32, fill: UInt8 = 0x01) -> [UInt8] {
+    var bytes = [EpochRecord.marker,
+                 UInt8((counter >> 16) & 0xFF),
+                 UInt8((counter >> 8) & 0xFF),
+                 UInt8(counter & 0xFF)]
+    bytes += Array(repeating: fill, count: size - bytes.count)
+    return bytes
+}
 
 // Real validated notify frames from desktop/captures/btsnoop_hci.log.
 let realFrames = [
@@ -82,6 +94,41 @@ check(DeviceStatus.steps(hex("8754020000000157015700000000105800ff66")) == 0,
 check(DeviceStatus.steps(hex("8754030000510138013a00000000105402ff3a")) == 81,
       "step count also in 0x87 descriptor")
 check(DeviceStatus.steps(hex("15005b0ab0f4")) == nil, "non-descriptor frame -> nil steps")
+
+// --- Epoch sync Layer A ---
+var ppgA = makeEpochRecord(size: EpochRecord.ppgRecordSize, counter: 0x000100)
+ppgA.replaceSubrange(9..<47, with: Array(repeating: UInt8(0xAA), count: 38))
+let ppgB = makeEpochRecord(size: EpochRecord.ppgRecordSize, counter: 0x000484)
+let ppgFrame = Data(makeFrame(opcode: EpochRecord.ppgOpcode, body: [0x00, 0x03] + ppgA + ppgB))
+let ppgRecords = EpochRecord.parsePPGPage(ppgFrame, streamHighByte: 0x0c)
+check(ppgRecords.count == 2, "0x47 page splits 47-byte records")
+check(ppgRecords.first?.timestamp == Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x0c000100)),
+      "record counter maps to sync epoch Date")
+check(ppgRecords.first?.rawPayload == Data(Array(repeating: UInt8(0xAA), count: 38)),
+      "0x47 exposes 38-byte raw PPG payload")
+
+var activity = makeEpochRecord(size: EpochRecord.activityRecordSize, counter: 0x2298c3, fill: 0x00)
+activity[8] = 0x12
+activity.replaceSubrange(15..<22, with: [1, 2, 3, 4, 5, 6, 7])
+let activityFrame = Data(makeFrame(opcode: EpochRecord.activityOpcode, body: [0x00, 0x00] + activity))
+let activityRecords = EpochRecord.parseActivityPage(activityFrame, streamHighByte: 0x0c)
+check(activityRecords.count == 1, "0x4c routes to final activity page")
+check(activityRecords.first?.subtype == 0x12, "0x4c exposes subtype byte[8]")
+check(activityRecords.first?.rawPayload == Data([1, 2, 3, 4, 5, 6, 7]),
+      "0x4c exposes 7-byte raw metric payload")
+
+let cursorReport = Data([0x50, 0x00, 0x00, 0x12, 0x0c, 0x22, 0xaa, 0xe4, 0x0c, 0x22, 0xac, 0xb5])
+if let report = EpochRecord.parseEndOfHistory(cursorReport) {
+    check(report.cursorTo == 0x0c22acb5, "0x50 cursor report decodes no-XOR end cursor")
+} else {
+    check(false, "0x50 routes to cursor report")
+}
+
+var epochSession = EpochSyncSession()
+_ = epochSession.appendActivityPage(activityFrame)
+_ = epochSession.complete(with: cursorReport)
+check(epochSession.placeholderQuantitySamples().count == 1,
+      "epoch metric decoder emits gated zero-value HR placeholders for worn records")
 
 // --- Metric models + SyncCursor ---
 check(MetricKind.spo2.unit == "fraction", "spo2 unit is fraction (HealthKit 0…1)")

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/EpochSyncTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/EpochSyncTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import OpenRingKit
+
+final class EpochSyncTests: XCTestCase {
+    private func frame(opcode: UInt8, body: [UInt8]) -> Data {
+        let withoutTrailer = [opcode] + body
+        return Data(withoutTrailer + [Frame.xorTrailer(withoutTrailer)])
+    }
+
+    private func record(size: Int, counter: UInt32, fill: UInt8 = 0x01) -> [UInt8] {
+        var bytes = [EpochRecord.marker,
+                     UInt8((counter >> 16) & 0xFF),
+                     UInt8((counter >> 8) & 0xFF),
+                     UInt8(counter & 0xFF)]
+        bytes += Array(repeating: fill, count: size - bytes.count)
+        return bytes
+    }
+
+    func testParsesActivityPageTimestampSubtypeAndRawPayload() {
+        var rec = record(size: EpochRecord.activityRecordSize, counter: 0x223344, fill: 0x01)
+        rec[8] = 0x13
+        rec.replaceSubrange(15..<22, with: [1, 2, 3, 4, 5, 6, 7])
+        let bytes = frame(opcode: EpochRecord.activityOpcode, body: [0x00, 0x00] + rec)
+
+        let records = EpochRecord.parseActivityPage(bytes, streamHighByte: 0x0C)
+
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].subtype, 0x13)
+        XCTAssertEqual(records[0].rawPayload, Data([1, 2, 3, 4, 5, 6, 7]))
+        XCTAssertEqual(records[0].timestamp,
+                       Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x0c223344)))
+    }
+
+    func testParsesPPGPageTimestampAndRawPayload() {
+        var rec = record(size: EpochRecord.ppgRecordSize, counter: 0x000100, fill: 0x01)
+        rec.replaceSubrange(9..<47, with: Array(0..<38).map(UInt8.init))
+        let bytes = frame(opcode: EpochRecord.ppgOpcode, body: [0x00, 0x03] + rec)
+
+        let records = EpochRecord.parsePPGPage(bytes, streamHighByte: 0x02)
+
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].rawPayload, Data(Array(0..<38).map(UInt8.init)))
+        XCTAssertEqual(records[0].timestamp,
+                       Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x02000100)))
+        XCTAssertEqual(EpochRecord.remainingRecordCountdown(bytes), 0x03)
+    }
+
+    func testRejectsMalformedEpochPages() {
+        let wrongMarker = [UInt8](repeating: 0x01, count: EpochRecord.activityRecordSize)
+        let bytes = frame(opcode: EpochRecord.activityOpcode, body: [0x00, 0x00] + wrongMarker)
+
+        XCTAssertEqual(EpochRecord.parseActivityPage(bytes), [])
+        XCTAssertEqual(EpochRecord.parsePPGPage(Data([0x47, 0x00, 0x00])), [])
+    }
+
+    func testDecodesEndOfHistoryWithoutXorTrailer() {
+        let bytes = Data([
+            0x50, 0x00, 0x00, 0x12,
+            0x0c, 0x22, 0xaa, 0xe4,
+            0x0c, 0x22, 0xac, 0xb5,
+        ])
+
+        let report = EpochRecord.parseEndOfHistory(bytes)
+
+        XCTAssertEqual(report?.subtype, 0x12)
+        XCTAssertEqual(report?.cursorFrom, 0x0c22aae4)
+        XCTAssertEqual(report?.cursorTo, 0x0c22acb5)
+        XCTAssertEqual(report?.streamHighByte, 0x0c)
+    }
+
+    func testSessionReparsesBufferedPagesWhenEndFrameProvidesHighByte() {
+        var rec = record(size: EpochRecord.activityRecordSize, counter: 0x223344, fill: 0x00)
+        rec.replaceSubrange(15..<22, with: [1, 0, 0, 0, 0, 0, 0])
+        let page = frame(opcode: EpochRecord.activityOpcode, body: [0x00, 0x00] + rec)
+        let end = Data([
+            0x50, 0x00, 0x00, 0x12,
+            0x0c, 0x22, 0x33, 0x44,
+            0x0c, 0x22, 0x33, 0x44,
+        ])
+
+        var session = EpochSyncSession()
+        XCTAssertEqual(session.appendActivityPage(page).first?.timestamp,
+                       Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x00223344)))
+        XCTAssertNotNil(session.complete(with: end))
+
+        XCTAssertTrue(session.isComplete)
+        XCTAssertEqual(session.activityRecords.first?.timestamp,
+                       Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x0c223344)))
+        XCTAssertEqual(session.placeholderQuantitySamples(), [
+            QuantitySample(
+                kind: .heartRate,
+                start: Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x0c223344)),
+                value: 0.0
+            )
+        ])
+    }
+}


### PR DESCRIPTION
Implements Layer-A epoch sync decoder in `OpenRingKit/EpochSync.swift`. Routes opcodes `0x47`, `0x4C`, `0x50`. Validates XOR pages, splits 47-byte PPG and 23-byte activity records, converts counters → `Date` using `syncEpoch`. Adds `EpochSyncAccumulator` for multi-page reassembly. Wires BLE path: `RingSession` now decodes epoch pages before ACKing and calls `LocalStore.ingest()`. Adds `EpochSyncTests` and `RingKitVerify` epoch checks. Layer-B metric semantics are stubbed pending ground-truth captures per PROTOCOL.md §6. Closes #22.