### PR TITLE
Analytics: graded sleep score (#28), SpO2-decoupled layout (#39), wear gate (#41)

### DIFF
--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepDetection.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepDetection.swift
@@ -34,6 +34,18 @@ public struct MotionSample: Sendable, Equatable {
     }
 }
 
+/// One skin-temperature reading on the wear-detection timeline (#41). Skin temp rides
+/// the 0x10/0x87 descriptor (PROTOCOL.md §5.4), not the 0x4c sleep records, so callers
+/// thread the night's persisted temperature samples in alongside the motion timeline.
+public struct TemperatureSample: Sendable, Equatable {
+    public let time: Date
+    public let celsius: Double
+    public init(time: Date, celsius: Double) {
+        self.time = time
+        self.celsius = celsius
+    }
+}
+
 public enum Activity: Equatable, Sendable { case sleep, active }
 
 public struct ActivityPeriod: Equatable, Sendable {
@@ -61,6 +73,13 @@ public struct ActivityPeriod: Equatable, Sendable {
     /// Motion-count stillness threshold for the 0x4c [10:15] channel (🟢 grounded:
     /// recovers the captured night's in-bed window). Baseline `01` = still.
     static let motionStillThreshold: Float = 2
+
+    /// Minimum skin temperature for the ring to count as WORN (🟡 heuristic, NOT yet
+    /// ground-truthed — validate against a known charging-night capture). A worn Gen-2
+    /// reads ~30–34 °C; off-wrist / on the charger it falls toward room ambient (~20–24 °C).
+    /// 28 °C is a conservative midpoint. Used ONLY to exclude cold "still" blocks from
+    /// sleep (#41), never to add sleep — so a miss costs at worst an unfiltered charger block.
+    public static let wornMinTemperatureC: Double = 28.0
 
     private struct Temp { var activity: Activity; var start: Date; var end: Date }
 
@@ -101,6 +120,31 @@ public struct ActivityPeriod: Equatable, Sendable {
         guard history.count >= 2 else { return [] }
         return detect(times: history.map(\.time), deltas: history.map(\.movement),
                       stillThreshold: motionStillThreshold)
+    }
+
+    /// Sleep/Active detection (motion) with a WEAR GATE (#41): any detected `.sleep` block
+    /// whose median skin temperature indicates the ring was off-wrist / on the charger is
+    /// reclassified `.active`, so a perfectly still ring on the nightstand can't masquerade
+    /// as a night of sleep. A `.sleep` block with no temperature coverage is left as
+    /// detected — absence of data is not evidence of being unworn. `temperatureSamples`
+    /// may be unordered and sparse; only readings inside a block are considered.
+    public static func detectFromMotion(_ history: [MotionSample],
+                                        temperatureSamples: [TemperatureSample],
+                                        wornMinC: Double = wornMinTemperatureC) -> [ActivityPeriod] {
+        let periods = detectFromMotion(history)
+        guard !temperatureSamples.isEmpty else { return periods }
+        return periods.map { p in
+            guard p.activity == .sleep else { return p }
+            let inside = temperatureSamples
+                .filter { $0.time >= p.start && $0.time <= p.end }
+                .map(\.celsius)
+                .sorted()
+            guard !inside.isEmpty else { return p }   // no coverage → trust the motion verdict
+            let median = inside[inside.count / 2]
+            return median < wornMinC
+                ? ActivityPeriod(activity: .active, start: p.start, end: p.end)
+                : p
+        }
     }
 
     /// Shared core: classify a stillness-magnitude timeline into Sleep/Active runs.

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepScore.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepScore.swift
@@ -1,10 +1,10 @@
-// Sleep score — ported from openwhoop-algos/src/sleep.rs `sleep_score`.
+// Sleep score — adapted from openwhoop-algos/src/sleep.rs `sleep_score`.
 // Device-agnostic: a function of sleep duration only. 0…100.
 //
-// Faithful to openwhoop, including its INTEGER-division behavior: the ratio
-// duration / 8h is computed in whole units, so e.g. 4h → 0, 8h → 100, and it is
-// clamped to 0…100. (This is openwhoop's current scoring; a finer model is a
-// future Phase 5 refinement, flagged here rather than silently "fixed".)
+// openwhoop computes `duration / 8h` in INTEGER units, which collapses the score to a
+// 0-or-100 step function (anything < 8h → 0, ≥ 8h → 100) — useless as a daily metric:
+// a 7h45m night scores 0 (#28). We compute the ratio in floating point so the score
+// grades linearly with duration and clamps at the 8h ideal: 4h → 50, 6h → 75, 8h+ → 100.
 
 import Foundation
 
@@ -14,8 +14,8 @@ public enum SleepScore {
 
     /// Score from a sleep duration in seconds.
     public static func score(durationSeconds: Int) -> Double {
-        let ratio = durationSeconds / idealDurationSeconds   // integer division, as openwhoop
-        return min(max(Double(ratio) * 100.0, 0.0), 100.0)
+        let ratio = Double(durationSeconds) / Double(idealDurationSeconds)   // #28: graded, not a step
+        return min(max(ratio * 100.0, 0.0), 100.0)
     }
 
     /// Convenience for a start/end span.

--- a/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
@@ -54,15 +54,26 @@ public struct BulkRecord: Equatable {
     }
 
     public var layout: Layout {
-        // A sleep-vitals epoch carries SpO2 in [8] even when motion is at baseline and
-        // the [15:22] payload is zero (common in deep sleep) — so check [8] FIRST, else
-        // those real epochs would be mistaken for the idle/unworn template and their
-        // HR/SpO2 dropped.
-        if (0x57...0x63).contains(raw[8]) { return .sleepVitals }
-        if raw[10..<15] == [1, 1, 1, 1, 1] && raw[15..<22] == [0, 0, 0, 0, 0, 0, 0] {
+        // Decide layout from STRUCTURE, not the SpO2 *value* (#39). The old code returned
+        // .sleepVitals only when [8] ∈ 0x57…0x63 (87–99 %), so a genuine desaturation
+        // (< 87 %, the clinically interesting apnea case) failed that gate, fell through to
+        // .activity, and the WHOLE epoch's HR/HRV/SpO2 was discarded. Decide instead by the
+        // two STRUCTURAL signatures and treat anything else as sleep-vitals:
+        //   • idle/unworn template (🟢 §5.3): [4:8]=05 00 0c 00, [9]=0a, motion 01×5,
+        //     [15:22]=00×7. The FULL template matters: a deep-sleep epoch is also still with
+        //     a zero [15:22] payload, but carries real HR/HRV in [4:8] — so matching only
+        //     "still + zero payload" would mistake deep sleep for idle and drop its vitals.
+        //   • activity/awake epoch (🟢 §5.3): [8] subtype tag 0x12 / 0x13.
+        // A low-SpO2 sleep epoch matches neither → .sleepVitals, so its vitals survive. The
+        // emitted SpO2 is range-guarded in `spo2Percent`, but the band no longer gates layout.
+        if raw[4] == 0x05 && raw[5] == 0x00 && raw[6] == 0x0c && raw[7] == 0x00
+            && raw[9] == 0x0a
+            && raw[10..<15] == [1, 1, 1, 1, 1]
+            && raw[15..<22] == [0, 0, 0, 0, 0, 0, 0] {
             return .idle
         }
-        return .activity
+        if raw[8] == 0x12 || raw[8] == 0x13 { return .activity }
+        return .sleepVitals
     }
 
     /// Heart rate in bpm — `[4]` on a sleep-vitals epoch (🟢). nil otherwise / when 0.
@@ -78,10 +89,14 @@ public struct BulkRecord: Equatable {
         return Int(raw[5])
     }
 
-    /// SpO2 percent — `[8]` on a sleep-vitals epoch (🟢, range 87…99 observed). nil otherwise.
+    /// SpO2 percent — `[8]` on a sleep-vitals epoch (🟢). nil otherwise. Guarded to a
+    /// clinically plausible band (70…100): unlike the old layout gate this admits genuine
+    /// desaturations below the healthy 87…99 range (#39) while rejecting noise. The HR/HRV
+    /// of a sub-70 epoch still decode — only the implausible SpO2 reading is dropped.
     public var spo2Percent: Int? {
         guard layout == .sleepVitals else { return nil }
-        return Int(raw[8])
+        let v = Int(raw[8])
+        return (70...100).contains(v) ? v : nil
     }
 
     /// Respiratory rate in breaths/min — `[7]` on a sleep-vitals epoch, scaled ÷8 (🟢,
@@ -152,11 +167,15 @@ public enum BulkSleep {
 
     /// The main sleep block (in-bed window) detected from the motion channel, or nil.
     /// Pass `within:` to bound detection to the user's scheduled sleep window (optional).
+    /// Pass `temperatures:` (the night's persisted skin-temp samples) to exclude
+    /// off-wrist / charging blocks from sleep (#41); empty = motion-only (unchanged).
     public static func mainSleep(from records: [BulkRecord],
                                  within hint: DateInterval? = nil,
+                                 temperatures: [TemperatureSample] = [],
                                  epoch: Int = Command.syncEpoch) -> ActivityPeriod? {
         let scoped = Self.records(records, within: hint, epoch: epoch)
-        var periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch))
+        var periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch),
+                                                      temperatureSamples: temperatures)
         return ActivityPeriod.findSleep(&periods)
     }
 
@@ -164,11 +183,14 @@ public enum BulkSleep {
     /// `asleepCore`/`awake` sub-segments from the stillness detection. Finer
     /// Light/Deep/REM staging needs an HR-based model (TODO) — the ring doesn't
     /// send a hypnogram (PROTOCOL.md §5.3), so all "asleep" is reported as core.
+    /// Pass `temperatures:` to drop off-wrist / charging blocks from the night (#41).
     public static func sleepSegments(from records: [BulkRecord],
                                      within hint: DateInterval? = nil,
+                                     temperatures: [TemperatureSample] = [],
                                      epoch: Int = Command.syncEpoch) -> [SleepSegment] {
         let scoped = Self.records(records, within: hint, epoch: epoch)
-        let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch))
+        let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch),
+                                                      temperatureSamples: temperatures)
         // Main in-bed block = longest sleep period over the minimum duration (1 h).
         guard let block = periods
             .filter({ $0.activity == .sleep })

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/AnalyticsTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/AnalyticsTests.swift
@@ -105,8 +105,11 @@ final class AnalyticsTests: XCTestCase {
     // MARK: Sleep score (sleep.rs)
 
     func testSleepScore() {
+        // #28: graded (floating-point ratio), not a 0-or-100 step function.
         XCTAssertEqual(SleepScore.score(durationSeconds: 8 * 3600), 100.0)
-        XCTAssertEqual(SleepScore.score(durationSeconds: 4 * 3600), 0.0)  // integer ratio
-        XCTAssertEqual(SleepScore.score(durationSeconds: 24 * 3600), 100.0)  // clamped
+        XCTAssertEqual(SleepScore.score(durationSeconds: 6 * 3600), 75.0)
+        XCTAssertEqual(SleepScore.score(durationSeconds: 4 * 3600), 50.0)
+        XCTAssertEqual(SleepScore.score(durationSeconds: 0), 0.0)
+        XCTAssertEqual(SleepScore.score(durationSeconds: 24 * 3600), 100.0)  // clamped at the ideal
     }
 }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
@@ -173,4 +173,29 @@ final class BulkSleepTests: XCTestCase {
         // Stream split drops a trailing partial chunk.
         XCTAssertEqual(BulkSleep.records(fromStream: hex(deepSleepRec) + [0xff, 0xff]).count, 1)
     }
+
+    // MARK: #39 — desaturations keep their vitals (layout no longer gated on the SpO2 value)
+
+    /// A genuine desaturation epoch (deepSleepRec with SpO2 byte 0x62→0x50 = 80 %, below the
+    /// old 87…99 gate). It must still decode as sleep-vitals so HR/HRV/SpO2 survive — the old
+    /// gate dropped the WHOLE epoch. The HR/HRV bytes are unchanged from the proven fixture.
+    func testLowSpO2EpochKeepsVitals() {
+        let r = BulkRecord(hex("0c22d5bf444d057a500a01010101012aa0000090000004"))!
+        XCTAssertEqual(r.layout, .sleepVitals)
+        XCTAssertEqual(r.heartRate, 68)
+        XCTAssertEqual(r.hrvRMSSD, 77)
+        XCTAssertEqual(r.spo2Percent, 80, "80 % is a plausible desaturation (≥70) — emitted")
+        let kinds = Set(BulkSleep.samples(from: [r]).map(\.kind))
+        XCTAssertTrue(kinds.isSuperset(of: [.heartRate, .hrvSDNN, .spo2]), "all vitals emitted")
+    }
+
+    /// An implausible SpO2 (< 70) is range-guarded out of the emitted sample, but the epoch
+    /// stays sleep-vitals so its HR/HRV are not lost with it (SpO2 byte 0x62→0x30 = 48 %).
+    func testImplausibleSpO2GuardedButHRKept() {
+        let r = BulkRecord(hex("0c22d5bf444d057a300a01010101012aa0000090000004"))!
+        XCTAssertEqual(r.layout, .sleepVitals)
+        XCTAssertNil(r.spo2Percent, "48 % is implausible → dropped")
+        XCTAssertEqual(r.heartRate, 68, "but HR survives")
+        XCTAssertEqual(r.hrvRMSSD, 77)
+    }
 }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SleepDetectionTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SleepDetectionTests.swift
@@ -58,4 +58,36 @@ final class SleepDetectionTests: XCTestCase {
         XCTAssertTrue(ActivityPeriod(activity: .active, start: base, end: base.addingTimeInterval(3600)).isActive)
         XCTAssertFalse(ActivityPeriod(activity: .sleep, start: base, end: base.addingTimeInterval(3600)).isActive)
     }
+
+    // MARK: #41 — wear / charging gate
+
+    /// A 4 h still motion block (would detect as sleep) sampled every 5 min.
+    private func stillNight() -> [MotionSample] {
+        (0..<48).map { MotionSample(time: base.addingTimeInterval(Double($0) * 5 * 60), movement: 1) }
+    }
+    private func temps(_ celsius: Double) -> [TemperatureSample] {
+        (0..<48).map { TemperatureSample(time: base.addingTimeInterval(Double($0) * 5 * 60), celsius: celsius) }
+    }
+
+    func testWearGateReclassifiesColdStillBlockAsActive() {
+        let motion = stillNight()
+        XCTAssertEqual(ActivityPeriod.detectFromMotion(motion).first?.activity, .sleep,
+                       "motion-only: a still block reads as sleep")
+        // Same motion, but skin temp ~22 °C (off-wrist / charging) -> no sleep survives.
+        let gated = ActivityPeriod.detectFromMotion(motion, temperatureSamples: temps(22))
+        XCTAssertFalse(gated.contains { $0.activity == .sleep },
+                       "cold (unworn) still block must not count as sleep")
+    }
+
+    func testWearGateKeepsWarmStillBlockAsSleep() {
+        let gated = ActivityPeriod.detectFromMotion(stillNight(), temperatureSamples: temps(32))
+        XCTAssertEqual(gated.first?.activity, .sleep, "worn (32 °C) still block stays sleep")
+    }
+
+    func testWearGateNoTemperatureLeavesDetectionUnchanged() {
+        let motion = stillNight()
+        XCTAssertEqual(ActivityPeriod.detectFromMotion(motion, temperatureSamples: []),
+                       ActivityPeriod.detectFromMotion(motion),
+                       "no temperature coverage -> identical to motion-only (absence ≠ unworn)")
+    }
 }


### PR DESCRIPTION
Surgical reimplementation of the analytics lane (supersedes #48, which was rebuilt on a stale base and rewrote the ground-truthed decoder — discarded).

## Changes
- **#28** `SleepScore`: floating-point ratio so the score grades with duration (4h→50, 6h→75, 8h+→100) instead of the old 0-or-100 integer step.
- **#39** `BulkRecord.layout`: decide idle/activity/sleep-vitals from the **structural** idle template (`[4:8]=05 00 0c 00`, `[9]=0a`, motion `01×5`, `[15:22]=00×7`, 🟢 §5.3) and the `0x12/0x13` activity tag — **not** the SpO2 value. Genuine desaturations (<87%) now keep their HR/HRV/SpO2 instead of being dropped whole. `spo2Percent` range-guarded to 70…100. The `.activity` bucket and the full-idle-template check (so deep sleep isn't mistaken for idle) are preserved.
- **#41** `SleepDetection`: temperature-gated `detectFromMotion` overload + `TemperatureSample`; a still block whose median skin temp reads off-wrist/charging is reclassified `.active` (a charging ring can't masquerade as sleep). Optional `temperatures:` param threaded through `BulkSleep.mainSleep`/`sleepSegments` (default = unchanged). 28°C threshold tagged 🟡 (heuristic — validate against a charging-night capture).

## Verification
- 89 OpenRingKit tests pass (incl. new `#28`/`#39`/`#41` tests).
- Device build of this + Lanes B/C on the iPhone target: **BUILD SUCCEEDED**.
- Passed adversarial peer review (APPROVE, no blocking defects).
- Ground-truthed byte positions untouched; no `BulkSleep`/`SleepStaging` rewrite.

Closes #28
Closes #39
Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)