### PR TITLE
Store robustness: bounded vitals queries, lean ingest, migration safety, post-commit cursor (#32 #33 #40 #22)

### DIFF
--- a/ios/OpenRingConn/App.swift
+++ b/ios/OpenRingConn/App.swift
@@ -9,38 +9,79 @@ struct OpenRingConnApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                // Retention housekeeping: drop raw samples older than the window once per launch
+                // (the data already lives in Apple Health; rollups are kept). Runs off the launch
+                // path, never per write — see LocalStore.pruneExpiredSamples. (#32)
+                .task { OpenRingConnApp.pruneExpiredSamplesAtLaunch(container) }
         }
         .modelContainer(container)
     }
 
+    // MARK: Schema versioning (#40)
+    //
+    // A real (currently single-version) migration plan so an *expected* schema change is handled
+    // by lightweight/custom migration instead of falling through to the last-resort wipe below.
+    // Future schema changes append a `VersionedSchema` + a `MigrationStage` here rather than
+    // relying on the wipe — which destroys un-resyncable local history.
+    enum SchemaV1: VersionedSchema {
+        static var versionIdentifier = Schema.Version(1, 0, 0)
+        static var models: [any PersistentModel.Type] {
+            [StoredSample.self, StoredCursor.self, StoredSleepSummary.self, StoredDaily.self]
+        }
+    }
+
+    enum MigrationPlan: SchemaMigrationPlan {
+        static var schemas: [any VersionedSchema.Type] { [SchemaV1.self] }
+        static var stages: [MigrationStage] { [] }
+    }
+
+    /// UserDefaults flag the UI can read to tell the user their local cache was rebuilt (raw
+    /// sample history isn't re-syncable once the ring has been drained). Set only when the
+    /// last-resort wipe runs; the UI clears it after showing the notice. (#40)
+    static let historyResetDefaultsKey = "localHistoryWasReset"
+
     /// Build the SwiftData container, recovering from an incompatible on-disk store.
     ///
-    /// The default `.modelContainer(for:)` modifier traps if the container can't be
-    /// created — e.g. a schema change that lightweight migration can't handle — so the
-    /// app dies on the launch screen (black screen). Instead, if the first attempt
-    /// fails we wipe the local store and retry: it's only a cache of metrics the ring
-    /// re-syncs (and that are already in Apple Health), so nothing is permanently lost.
-    /// Prefer a real `SchemaMigrationPlan` for *expected* migrations; this is the
-    /// last-resort net so a model change can never hard-crash launch again.
+    /// The default `.modelContainer(for:)` modifier traps if the container can't be created —
+    /// e.g. a schema change neither `MigrationPlan` nor lightweight migration can handle — so the
+    /// app dies on the launch screen (black screen). Expected migrations go through the plan;
+    /// only if that STILL fails do we fall back to wiping. Before wiping we export the durable
+    /// rollups (sleep summaries + daily steps) to a JSON backup and restore them into the fresh
+    /// store, and raise `historyResetDefaultsKey` so the UI can tell the user. Raw epoch samples
+    /// are not backed up — they're already in Apple Health. (#40)
     static func makeContainer() -> ModelContainer {
         let schema = Schema([StoredSample.self, StoredCursor.self,
                              StoredSleepSummary.self, StoredDaily.self])
         let config = ModelConfiguration(schema: schema)
 
         do {
-            return try ModelContainer(for: schema, configurations: config)
+            return try ModelContainer(for: schema, migrationPlan: MigrationPlan.self,
+                                      configurations: config)
         } catch {
             #if DEBUG
-            print("SwiftData store unusable (\(error)); resetting local cache and retrying.")
+            print("SwiftData store unusable (\(error)); backing up rollups, resetting cache, retrying.")
             #endif
+            let backup = RollupBackup.exportBeforeWipe(config: config)
             removeStoreFiles(at: config.url)
+            let fresh: ModelContainer
             do {
-                return try ModelContainer(for: schema, configurations: config)
+                fresh = try ModelContainer(for: schema, migrationPlan: MigrationPlan.self,
+                                           configurations: config)
             } catch {
                 // A fresh store still failed — genuinely unrecoverable (e.g. no disk).
                 fatalError("Unrecoverable SwiftData store error: \(error)")
             }
+            backup?.restore(into: fresh)
+            UserDefaults.standard.set(true, forKey: historyResetDefaultsKey)
+            return fresh
         }
+    }
+
+    /// Prune expired raw samples once at launch. Best-effort — retention is housekeeping, so a
+    /// failure here must never block the UI.
+    @MainActor
+    static func pruneExpiredSamplesAtLaunch(_ container: ModelContainer) {
+        try? LocalStore(container.mainContext).pruneExpiredSamples()
     }
 
     /// Delete the SQLite store plus its `-shm`/`-wal` sidecar files.
@@ -51,6 +92,82 @@ struct OpenRingConnApp: App {
                     base.appendingPathExtension("store-shm"),
                     base.appendingPathExtension("store-wal")] {
             try? fm.removeItem(at: url)
+        }
+    }
+}
+
+/// Best-effort JSON backup of the durable rollup tables, used by `makeContainer` to carry sleep
+/// summaries + daily steps across a last-resort store wipe (#40). Raw `StoredSample` epochs are
+/// intentionally excluded — they already live in Apple Health and would bloat the backup.
+/// Everything here is best-effort: a failure degrades to "history reset", never a crash.
+struct RollupBackup: Codable {
+    struct Sleep: Codable {
+        var night: Date
+        var asleepMin, deepMin, lightMin, remMin, awakeMin: Int
+        var efficiency: Double
+        var inBedStart, inBedEnd, updatedAt: Date
+    }
+    struct Daily: Codable {
+        var day: Date
+        var steps: Int
+        var updatedAt: Date
+        var healthWrittenSteps: Int
+    }
+    var sleep: [Sleep]
+    var daily: [Daily]
+
+    private static var backupURL: URL? {
+        guard let dir = try? FileManager.default.url(
+            for: .applicationSupportDirectory, in: .userDomainMask,
+            appropriateFor: nil, create: true) else { return nil }
+        return dir.appendingPathComponent("rollup-backup.json")
+    }
+
+    /// Read the rollup tables from the (un-openable-as-current) store using a schema LIMITED to
+    /// just those tables — so a schema change to the sample/cursor tables can't block reading
+    /// them — and write a JSON snapshot. Returns the snapshot (nil if even this best-effort read
+    /// fails). The file persists so a crash mid-wipe can't lose the rollups.
+    static func exportBeforeWipe(config: ModelConfiguration) -> RollupBackup? {
+        let schema = Schema([StoredSleepSummary.self, StoredDaily.self])
+        let limited = ModelConfiguration(schema: schema, url: config.url)
+        guard let container = try? ModelContainer(for: schema, configurations: limited) else { return nil }
+        let ctx = ModelContext(container)
+        let sleepRows = (try? ctx.fetch(FetchDescriptor<StoredSleepSummary>())) ?? []
+        let dailyRows = (try? ctx.fetch(FetchDescriptor<StoredDaily>())) ?? []
+        let backup = RollupBackup(
+            sleep: sleepRows.map {
+                Sleep(night: $0.night, asleepMin: $0.asleepMin, deepMin: $0.deepMin,
+                      lightMin: $0.lightMin, remMin: $0.remMin, awakeMin: $0.awakeMin,
+                      efficiency: $0.efficiency, inBedStart: $0.inBedStart,
+                      inBedEnd: $0.inBedEnd, updatedAt: $0.updatedAt)
+            },
+            daily: dailyRows.map {
+                Daily(day: $0.day, steps: $0.steps, updatedAt: $0.updatedAt,
+                      healthWrittenSteps: $0.healthWrittenSteps)
+            })
+        if let url = backupURL, let data = try? JSONEncoder().encode(backup) {
+            try? data.write(to: url, options: .atomic)
+        }
+        return backup
+    }
+
+    /// Re-insert the backed-up rollups into the fresh store, then remove the JSON file. The
+    /// unique `night`/`day` keys keep this idempotent. Best-effort — a failure just means the
+    /// dashboard starts without past history.
+    func restore(into container: ModelContainer) {
+        let ctx = ModelContext(container)
+        for s in sleep {
+            ctx.insert(StoredSleepSummary(
+                night: s.night, asleepMin: s.asleepMin, deepMin: s.deepMin, lightMin: s.lightMin,
+                remMin: s.remMin, awakeMin: s.awakeMin, efficiency: s.efficiency,
+                inBedStart: s.inBedStart, inBedEnd: s.inBedEnd, updatedAt: s.updatedAt))
+        }
+        for d in daily {
+            ctx.insert(StoredDaily(day: d.day, steps: d.steps, updatedAt: d.updatedAt,
+                                   healthWrittenSteps: d.healthWrittenSteps))
+        }
+        if (try? ctx.save()) != nil, let url = Self.backupURL {
+            try? FileManager.default.removeItem(at: url)
         }
     }
 }

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -162,20 +162,40 @@ struct LocalStore {
 
     init(_ context: ModelContext) { self.context = context }
 
-    /// Rebuild the in-memory SyncCursor from persisted rows. Skips the `hk:`-prefixed
-    /// HealthKit-watermark rows (see `pendingHealthSamples`) — they live in the same table
-    /// but track a separate concern and must not pollute the store-ingest cursor.
+    /// The store-ingest cursor rows (live `@Model` objects, so mutating `.last` updates the
+    /// context). Skips the `hk:`-prefixed HealthKit-watermark rows (see `pendingHealthSamples`)
+    /// — they live in the same table but track a separate concern and must not pollute the
+    /// store-ingest cursor.
+    private func storeCursorRows() throws -> [StoredCursor] {
+        try context.fetch(FetchDescriptor<StoredCursor>())
+            .filter { !$0.kindRaw.hasPrefix(Self.healthCursorPrefix) }
+    }
+
+    /// Rebuild the in-memory SyncCursor from persisted rows.
     func loadCursor() throws -> SyncCursor {
-        let rows = try context.fetch(FetchDescriptor<StoredCursor>())
         var map: [String: Date] = [:]
-        for r in rows where !r.kindRaw.hasPrefix(Self.healthCursorPrefix) { map[r.kindRaw] = r.last }
+        for r in try storeCursorRows() { map[r.kindRaw] = r.last }
         return SyncCursor(lastByKind: map)
     }
 
     /// Persist new samples and advance the cursor in one step.
+    ///
+    /// Ordering matters (#22): the cursor advance is STAGED in memory and only the rows that
+    /// actually moved are written, then samples + cursor commit together in a single
+    /// `context.save()`. On a save failure we roll back, so the persisted cursor never moves
+    /// ahead of un-stored samples — they're retried on the next ingest instead of being lost.
     func ingest(_ samples: [QuantitySample]) throws -> [QuantitySample] {
-        var cursor = try loadCursor()
-        let fresh = cursor.selectNew(samples)
+        // Fetch the cursor rows ONCE and reuse them for both the in-memory cursor and the
+        // post-insert upsert — no per-`MetricKind` fetch loop (#33).
+        let rows = try storeCursorRows()
+        var rowByKind: [String: StoredCursor] = [:]
+        for r in rows { rowByKind[r.kindRaw] = r }
+        let cursor = SyncCursor(lastByKind: rowByKind.mapValues(\.last))
+
+        // Stage the advance — don't touch the persisted cursor until the save commits (#22).
+        let (fresh, advanced) = cursor.selectNewStaged(samples)
+        guard !fresh.isEmpty else { return [] }
+
         var cumulativeStates: [MetricKind: CumulativeMetricState] = [:]
         var cumulativeStateDays: [MetricKind: Date] = [:]
         var ingested: [QuantitySample] = []
@@ -198,6 +218,9 @@ struct LocalStore {
                     ? existing
                     : CumulativeMetricState(previousRawValue: existing.previousRawValue, dailyTotal: 0)
             } else {
+                // First sample of this kind in the batch: the ONLY DB hit for cumulative state.
+                // Subsequent samples of the same kind reuse the in-memory `cumulativeStates`
+                // cache above, so no further per-sample lookups occur this ingest (#33).
                 state = try cumulativeState(for: s.kind, before: s.start)
             }
 
@@ -219,12 +242,45 @@ struct LocalStore {
             // every epoch would massively overcount. Deltas sum back to the daily total in Health.
             ingested.append(deltaSample)
         }
-        for kind in MetricKind.allCases {
-            guard let last = cursor.last(kind) else { continue }
-            upsertCursor(kind: kind.rawValue, last: last)
+        // Persist ONLY the kinds whose cursor actually advanced, reusing the rows already
+        // fetched above — no fetch-per-`MetricKind.allCases` loop (#33).
+        for kind in advanced.advancedKinds(since: cursor) {
+            guard let last = advanced.last(kind) else { continue }
+            if let existing = rowByKind[kind.rawValue] {
+                existing.last = last
+            } else {
+                context.insert(StoredCursor(kindRaw: kind.rawValue, last: last))
+            }
         }
-        try context.save()
+        do {
+            // Samples + cursor advance commit atomically. On failure, roll back the staged
+            // inserts and cursor moves so the next ingest re-stores the same samples (#22).
+            try context.save()
+        } catch {
+            context.rollback()
+            throw error
+        }
         return ingested
+    }
+
+    // MARK: Retention (#32)
+    //
+    // Days of raw `StoredSample` history kept on-device. Older epochs are pruned — the data
+    // already lives in Apple Health — while the rollup tables (`StoredSleepSummary` /
+    // `StoredDaily`) are kept long-term so the offline dashboard still shows past nights/days.
+    static let sampleRetentionDays = 30
+
+    /// Delete raw samples older than the retention window; rollup tables are untouched. Meant to
+    /// run occasionally (e.g. once at launch), NOT per write: with no column index a predicate
+    /// delete scans `start`, so running it on every live sample would reintroduce the unbounded
+    /// scan #32 is removing. The cumulative-counter day chain is unaffected (it only reaches back
+    /// to the current day, far inside the window).
+    func pruneExpiredSamples(olderThan days: Int = LocalStore.sampleRetentionDays,
+                             now: Date = Date()) throws {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: now) ?? now
+        try context.delete(model: StoredSample.self,
+                           where: #Predicate { $0.start < cutoff })
+        try context.save()
     }
 
     /// Stored samples of one kind within `[start, end)`, oldest→newest. Used by the

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -13,7 +13,7 @@ struct VitalsTableView: View {
     /// Latest stored sample per displayed kind (newest first, capped at 1 each).
     @Query private var latestHR: [StoredSample]
     @Query private var latestSpO2: [StoredSample]
-    @Query private var latestTemp: [StoredSample]
+    @Query private var latestTempSample: [StoredSample]
     @Query private var latestHRV: [StoredSample]
     @Query private var latestRR: [StoredSample]
     /// Heart-rate samples over the last 24 h — the window resting HR (the sleep low) scans.
@@ -64,7 +64,7 @@ struct VitalsTableView: View {
 
         _latestHR = Query(Self.latestDescriptor(hr))
         _latestSpO2 = Query(Self.latestDescriptor(spo2))
-        _latestTemp = Query(Self.latestDescriptor(temp))
+        _latestTempSample = Query(Self.latestDescriptor(temp))
         _latestHRV = Query(Self.latestDescriptor(hrv))
         _latestRR = Query(Self.latestDescriptor(rr))
         _recentHR = Query(FetchDescriptor<StoredSample>(
@@ -115,7 +115,7 @@ struct VitalsTableView: View {
         var out: [MetricKind: StoredSample] = [:]
         out[.heartRate] = latestHR.first
         out[.spo2] = latestSpO2.first
-        out[.temperature] = latestTemp.first
+        out[.temperature] = latestTempSample.first
         out[.hrvSDNN] = latestHRV.first
         out[.respiratoryRate] = latestRR.first
         return out

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -6,12 +6,25 @@ import OpenRingKit
 /// are always visible offline) and prefers the live session reading when connected.
 struct VitalsTableView: View {
     @Environment(\.modelContext) private var modelContext
-    /// Most-recent samples first; we reduce to the latest per kind in `latest`.
-    @Query(sort: \StoredSample.start, order: .reverse) private var samples: [StoredSample]
-    /// Persisted sleep summaries (latest night first) — the offline fallback for `sleep`.
-    @Query(sort: \StoredSleepSummary.night, order: .reverse) private var storedSleep: [StoredSleepSummary]
-    /// Persisted daily rollups (latest day first) — the offline fallback for live steps.
-    @Query(sort: \StoredDaily.day, order: .reverse) private var storedDaily: [StoredDaily]
+    // BOUNDED fetches replace the old unbounded `@Query` that loaded every StoredSample on every
+    // view update (#32). Each "latest" query is `fetchLimit = 1`; the two windowed queries cap
+    // the scan to a recent time slice instead of all history. All filtering done in `body` is
+    // over these already-bounded arrays — never a synchronous fetch (the #14 black-screen hazard).
+    /// Latest stored sample per displayed kind (newest first, capped at 1 each).
+    @Query private var latestHR: [StoredSample]
+    @Query private var latestSpO2: [StoredSample]
+    @Query private var latestTemp: [StoredSample]
+    @Query private var latestHRV: [StoredSample]
+    @Query private var latestRR: [StoredSample]
+    /// Heart-rate samples over the last 24 h — the window resting HR (the sleep low) scans.
+    @Query private var recentHR: [StoredSample]
+    /// Temperature samples over the last few days — narrowed in memory to the precise night
+    /// window for the overnight average (the exact window depends on async @State).
+    @Query private var recentTemp: [StoredSample]
+    /// Latest persisted sleep summary (capped at 1) — the offline fallback for `sleep`.
+    @Query private var storedSleep: [StoredSleepSummary]
+    /// Latest persisted daily rollup (capped at 1) — the offline fallback for live steps.
+    @Query private var storedDaily: [StoredDaily]
     /// Live session (optional) — its readings override stored ones while connected.
     var session: RingSession?
     /// LIVE sleep summary for the most recent night (total asleep + estimated stage
@@ -26,6 +39,59 @@ struct VitalsTableView: View {
     @AppStorage(SleepScheduleDefaults.enabled) private var sleepEnabled = false
     @AppStorage(SleepScheduleDefaults.bedMinutes) private var bedMinutes = SleepScheduleDefaults.defaultBedMinutes
     @AppStorage(SleepScheduleDefaults.wakeMinutes) private var wakeMinutes = SleepScheduleDefaults.defaultWakeMinutes
+
+    /// Days of temperature history the night-temp window query scans before the precise night
+    /// window is applied in memory — generous enough to cover the most recent night, still tiny
+    /// versus all history.
+    private static let tempWindowDays: TimeInterval = 3
+
+    init(session: RingSession? = nil, sleep: SleepStaging.Summary? = nil) {
+        self.session = session
+        self.sleep = sleep
+
+        // Anchor the time windows to the start of the current hour so the @Query descriptors stay
+        // stable across rapid SwiftUI re-renders (only re-fetching hourly or when data changes),
+        // instead of churning on every render with a millisecond-fresh cutoff.
+        let hourStart = Calendar.current.dateInterval(of: .hour, for: Date())?.start ?? Date()
+        let dayAgo = hourStart.addingTimeInterval(-86_400)
+        let tempLookback = hourStart.addingTimeInterval(-Self.tempWindowDays * 86_400)
+
+        let hr = MetricKind.heartRate.rawValue
+        let spo2 = MetricKind.spo2.rawValue
+        let temp = MetricKind.temperature.rawValue
+        let hrv = MetricKind.hrvSDNN.rawValue
+        let rr = MetricKind.respiratoryRate.rawValue
+
+        _latestHR = Query(Self.latestDescriptor(hr))
+        _latestSpO2 = Query(Self.latestDescriptor(spo2))
+        _latestTemp = Query(Self.latestDescriptor(temp))
+        _latestHRV = Query(Self.latestDescriptor(hrv))
+        _latestRR = Query(Self.latestDescriptor(rr))
+        _recentHR = Query(FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == hr && $0.start > dayAgo && $0.value > 0 },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]))
+        _recentTemp = Query(FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == temp && $0.start > tempLookback && $0.value > 0 },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]))
+
+        var sleepDesc = FetchDescriptor<StoredSleepSummary>(
+            sortBy: [SortDescriptor(\.night, order: .reverse)])
+        sleepDesc.fetchLimit = 1
+        _storedSleep = Query(sleepDesc)
+        var dailyDesc = FetchDescriptor<StoredDaily>(sortBy: [SortDescriptor(\.day, order: .reverse)])
+        dailyDesc.fetchLimit = 1
+        _storedDaily = Query(dailyDesc)
+    }
+
+    /// Newest-first, single-row descriptor for one metric kind. Predicate shape (`kindRaw` then
+    /// `start`) is index-friendly so it can use a composite index if one is added later. (#32)
+    private static func latestDescriptor(_ kindRaw: String) -> FetchDescriptor<StoredSample> {
+        var d = FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == kindRaw },
+            sortBy: [SortDescriptor(\.start, order: .reverse)])
+        d.fetchLimit = 1
+        return d
+    }
 
     /// Prefer the live session summary; fall back to the latest stored night offline.
     private var effectiveSleep: SleepStaging.Summary? {
@@ -42,22 +108,23 @@ struct VitalsTableView: View {
         return storedDaily.first.flatMap { $0.day == today ? $0.steps : nil }
     }
 
+    /// Latest stored sample per displayed kind, assembled from the per-kind `fetchLimit = 1`
+    /// queries (absent kinds stay out of the dict). Replaces the old in-memory reduce over every
+    /// stored row. (#32)
     private var latest: [MetricKind: StoredSample] {
         var out: [MetricKind: StoredSample] = [:]
-        for s in samples {
-            guard let k = MetricKind(rawValue: s.kindRaw), out[k] == nil else { continue }
-            out[k] = s
-        }
+        out[.heartRate] = latestHR.first
+        out[.spo2] = latestSpO2.first
+        out[.temperature] = latestTemp.first
+        out[.hrvSDNN] = latestHRV.first
+        out[.respiratoryRate] = latestRR.first
         return out
     }
 
-    /// Resting HR ≈ the lowest HR over the last 24 h (sleep low), derived from stored HR.
+    /// Resting HR ≈ the lowest HR over the last 24 h (sleep low). `recentHR` is already the
+    /// bounded 24 h, value-positive HR window, so this is just its min. (#32)
     private var restingHR: Int? {
-        let dayAgo = Date().addingTimeInterval(-86_400)
-        let hrs = samples
-            .filter { $0.kindRaw == MetricKind.heartRate.rawValue && $0.start > dayAgo && $0.value > 0 }
-            .map { $0.value }
-        return hrs.min().map { Int($0) }
+        recentHR.map(\.value).min().map { Int($0) }
     }
 
     var body: some View {
@@ -232,12 +299,10 @@ struct VitalsTableView: View {
     /// else local 00:00–06:00 of the most recent date that has temperature samples.
     private var nightTemp: Double? {
         guard let window = nightWindow else { return nil }
-        // Filter the already-loaded @Query array in memory — no synchronous fetch in `body`
-        // (that hazard once caused a black-screen launch). #14
-        let tempKind = MetricKind.temperature.rawValue
-        let vals = samples.lazy
-            .filter { $0.kindRaw == tempKind && $0.value > 0
-                      && $0.start >= window.start && $0.start <= window.end }
+        // Narrow the already-loaded (bounded) `recentTemp` window to the precise night in memory
+        // — no synchronous fetch in `body` (that hazard once caused a black-screen launch). #14
+        let vals = recentTemp.lazy
+            .filter { $0.start >= window.start && $0.start <= window.end }
             .map(\.value)
         var sum = 0.0, n = 0
         for v in vals { sum += v; n += 1 }

--- a/ios/OpenRingKit/Sources/OpenRingKit/SyncCursor.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/SyncCursor.swift
@@ -36,4 +36,22 @@ public struct SyncCursor: Equatable, Codable, Sendable {
         for s in fresh { advance(s.kind, to: s.start) }
         return fresh
     }
+
+    /// Non-mutating `selectNew` for callers that must only advance the cursor AFTER a durable
+    /// store commit: returns the to-write subset together with the cursor state to persist
+    /// *once the save succeeds*. Staging the advance means a failed/rolled-back save leaves the
+    /// cursor where it was, so the same decoded samples are retried next time rather than being
+    /// skipped — decoded frames must always end up stored (#22).
+    public func selectNewStaged(_ samples: [QuantitySample]) -> (fresh: [QuantitySample], advanced: SyncCursor) {
+        var advanced = self
+        let fresh = advanced.selectNew(samples)
+        return (fresh, advanced)
+    }
+
+    /// Kinds whose high-water mark differs from `previous` — i.e. the cursors that actually
+    /// moved. Lets the store persist only the changed rows instead of re-writing every kind on
+    /// every ingest (#33).
+    public func advancedKinds(since previous: SyncCursor) -> [MetricKind] {
+        MetricKind.allCases.filter { last($0) != previous.last($0) }
+    }
 }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SyncCursorTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SyncCursorTests.swift
@@ -37,6 +37,36 @@ final class SyncCursorTests: XCTestCase {
         XCTAssertEqual(c.last(.heartRate), t2)
     }
 
+    func testSelectNewStagedDoesNotMutateUntilApplied() {
+        let c = SyncCursor()
+        let (fresh, advanced) = c.selectNewStaged([
+            QuantitySample(kind: .heartRate, start: t1, value: 60),
+            QuantitySample(kind: .heartRate, start: t0, value: 58),
+        ])
+        XCTAssertEqual(fresh.map(\.start), [t0, t1])     // sorted, both fresh
+        XCTAssertNil(c.last(.heartRate))                 // original cursor untouched
+        XCTAssertEqual(advanced.last(.heartRate), t1)    // advance only on the returned copy
+    }
+
+    func testStagedAdvanceIgnoredLeavesSamplesRetriable() {
+        // Simulate a failed commit: stage the advance but DON'T adopt `advanced`. The original
+        // cursor must still treat the same samples as new so they're retried (#22).
+        let c = SyncCursor()
+        _ = c.selectNewStaged([QuantitySample(kind: .heartRate, start: t1, value: 60)])
+        XCTAssertTrue(c.isNew(.heartRate, t1))
+    }
+
+    func testAdvancedKindsReportsOnlyMovedCursors() {
+        let base = SyncCursor()
+        var moved = base
+        _ = moved.selectNew([
+            QuantitySample(kind: .heartRate, start: t1, value: 60),
+            QuantitySample(kind: .spo2, start: t1, value: 0.97),
+        ])
+        XCTAssertEqual(Set(moved.advancedKinds(since: base)), [.heartRate, .spo2])
+        XCTAssertTrue(moved.advancedKinds(since: moved).isEmpty)   // no diff with self
+    }
+
     func testUnitsMatchHealthKitMapping() {
         XCTAssertEqual(MetricKind.spo2.unit, "fraction")
         XCTAssertEqual(MetricKind.hrvSDNN.unit, "ms")


### PR DESCRIPTION
## Summary
Lane C hardens the local SwiftData store and the sync→store→cursor path.

- **#32 — bounded vitals queries + retention.** `VitalsTableView` no longer loads every `StoredSample` unbounded and filters in memory. It now uses per-kind `fetchLimit = 1` "latest" queries plus two time-windowed queries (24 h resting-HR, ~3-day night-temp), with index-friendly `kindRaw`+`start` predicates. Adds a retention policy (`sampleRetentionDays = 30`) that prunes raw samples while keeping `StoredSleepSummary`/`StoredDaily` rollups long-term.
- **#33 — lean ingest.** `LocalStore.ingest` reuses a single fetched `SyncCursor`, upserts the cursor only for kinds that actually advanced (tracked during `selectNew`), and skips the save entirely when nothing new arrived — instead of a per-`MetricKind` fetch every ingest.
- **#22 (store half) — cursor only advances after a committed store.** `selectNew` stages a per-kind advance that is applied only after an atomic save; on save failure the staged advance is rolled back so the persisted cursor never moves past un-stored samples. Covered by 3 new `SyncCursorTests` (staged-advance / non-mutation-until-applied / `advancedKinds`).
- **#40 — migration safety + non-fatal reset signal.** Adds a `SchemaMigrationPlan` (`SchemaV1` matching current models) so the last-resort store wipe is genuinely last-resort, a best-effort rollup backup/restore around a wipe, and a `localHistoryWasReset` flag for the UI to surface a non-fatal "history was reset" notice.

## Tests
- `cd ios/OpenRingKit && swift build && swift test` → **Build complete; 72 tests, 0 failures** (incl. 8 `SyncCursorTests`, 3 new).
- App-target files (`VitalsTableView.swift`, `App.swift`, `Store/LocalStore.swift`) `swiftc -parse`-checked clean (cross-module "No such module" errors expected/ignored). Real device/simulator xcodebuild runs at integration.

## Adversarial peer review
Passed review after one fixup. The reviewer's single **must-fix blocker** was an invalid redeclaration: the new `@Query` stored property `latestTemp` collided with the pre-existing computed `latestTemp: Double?` in the same type (a Sema error `swiftc -parse` cannot catch). Fixed by renaming the `@Query` property to `latestTempSample` at its three sites (declaration, initializer, `latest` dict) and leaving the computed `latestTemp` untouched. Fabrication check came back clean — the only new constants are commented policy heuristics (`sampleRetentionDays = 30`, `tempWindowDays = 3`, `86_400`), no protocol/measured values.

Reviewer should-consider notes (non-blocking, carried forward): the #40 rollup backup opens a subset-schema container and is best-effort/non-crashing, so rollup survival in a genuinely incompatible-store wipe needs device verification; the `MigrationPlan` is scaffolding (`SchemaV1` only), so #40's data-safety rests on backup/restore + the reset flag, not on real migrations yet; and `localHistoryWasReset` is only set here — surfacing/clearing it is owned by the ContentView lane.

Closes #32
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)