### PR TITLE
HealthKit writeback: resting HR, calories, HRV label, nightly temp (#18, #29, #37)

### DIFF
--- a/docs/HEALTHKIT_MAPPING.md
+++ b/docs/HEALTHKIT_MAPPING.md
@@ -10,7 +10,7 @@ device's own timestamps (so historical sync backfills correctly).
 | Resting heart rate | `.restingHeartRate` | Quantity | count/min | daily, derived on-device (sleep mean → low-activity floor); see notes |
 | HRV (RMSSD) | `.heartRateVariabilitySDNN` | Quantity | ms | ring reports **RMSSD**; written into the SDNN field and **tagged via metadata** (no fake conversion) — see notes |
 | Blood oxygen (SpO₂) | `.oxygenSaturation` | Quantity | % (0–1.0) | HealthKit wants a fraction |
-| Skin / sleeping-wrist temperature | `.appleSleepingWristTemperature` | Quantity | °C | sleep-scoped: temp is captured only in the nightly window, so this (not `.bodyTemperature`) is correct — see notes |
+| Skin / sleeping-wrist temperature | `.basalBodyTemperature` | Quantity | °C | sleep-scoped writable type; the ideal `.appleSleepingWristTemperature` is Apple-computed/read-only for third parties — see notes |
 | Respiratory rate | `.respiratoryRate` | Quantity | count/min | |
 | Steps | `.stepCount` | Quantity | count | cumulative; avoid double-counting with phone |
 | Active energy | `.activeEnergyBurned` | Quantity | kcal | |
@@ -33,14 +33,24 @@ device's own timestamps (so historical sync backfills correctly).
 - **No HealthKit on desktop/macOS.** This mapping is only realized in the iOS app;
   the desktop workbench just dumps to SQLite/CSV for validation.
 
-### Temperature → `.appleSleepingWristTemperature` (#29)
+### Temperature → `.basalBodyTemperature` (#29)
 
 OpenRingConn only captures skin temperature during the nightly sleep window
-(`RingSession` gates temp frames to the detected/scheduled night). That makes
-`.appleSleepingWristTemperature` (iOS 16+; deployment target is iOS 17) the correct
-destination — it's the sleep-scoped wrist-temp type Apple's own sleep apps and Bevel's
-wrist-temp baseline read. `.bodyTemperature` is a clinical oral/core type; writing
-skin-temp values (~5 °C below core) there would corrupt that chart. Values stay in °C.
+(`RingSession` gates temp frames to the detected/scheduled night), so it belongs in a
+rest-oriented type — NOT clinical `.bodyTemperature`, whose oral/core chart a skin reading
+(~5 °C below core) would corrupt.
+
+The *ideal* home is `.appleSleepingWristTemperature` (what Apple's own sleep apps and
+Bevel's wrist-temp baseline read), but that type is **Apple-computed and read-only for
+third-party apps**: a `save()` of it would fail, and — worse — listing it in the
+`toShare` set of `requestAuthorization` raises an Obj-C `NSInvalidArgumentException`
+("Authorization to share the following types is disallowed"), which crashes the auth
+flow or, once swallowed by the call site's `try?`, silently disables writeback for *every*
+metric. So we write the writable, rest-scoped **`.basalBodyTemperature`** instead
+(`HealthKitWriter.quantityType(for: .temperature)`), and `requestAuthorization` is
+hardened to drop the temperature type rather than poison the whole share request if it is
+ever refused. Trade-off: third-party apps simply cannot populate the sleeping-wrist chart,
+so a wrist-temp baseline reader won't see ring temperature there. Values stay in °C.
 
 ### HRV: RMSSD stored in the SDNN field, labeled via metadata (#37)
 

--- a/docs/HEALTHKIT_MAPPING.md
+++ b/docs/HEALTHKIT_MAPPING.md
@@ -7,10 +7,10 @@ device's own timestamps (so historical sync backfills correctly).
 | RingConn metric | HealthKit type | Kind | Unit | Notes |
 |---|---|---|---|---|
 | Heart rate | `HKQuantityType(.heartRate)` | Quantity | count/min | live + history |
-| Resting heart rate | `.restingHeartRate` | Quantity | count/min | daily, derived |
-| HRV (RMSSD) | `.heartRateVariabilitySDNN` | Quantity | ms | HealthKit stores **SDNN**, not RMSSD — convert or store SDNN if the ring reports it |
+| Resting heart rate | `.restingHeartRate` | Quantity | count/min | daily, derived on-device (sleep mean → low-activity floor); see notes |
+| HRV (RMSSD) | `.heartRateVariabilitySDNN` | Quantity | ms | ring reports **RMSSD**; written into the SDNN field and **tagged via metadata** (no fake conversion) — see notes |
 | Blood oxygen (SpO₂) | `.oxygenSaturation` | Quantity | % (0–1.0) | HealthKit wants a fraction |
-| Skin / body temperature | `.bodyTemperature` or `.appleSleepingWristTemperature` | Quantity | °C | wrist-temp type is sleep-scoped |
+| Skin / sleeping-wrist temperature | `.appleSleepingWristTemperature` | Quantity | °C | sleep-scoped: temp is captured only in the nightly window, so this (not `.bodyTemperature`) is correct — see notes |
 | Respiratory rate | `.respiratoryRate` | Quantity | count/min | |
 | Steps | `.stepCount` | Quantity | count | cumulative; avoid double-counting with phone |
 | Active energy | `.activeEnergyBurned` | Quantity | kcal | |
@@ -32,3 +32,49 @@ device's own timestamps (so historical sync backfills correctly).
   Decide per-metric whether the ring already reports it or we derive it.
 - **No HealthKit on desktop/macOS.** This mapping is only realized in the iOS app;
   the desktop workbench just dumps to SQLite/CSV for validation.
+
+### Temperature → `.appleSleepingWristTemperature` (#29)
+
+OpenRingConn only captures skin temperature during the nightly sleep window
+(`RingSession` gates temp frames to the detected/scheduled night). That makes
+`.appleSleepingWristTemperature` (iOS 16+; deployment target is iOS 17) the correct
+destination — it's the sleep-scoped wrist-temp type Apple's own sleep apps and Bevel's
+wrist-temp baseline read. `.bodyTemperature` is a clinical oral/core type; writing
+skin-temp values (~5 °C below core) there would corrupt that chart. Values stay in °C.
+
+### HRV: RMSSD stored in the SDNN field, labeled via metadata (#37)
+
+The ring reports HRV as **RMSSD** (`BulkSleep` / `HRV.rmssd`), but HealthKit only has a
+single HRV field, `.heartRateVariabilitySDNN`. RMSSD and SDNN are **not** related by a
+fixed constant (their ratio depends on the RR spectrum), so we do **not** apply a made-up
+conversion. Instead each HRV sample is written to the SDNN field with metadata
+`OpenRingConnHRVStatistic = "RMSSD"` (`HealthKitWriter.metadata(for:)`), so the value is
+honest and a reader can tell which statistic it actually is. If a future capture shows the
+ring also reports true SDNN, switch to writing that directly and drop the tag.
+
+### Resting HR: derived daily, idempotent (#18, #37)
+
+The ring does not transmit resting HR; `OpenRingKit.RestingHR` derives a daily value:
+preferred = mean HR across the night's `asleep*` segments; fallback = the lowest sustained
+(5-min rolling-mean) HR, the same basis Apple Health uses, so the values sit side by side.
+`HealthKitWriter.flushRestingHR` writes one `.restingHeartRate` sample per day, anchored at
+start-of-day, finalizing a day only once it's ~12 h old (so a pre-dawn sync can't freeze a
+partial-night value while last night's RHR still lands by midday).
+
+### Calories: passive (BMR) + active (TRIMP), idempotent (#37)
+
+`flushToHealth` also writes energy: **passive** = hourly BMR (`Calories.bmrKcalPerHour`) to
+`.basalEnergyBurned`, one sample per completed hour; **active** = the day's Edwards-TRIMP
+kcal (`Calories.activeKcal`) to `.activeEnergyBurned`, written as the delta over what was
+already written today (HealthKit SUMS energy, so deltas land the running total). Active
+energy needs dense HR (Edwards TRIMP requires ≥10 min of readings), so it's ~0 on sparse
+auto-measure days and meaningful during live monitoring. Body inputs (age/weight/height/sex)
+come from the user profile; the ring transmits none of them.
+
+### Idempotency for derived writes
+
+Raw samples and sleep dedupe through the LocalStore sync cursor. The **derived** writes
+above are not stored samples, so each carries its own high-water mark in `UserDefaults`
+(resting-HR day, basal next-hour, active-energy day + written-kcal). Marks advance only after
+a confirmed save and are shared across the foreground + background writer instances, so
+repeated foreground/background syncs never double-write.

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -362,6 +362,9 @@ struct ContentView: View {
                 lastWrite = "Synced to Health: \(r.samples) samples"
                     + (r.sleepSegments > 0 ? ", \(r.sleepSegments) sleep segs" : "")
                     + (r.steps > 0 ? ", \(r.steps) steps" : "")
+                    + (r.restingDays > 0 ? ", \(r.restingDays) resting HR" : "")
+                    + (r.passiveHours > 0 ? ", \(r.passiveHours)h basal" : "")
+                    + (r.activeKcal > 0 ? ", \(Int(r.activeKcal.rounded())) active kcal" : "")
             }
         }
     }

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -27,12 +27,15 @@ final class HealthKitWriter {
         case .restingHeartRate: id = .restingHeartRate
         case .hrvSDNN: id = .heartRateVariabilitySDNN
         case .spo2: id = .oxygenSaturation
-        // Skin temp is captured ONLY during the nightly sleep window (RingSession), so the
-        // sleeping-wrist type is the semantically correct destination — it's what Apple's own
-        // sleep apps and Bevel's wrist-temp baseline read. `.bodyTemperature` is a clinical
-        // oral/core type and would pollute that chart with skin values ~5°C low (#29). iOS 16+;
-        // deployment target is iOS 17. Units stay °C (see `unit(for:)`).
-        case .temperature: id = .appleSleepingWristTemperature
+        // Skin temp is captured ONLY during the nightly sleep window (RingSession), so a
+        // rest-oriented type is the right home — NOT clinical `.bodyTemperature`, whose chart a
+        // skin reading (~5 °C below oral/core) would pollute (#29). The ideal sleeping-wrist type
+        // (`.appleSleepingWristTemperature`) is Apple-COMPUTED and read-only for third parties:
+        // it can't be save()d, and putting it in the `toShare` set of `requestAuthorization`
+        // raises NSInvalidArgumentException, which would crash auth or — swallowed by the
+        // call-site `try?` — silently disable EVERY metric's writeback. So we use the writable,
+        // rest-scoped `.basalBodyTemperature` instead. Units stay °C (see `unit(for:)`).
+        case .temperature: id = .basalBodyTemperature
         case .respiratoryRate: id = .respiratoryRate
         case .steps: id = .stepCount
         case .activeEnergy: id = .activeEnergyBurned
@@ -138,7 +141,21 @@ final class HealthKitWriter {
         // Read sleepAnalysis so the iOS Sleep-schedule window (HealthKitSleepSchedule) works
         // the moment the HealthKit entitlement is enabled — no further auth change needed.
         // (No effect today: without the entitlement the request is a no-op, so it can't prompt.)
-        try await store.requestAuthorization(toShare: allTypes, read: [HKCategoryType(.sleepAnalysis)])
+        let read: Set<HKObjectType> = [HKCategoryType(.sleepAnalysis)]
+        // Every type in `allTypes` is deliberately third-party-WRITABLE (that's why `.temperature`
+        // maps to `.basalBodyTemperature`, not the read-only `.appleSleepingWristTemperature`) —
+        // an unshareable type here would poison the whole request. Defensive isolation: if the
+        // request still throws (a future/edge type the OS refuses to share), retry WITHOUT
+        // temperature so one bad type degrades to "temp not shared" instead of disabling share
+        // access for every metric. (A genuinely non-shareable Apple-computed type raises an Obj-C
+        // NSInvalidArgumentException this can't catch — which is exactly why we never list one.)
+        do {
+            try await store.requestAuthorization(toShare: allTypes, read: read)
+        } catch {
+            var writable = allTypes
+            if let temp = Self.quantityType(for: .temperature) { writable.remove(temp) }
+            try await store.requestAuthorization(toShare: writable, read: read)
+        }
     }
 
     /// Write scalar samples. Caller filters with SyncCursor first.

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -27,7 +27,12 @@ final class HealthKitWriter {
         case .restingHeartRate: id = .restingHeartRate
         case .hrvSDNN: id = .heartRateVariabilitySDNN
         case .spo2: id = .oxygenSaturation
-        case .temperature: id = .bodyTemperature
+        // Skin temp is captured ONLY during the nightly sleep window (RingSession), so the
+        // sleeping-wrist type is the semantically correct destination — it's what Apple's own
+        // sleep apps and Bevel's wrist-temp baseline read. `.bodyTemperature` is a clinical
+        // oral/core type and would pollute that chart with skin values ~5°C low (#29). iOS 16+;
+        // deployment target is iOS 17. Units stay °C (see `unit(for:)`).
+        case .temperature: id = .appleSleepingWristTemperature
         case .respiratoryRate: id = .respiratoryRate
         case .steps: id = .stepCount
         case .activeEnergy: id = .activeEnergyBurned
@@ -73,7 +78,12 @@ final class HealthKitWriter {
     /// was nothing pending or share access isn't granted.
     struct FlushResult: Equatable {
         var samples = 0, sleepSegments = 0, steps = 0
-        var wroteAnything: Bool { samples > 0 || sleepSegments > 0 || steps > 0 }
+        var restingDays = 0, passiveHours = 0
+        var activeKcal = 0.0
+        var wroteAnything: Bool {
+            samples > 0 || sleepSegments > 0 || steps > 0
+                || restingDays > 0 || passiveHours > 0 || activeKcal > 0
+        }
     }
 
     /// Mirror everything pending into Apple Health in one pass — scalar vitals, the night's
@@ -110,6 +120,17 @@ final class HealthKitWriter {
                 result.steps = delta
             } catch { /* leave the watermark; retry next flush */ }
         }
+        // Derived daily resting HR — one sample per finalized day (#18, #37). Idempotency is a
+        // UserDefaults day-watermark, NOT the store cursor: RHR isn't a stored sample, and the
+        // `hk:` cursor rows belong to the raw-sample mirror above.
+        result.restingDays = await flushRestingHR(local: store, sleepSegments: sleepSegments)
+
+        // Energy: passive (hourly BMR) + active (HR-derived Edwards TRIMP). Each carries its own
+        // UserDefaults watermark so repeated flushes never double-count (#37). Body inputs come
+        // from the shared profile defaults — the ring transmits none of them.
+        let profile = Self.storedUserProfile()
+        result.passiveHours = await flushPassiveCalories(profile: profile)
+        result.activeKcal = await flushActiveCalories(local: store, profile: profile)
         return result
     }
 
@@ -125,10 +146,25 @@ final class HealthKitWriter {
         let hkSamples: [HKQuantitySample] = samples.compactMap { s in
             guard let type = Self.quantityType(for: s.kind) else { return nil }
             let q = HKQuantity(unit: Self.unit(for: s.kind), doubleValue: s.value)
-            return HKQuantitySample(type: type, quantity: q, start: s.start, end: s.end)
+            return HKQuantitySample(type: type, quantity: q, start: s.start, end: s.end,
+                                    metadata: Self.metadata(for: s.kind))
         }
         guard !hkSamples.isEmpty else { return }
         try await store.save(hkSamples)
+    }
+
+    /// Metadata key on HRV samples flagging which statistic the value actually is.
+    static let hrvStatisticMetadataKey = "OpenRingConnHRVStatistic"
+
+    /// Per-kind sample metadata. The ring reports HRV as **RMSSD**, but HealthKit only offers
+    /// an **SDNN** field — so we store the RMSSD value in `.heartRateVariabilitySDNN` and tag it
+    /// honestly here rather than invent an RMSSD→SDNN conversion constant (the two are not a
+    /// fixed ratio; see docs/HEALTHKIT_MAPPING.md). Readers can distinguish via this key.
+    static func metadata(for kind: MetricKind) -> [String: Any]? {
+        switch kind {
+        case .hrvSDNN: return [hrvStatisticMetadataKey: "RMSSD"]
+        default: return nil
+        }
     }
 
     func writePassiveCalories(profile: UserProfile, date: Date) async throws {
@@ -163,6 +199,139 @@ final class HealthKitWriter {
         let maxHR = max(220 - profile.age, 1)
         let kcal = Calories.activeKcal(hrSamples: hrSamples, maxHR: maxHR)
         try await writeActiveCalories(kcal: kcal, date: date)
+    }
+
+    /// One derived resting-HR sample for a day (anchored at start-of-day; HealthKit buckets it
+    /// onto that calendar day). Value comes from `RestingHR` (sleep mean → low-activity floor).
+    func writeRestingHR(bpm: Double, day: Date) async throws {
+        let q = HKQuantity(unit: Self.unit(for: .restingHeartRate), doubleValue: bpm)
+        let sample = HKQuantitySample(type: HKQuantityType(.restingHeartRate),
+                                      quantity: q, start: day, end: day)
+        try await store.save(sample)
+    }
+
+    // MARK: Derived-write watermarks (UserDefaults — see flushToHealth)
+    //
+    // Resting HR and energy are DERIVED, not stored samples, so they can't ride the LocalStore
+    // `hk:` cursor (which gates the raw-sample mirror). Each keeps its own idempotency mark in
+    // UserDefaults — shared across the foreground + background `HealthKitWriter` instances, and
+    // only advanced after a confirmed write, so a failed/unauthorized flush backfills next time.
+    private static let rhrWatermarkKey = "hk.restingHR.lastDay"      // start-of-day last written
+    private static let basalWatermarkKey = "hk.basalEnergy.nextHour" // first hour not yet written
+    private static let activeDayKey = "hk.activeEnergy.day"          // start-of-day of the accumulator
+    private static let activeWrittenKey = "hk.activeEnergy.writtenKcal"
+    /// A day's resting HR is finalized once the day is ~half over, so a pre-dawn flush can't
+    /// freeze a partial-night value, yet last night's RHR still lands the same day (by midday).
+    private static let restingFinalizationDelay: TimeInterval = 12 * 3600
+
+    /// Write one resting-HR sample per finalized day not yet covered by the day-watermark.
+    /// Reads HR straight from the store (the dashboard's source) via its public accessor.
+    private func flushRestingHR(local: LocalStore, sleepSegments: [SleepSegment]) async -> Int {
+        let cal = Calendar.current
+        let now = Date()
+        let defaults = UserDefaults.standard
+        let lastWritten = Date(timeIntervalSince1970: defaults.double(forKey: Self.rhrWatermarkKey))
+        let cutoff = now.addingTimeInterval(-Self.restingFinalizationDelay)
+        // Bound the scan: never re-read already-written days, and look back at most a week so a
+        // first run backfills recent history without an unbounded query.
+        let lookback = cal.date(byAdding: .day, value: -7, to: cal.startOfDay(for: now))
+            ?? now.addingTimeInterval(-7 * 86_400)
+        let scanStart = max(lookback, lastWritten)
+        guard let stored = try? local.samples(kind: .heartRate, from: scanStart, to: now),
+              !stored.isEmpty else { return 0 }
+        let hr = stored.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        let days = RestingHR.dailyValues(hr: hr, sleep: sleepSegments, calendar: cal)
+
+        var written = 0
+        var newWatermark = lastWritten
+        for d in days where d.day > lastWritten && d.day <= cutoff {  // days ascend
+            do {
+                try await writeRestingHR(bpm: d.bpm, day: d.day)
+                written += 1
+                newWatermark = d.day
+            } catch { break }  // stop at the first failure; already-written days stay covered
+        }
+        if newWatermark > lastWritten {
+            defaults.set(newWatermark.timeIntervalSince1970, forKey: Self.rhrWatermarkKey)
+        }
+        return written
+    }
+
+    /// Write basal (passive) energy for each completed hour since the watermark, returning the
+    /// count. First run starts the meter at the current hour (no historical flood); a long gap
+    /// is clamped to the last ~24 hours.
+    private func flushPassiveCalories(profile: UserProfile) async -> Int {
+        let defaults = UserDefaults.standard
+        let now = Date()
+        let currentHour = Self.startOfHour(now)
+        let stored = defaults.double(forKey: Self.basalWatermarkKey)
+        var hour = stored == 0 ? currentHour : Date(timeIntervalSince1970: stored)
+        hour = max(hour, currentHour.addingTimeInterval(-24 * 3600))  // clamp a long gap
+
+        var written = 0
+        while hour < currentHour {
+            do {
+                try await writePassiveCalories(profile: profile, date: hour)
+                written += 1
+                hour = hour.addingTimeInterval(3600)
+            } catch { break }  // leave the watermark at the failed hour; retry next flush
+        }
+        // `hour` now points at the first hour still unwritten (currentHour when all succeeded).
+        if hour.timeIntervalSince1970 > stored {
+            defaults.set(hour.timeIntervalSince1970, forKey: Self.basalWatermarkKey)
+        }
+        return written
+    }
+
+    /// Write today's active-energy DELTA (today's HR-derived TRIMP kcal minus what's already
+    /// been written today), returning the kcal written. HealthKit SUMS activeEnergyBurned, so
+    /// writing the delta lands the running daily total without re-adding it each flush.
+    private func flushActiveCalories(local: LocalStore, profile: UserProfile) async -> Double {
+        let cal = Calendar.current
+        let now = Date()
+        let today = cal.startOfDay(for: now)
+        let defaults = UserDefaults.standard
+        let storedDay = Date(timeIntervalSince1970: defaults.double(forKey: Self.activeDayKey))
+        var written = defaults.double(forKey: Self.activeWrittenKey)
+        if cal.startOfDay(for: storedDay) != today { written = 0 }  // new day → reset accumulator
+
+        guard let stored = try? local.samples(kind: .heartRate, from: today, to: now),
+              !stored.isEmpty else {
+            defaults.set(today.timeIntervalSince1970, forKey: Self.activeDayKey)
+            defaults.set(written, forKey: Self.activeWrittenKey)
+            return 0
+        }
+        let hr = stored.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        let maxHR = max(220 - profile.age, 1)
+        let total = Calories.activeKcal(hrSamples: hr, maxHR: maxHR)
+        let delta = total - written
+        guard delta >= 1.0 else {  // ignore sub-kcal churn; still persist the (reset) day marker
+            defaults.set(today.timeIntervalSince1970, forKey: Self.activeDayKey)
+            defaults.set(written, forKey: Self.activeWrittenKey)
+            return 0
+        }
+        do {
+            try await writeActiveCalories(kcal: delta, date: today)
+            defaults.set(today.timeIntervalSince1970, forKey: Self.activeDayKey)
+            defaults.set(total, forKey: Self.activeWrittenKey)
+            return delta
+        } catch { return 0 }
+    }
+
+    /// The user's body profile, read from the shared `@AppStorage` keys (the same keys
+    /// `UserProfileSettingsView`/`CaloriesCardView` use — keep these defaults in sync). Feeds the
+    /// BMR/TRIMP energy estimates; the ring transmits none of these inputs.
+    static func storedUserProfile(_ defaults: UserDefaults = .standard) -> UserProfile {
+        let age = defaults.object(forKey: "userProfile.age") as? Int ?? 35
+        let weightKg = defaults.object(forKey: "userProfile.weightKg") as? Double ?? 70
+        let heightCm = defaults.object(forKey: "userProfile.heightCm") as? Double ?? 170
+        let sexRaw = defaults.string(forKey: "userProfile.sex") ?? BiologicalSex.male.rawValue
+        return UserProfile(age: age, weightKg: max(weightKg, 1), heightCm: max(heightCm, 1),
+                           sex: BiologicalSex(rawValue: sexRaw) ?? .male)
+    }
+
+    private static func startOfHour(_ date: Date, _ cal: Calendar = .current) -> Date {
+        cal.date(from: cal.dateComponents([.year, .month, .day, .hour], from: date)) ?? date
     }
 
     /// Write a night as contiguous sleepAnalysis category samples (mapping notes).

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/RestingHR.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/RestingHR.swift
@@ -1,0 +1,119 @@
+// Resting heart rate (daily) — derived on-device; the ring does not report it (#18, #37).
+//
+// Two tiers, in preference order:
+//   1. Sleep mean — the average HR across the night's `asleep*` segments. Sleeping HR is
+//      the most stable, least motion-contaminated signal, so its mean is the best single
+//      resting estimate when sleep staging is available.
+//   2. Lowest sustained — the minimum of a rolling `window`-length mean (default 5 min).
+//      This mirrors the convention Apple Health uses for its own resting-HR estimate
+//      (lowest sustained HR during inactivity), so our value sits alongside Apple's on a
+//      comparable basis. Requiring a multi-reading window rejects single-reading dips.
+//
+// Pure value-type math (no HealthKit / device types) so it unit-tests on macOS.
+
+import Foundation
+
+public enum RestingHR {
+    /// Shortest span over which a depressed HR counts as "sustained" rather than a
+    /// transient dip — 5 minutes, matching Apple Health's resting-HR convention.
+    public static let sustainedWindow: TimeInterval = 5 * 60
+    /// Floor on the sleep-mean path: fewer asleep readings than this is too thin to trust as
+    /// a night's resting value, so we fall back to the low-activity method instead.
+    public static let minSleepSamples = 3
+
+    /// One day's resting-HR estimate in bpm, or nil when there are no readings at all.
+    /// `sleep` should be the segments overlapping this day; only `asleep*` stages count
+    /// (in-bed/awake carry motion and arousals and are excluded).
+    public static func value(
+        hr: [HRSample],
+        sleep: [SleepSegment] = [],
+        window: TimeInterval = sustainedWindow,
+        minSleepSamples: Int = minSleepSamples
+    ) -> Double? {
+        if let asleepMean = sleepMean(hr: hr, sleep: sleep, minSleepSamples: minSleepSamples) {
+            return asleepMean
+        }
+        return lowestSustained(hr: hr, window: window)
+    }
+
+    /// Mean HR of readings that fall inside an `asleep*` segment; nil below the floor or
+    /// when there are no asleep segments.
+    static func sleepMean(hr: [HRSample], sleep: [SleepSegment], minSleepSamples: Int) -> Double? {
+        let asleep = sleep.filter { isAsleep($0.stage) }
+        guard !asleep.isEmpty else { return nil }
+        let inSleep = hr.filter { s in
+            asleep.contains { seg in s.start >= seg.start && s.start < seg.end }
+        }
+        guard inSleep.count >= minSleepSamples else { return nil }
+        return mean(inSleep)
+    }
+
+    /// Lowest rolling `window`-mean across the readings. Each window is anchored at a
+    /// reading and must hold ≥2 readings to count as "sustained"; if no window qualifies
+    /// (all readings isolated) we fall back to the single lowest reading. nil if empty.
+    static func lowestSustained(hr: [HRSample], window: TimeInterval) -> Double? {
+        guard !hr.isEmpty else { return nil }
+        let sorted = hr.sorted { $0.start < $1.start }
+        var best: Double?
+        for i in sorted.indices {
+            let cutoff = sorted[i].start.addingTimeInterval(window)
+            var bucket: [HRSample] = []
+            var j = i
+            while j < sorted.count, sorted[j].start < cutoff {
+                bucket.append(sorted[j]); j += 1
+            }
+            guard bucket.count >= 2 || sorted.count == 1 else { continue }
+            let m = mean(bucket)
+            best = best.map { Swift.min($0, m) } ?? m
+        }
+        // Readings existed but none formed a sustained window (all isolated): fall back to
+        // the single lowest reading so the day still produces a value.
+        if best == nil { best = sorted.map { Double($0.bpm) }.min() }
+        return best
+    }
+
+    /// Per-calendar-day resting HR over a span of readings, oldest day first. HR is bucketed
+    /// by the local day of each reading's start; `sleep` segments are matched to a day by
+    /// temporal overlap (so an early-morning night lands on the day you woke). Days with no
+    /// readings are omitted.
+    public struct DailyValue: Equatable, Sendable {
+        public let day: Date    // start-of-day (in `calendar`)
+        public let bpm: Double
+        public init(day: Date, bpm: Double) { self.day = day; self.bpm = bpm }
+    }
+
+    public static func dailyValues(
+        hr: [HRSample],
+        sleep: [SleepSegment] = [],
+        calendar: Calendar = .current,
+        window: TimeInterval = sustainedWindow,
+        minSleepSamples: Int = minSleepSamples
+    ) -> [DailyValue] {
+        guard !hr.isEmpty else { return [] }
+        let byDay = Dictionary(grouping: hr) { calendar.startOfDay(for: $0.start) }
+        var out: [DailyValue] = []
+        for day in byDay.keys.sorted() {
+            let dayHR = byDay[day] ?? []
+            let dayEnd = calendar.date(byAdding: .day, value: 1, to: day)
+                ?? day.addingTimeInterval(86_400)
+            let daySleep = sleep.filter { $0.start < dayEnd && $0.end > day }
+            if let v = value(hr: dayHR, sleep: daySleep, window: window,
+                             minSleepSamples: minSleepSamples) {
+                out.append(DailyValue(day: day, bpm: v))
+            }
+        }
+        return out
+    }
+
+    private static func isAsleep(_ stage: SleepStage) -> Bool {
+        switch stage {
+        case .asleepCore, .asleepDeep, .asleepREM: return true
+        case .inBed, .awake: return false
+        }
+    }
+
+    private static func mean(_ samples: [HRSample]) -> Double {
+        guard !samples.isEmpty else { return 0 }
+        return samples.reduce(0.0) { $0 + Double($1.bpm) } / Double(samples.count)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/RestingHRTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/RestingHRTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import OpenRingKit
+
+// Resting-HR derivation (#18, #37). Pure value-type math; runs under `swift test`.
+final class RestingHRTests: XCTestCase {
+
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)  // fixed anchor
+
+    private func hr(_ bpm: Int, _ offset: TimeInterval) -> HRSample {
+        HRSample(bpm: bpm, start: t0.addingTimeInterval(offset))
+    }
+
+    /// Assert an optional Double equals `expected` (the derivations return nil when there's
+    /// no data, so unwrap before the accuracy comparison).
+    private func assertEqual(_ value: Double?, _ expected: Double,
+                             file: StaticString = #filePath, line: UInt = #line) {
+        guard let value else {
+            XCTFail("expected \(expected), got nil", file: file, line: line); return
+        }
+        XCTAssertEqual(value, expected, accuracy: 0.001, file: file, line: line)
+    }
+
+    // MARK: Sleep mean (preferred tier)
+
+    func testSleepMeanAveragesAsleepReadings() {
+        let sleep = [SleepSegment(start: t0, end: t0.addingTimeInterval(600), stage: .asleepCore)]
+        let samples = [hr(60, 0), hr(50, 100), hr(70, 200)]  // all inside the segment
+        assertEqual(RestingHR.sleepMean(hr: samples, sleep: sleep, minSleepSamples: 3), 60)
+    }
+
+    func testSleepMeanExcludesAwakeAndOutOfWindow() {
+        let sleep = [
+            SleepSegment(start: t0, end: t0.addingTimeInterval(300), stage: .asleepDeep),
+            SleepSegment(start: t0.addingTimeInterval(300), end: t0.addingTimeInterval(600), stage: .awake),
+        ]
+        // 3 asleep readings (mean 55) + a high awake reading + a reading after the window.
+        let samples = [hr(50, 0), hr(55, 100), hr(60, 200), hr(120, 400), hr(120, 1000)]
+        assertEqual(RestingHR.sleepMean(hr: samples, sleep: sleep, minSleepSamples: 3), 55)
+    }
+
+    func testSleepMeanNilWhenTooFewAsleepReadings() {
+        let sleep = [SleepSegment(start: t0, end: t0.addingTimeInterval(600), stage: .asleepREM)]
+        XCTAssertNil(RestingHR.sleepMean(hr: [hr(60, 0), hr(58, 100)], sleep: sleep, minSleepSamples: 3))
+    }
+
+    func testSleepMeanNilWhenNoAsleepSegments() {
+        let sleep = [SleepSegment(start: t0, end: t0.addingTimeInterval(600), stage: .inBed)]
+        XCTAssertNil(RestingHR.sleepMean(hr: [hr(60, 0), hr(58, 100), hr(59, 200)], sleep: sleep, minSleepSamples: 3))
+    }
+
+    // MARK: Lowest sustained (fallback tier)
+
+    func testLowestSustainedFindsTheLowMinuteBlock() {
+        // 5 high readings then 5 low readings, one per minute; the 5-min window over the low
+        // block has the minimum mean (50).
+        var samples: [HRSample] = []
+        for i in 0..<5 { samples.append(hr(70, Double(i) * 60)) }
+        for i in 5..<10 { samples.append(hr(50, Double(i) * 60)) }
+        assertEqual(RestingHR.lowestSustained(hr: samples, window: 300), 50)
+    }
+
+    func testLowestSustainedSingleReadingFallsBackToThatReading() {
+        assertEqual(RestingHR.lowestSustained(hr: [hr(55, 0)], window: 300), 55)
+    }
+
+    func testLowestSustainedAllIsolatedFallsBackToLowestSingle() {
+        // Readings >5 min apart never co-occur in a window → fall back to the single lowest.
+        let samples = [hr(60, 0), hr(50, 1000), hr(70, 2000)]
+        assertEqual(RestingHR.lowestSustained(hr: samples, window: 300), 50)
+    }
+
+    func testLowestSustainedNilWhenEmpty() {
+        XCTAssertNil(RestingHR.lowestSustained(hr: [], window: 300))
+    }
+
+    // MARK: Tier selection
+
+    func testValuePrefersSleepMeanOverDaytimeLow() {
+        let sleep = [SleepSegment(start: t0, end: t0.addingTimeInterval(300), stage: .asleepCore)]
+        let asleep = [hr(55, 0), hr(55, 100), hr(55, 200)]          // sleep mean 55
+        let daytime = [hr(45, 4000), hr(45, 4060), hr(45, 4120)]    // sustained low 45 (ignored)
+        assertEqual(RestingHR.value(hr: asleep + daytime, sleep: sleep), 55)
+    }
+
+    func testValueFallsBackWhenNoSleep() {
+        let daytime = [hr(45, 0), hr(45, 60), hr(45, 120)]
+        assertEqual(RestingHR.value(hr: daytime), 45)
+    }
+
+    // MARK: Daily grouping
+
+    func testDailyValuesGroupsByCalendarDay() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let day1 = cal.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+        let day2 = cal.date(byAdding: .day, value: 1, to: day1)!
+        let samples = [
+            HRSample(bpm: 60, start: day1.addingTimeInterval(3600)),
+            HRSample(bpm: 50, start: day1.addingTimeInterval(3660)),
+            HRSample(bpm: 70, start: day2.addingTimeInterval(3600)),
+            HRSample(bpm: 72, start: day2.addingTimeInterval(3660)),
+        ]
+        let daily = RestingHR.dailyValues(hr: samples, calendar: cal)
+        XCTAssertEqual(daily.count, 2)
+        XCTAssertEqual(daily[0].day, day1)
+        XCTAssertEqual(daily[1].day, day2)
+        XCTAssertEqual(daily[0].bpm, 55, accuracy: 0.001)   // (60+50)/2 sustained window
+        XCTAssertEqual(daily[1].bpm, 71, accuracy: 0.001)   // (70+72)/2
+    }
+
+    func testDailyValuesEmptyForNoReadings() {
+        XCTAssertEqual(RestingHR.dailyValues(hr: []), [])
+    }
+}


### PR DESCRIPTION
## Summary
Wires the previously-computed-but-never-written analytics into Apple Health and fixes the temperature destination type.

- **Resting HR (#18, #37):** `OpenRingKit.RestingHR` derives a daily value (sleep-mean across `asleep*` segments → fallback to the lowest sustained 5-min HR, matching Apple's own basis). `HealthKitWriter.flushRestingHR` writes one `.restingHeartRate` sample per day, anchored at start-of-day, finalizing a day only once it is ~12h old. Idempotent via a UserDefaults day-watermark.
- **Calories (#37):** passive = hourly BMR (`Calories.bmrKcalPerHour`) → `.basalEnergyBurned`, one sample per completed hour; active = the day's Edwards-TRIMP kcal (`Calories.activeKcal`) → `.activeEnergyBurned`, written as a delta (HealthKit sums energy). Each carries its own UserDefaults high-water mark so repeated foreground/background syncs never double-count.
- **HRV labeling (#37):** the ring reports **RMSSD**, HealthKit only has the SDNN field. We write RMSSD into `.heartRateVariabilitySDNN` and tag it honestly with metadata `OpenRingConnHRVStatistic = "RMSSD"` — no invented RMSSD→SDNN conversion.
- **Sleep auto-write (#29.1):** sleep is mirrored on the automatic foreground + background paths, not just the manual button.
- **Temperature (#29.2):** routed to a writable, rest/sleep-scoped HealthKit type (see below).

## Peer-review must-fix (resolved)
The reviewer flagged the original temperature mapping to `.appleSleepingWristTemperature`: that type is Apple-computed and **read-only for third-party apps**. Because it fed `allTypes` (the `toShare` set of `requestAuthorization`), it risked raising an Obj-C `NSInvalidArgumentException` that would crash auth or — swallowed by the call-site `try?` — silently disable **all** HealthKit writeback, and it was never device-tested.

Fix:
- `.temperature` now maps to `.basalBodyTemperature` — a third-party-writable, rest-oriented type — so the write and the share request only ever contain writable types, while still avoiding the clinical `.bodyTemperature` chart pollution #29 raised.
- `requestAuthorization` is hardened to drop the temperature type and retry if the share request is ever refused, isolating any one bad type from poisoning auth for every other metric.
- `docs/HEALTHKIT_MAPPING.md` updated (table row + temperature note) with the writable-type decision and the trade-off (third-party apps cannot populate the Apple sleeping-wrist chart).

## Tests run
- `cd ios/OpenRingKit && swift build && swift test` → **81 tests pass** (incl. 12 `RestingHRTests`).
- `swiftc -parse` syntax-check of the changed app file `HealthKitWriter.swift` → clean (only expected cross-module "No such module" notes). Real device build runs at integration.

Passed adversarial peer review (verdict: revise); the single blocking must-fix (temperature type) was handled by routing to a writable type plus defensive auth isolation. Non-blocking `shouldConsider` items (hourly active-energy anchoring, reinstall dedup, watch-coexistence basal double-count, feeding derived RHR into TRIMP, SDNN-chart-is-RMSSD downstream note, shared profile-defaults constant) are documented as acceptable v1 trade-offs and left for follow-up.

Closes #18
Closes #29
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)