### PR TITLE
BLE lifecycle: session teardown/deinit (#42), reconnect backoff (#35), stale-state guards (#36)

### DIFF
--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -138,12 +138,17 @@ final class RingScanner: NSObject {
     }
 
     /// Cancel any in-flight reconnect backoff and clear the calm state (#35). Used on a fresh
-    /// user scan, a user stop/disconnect, and once a link proves stable.
+    /// user scan, a user stop/disconnect, and once a link proves stable. Also clears the
+    /// deferred radio-off reconnect flag: a backoff timer that fired while the radio was off
+    /// sets `reconnectWhenPoweredOn`, and a subsequent user `disconnect()` must not leave that
+    /// armed — otherwise the next `.poweredOn` would re-issue a reconnect against disconnect()'s
+    /// "STOP auto-reconnecting" intent. (Reviewer MINOR.)
     private func resetReconnectBackoff() {
         reconnectTask?.cancel(); reconnectTask = nil
         connectStableTask?.cancel(); connectStableTask = nil
         reconnectAttempts = 0
         reconnectStalled = false
+        reconnectWhenPoweredOn = false
     }
 
     /// Reconnect to the last-known ring WITHOUT scanning. `retrievePeripherals` resurfaces a

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -58,6 +58,28 @@ final class RingScanner: NSObject {
     /// from `centralManagerDidUpdateState` once `.poweredOn` arrives.
     private var reconnectWhenPoweredOn = false
 
+    /// Consecutive failed auto-reconnect attempts since the last frame-delivering connect (#35).
+    /// Drives the backoff delay (`ReconnectBackoff`); reset to 0 once a reconnected link proves
+    /// real (`connectStableTask`). A ring on the charger that accepts then drops a connect keeps
+    /// this climbing, so the reconnect cadence stretches instead of hammering the radio.
+    private var reconnectAttempts = 0
+    /// The pending backoff timer: sleeps the computed delay, then re-issues a single standing
+    /// pending connect. Cancelled on connect / user stop so we never stack timers.
+    private var reconnectTask: Task<Void, Never>?
+    /// After a fresh connect, this waits a beat and only resets the backoff if the link SURVIVED
+    /// and delivered a real frame — the "successful data frame" reset signal (#35). Guards the
+    /// connect/reject loop a charging ring produces (resetting on `didConnect` alone would pin
+    /// the backoff at its shortest delay).
+    private var connectStableTask: Task<Void, Never>?
+    /// How long a new link must hold (and send a frame) before we trust it and reset the backoff.
+    private static let connectStablePeriod: TimeInterval = 6
+
+    /// True once enough reconnects have failed that the UI should show a calm "ring unreachable /
+    /// charging — will reconnect automatically" instead of a permanent "Connecting…" (#35). Based
+    /// on elapsed attempts, NOT a decoded charging byte (that descriptor bit is protocol-blocked,
+    /// #41) — we never claim to KNOW the ring is charging.
+    private(set) var reconnectStalled = false
+
     private override init() {
         super.init()
         // Opting into state restoration: iOS preserves this central's connections/pending
@@ -88,18 +110,40 @@ final class RingScanner: NSObject {
     func start(services: [CBUUID]? = nil) {
         guard central.state == .poweredOn else { return }
         wantConnection = true
+        resetReconnectBackoff()   // a fresh user scan starts clean — no lingering backoff/calm state
         state = .scanning
         central.scanForPeripherals(withServices: services)
     }
 
     func stop() {
         wantConnection = false
+        resetReconnectBackoff()   // user stop: cancel any pending backoff reconnect
         // Explicit user stop: forget the ring so we don't silently auto-reconnect on the next
         // launch (reconnect-by-identifier only re-arms while an id is saved). (Reviewer MINOR.)
         Self.savedPeripheralID = nil
         central.stopScan()
         if let target { central.cancelPeripheralConnection(target) }
         if case .scanning = state { state = .idle }
+    }
+
+    /// Tear down the active session (#42): persist its last live reading + captured pages
+    /// (`stopLiveMonitoring`), then cancel EVERY task it owns (`invalidate`), then release it.
+    /// Called everywhere `session` is replaced or dropped — before assigning a new session in
+    /// `didConnect`/`willRestoreState`, and on disconnect — so a stale session's keepalive/
+    /// auto-measure/sync loops can never keep writing to the peripheral behind a newer one.
+    private func teardownSession() {
+        session?.stopLiveMonitoring()
+        session?.invalidate()
+        session = nil
+    }
+
+    /// Cancel any in-flight reconnect backoff and clear the calm state (#35). Used on a fresh
+    /// user scan, a user stop/disconnect, and once a link proves stable.
+    private func resetReconnectBackoff() {
+        reconnectTask?.cancel(); reconnectTask = nil
+        connectStableTask?.cancel(); connectStableTask = nil
+        reconnectAttempts = 0
+        reconnectStalled = false
     }
 
     /// Reconnect to the last-known ring WITHOUT scanning. `retrievePeripherals` resurfaces a
@@ -144,11 +188,12 @@ final class RingScanner: NSObject {
     /// connection and immediately reconnects, looping forever (#14 fix).
     func disconnect() {
         wantConnection = false
+        resetReconnectBackoff()   // user stop: drop any pending backoff reconnect (#35)
         central.stopScan()
         if let target {
             central.cancelPeripheralConnection(target)
         }
-        session = nil
+        teardownSession()         // cancel all of the session's tasks, not just the live poll (#42)
         target = nil
         state = .idle
     }
@@ -160,8 +205,7 @@ final class RingScanner: NSObject {
     /// no-scan pending connect-by-identifier so reconnection stays armed across the next
     /// suspension. (Reviewer MAJOR fix.)
     private func endBackgroundReadRearming() {
-        session?.stopLiveMonitoring()
-        session = nil
+        teardownSession()   // stopLiveMonitoring + cancel keepalive/auto-measure/sync tasks (#42)
         if let target { central.cancelPeripheralConnection(target) }
         target = nil
         state = .idle
@@ -241,9 +285,19 @@ extension RingScanner: CBCentralManagerDelegate {
                 case .connected, .connecting: break
                 default: self.state = .idle
                 }
-                // A reconnect was requested before Bluetooth was ready (cold/background
-                // launch) — complete it now that the radio is on.
-                if self.reconnectWhenPoweredOn { self.reconnectKnownPeripheral() }
+                // A reconnect was requested before Bluetooth was ready (cold/background launch,
+                // or a backoff reconnect that armed while the radio was off) — complete it now.
+                // When we already hold the peripheral object, connect it directly: a backoff sets
+                // state to `.connecting`, which `reconnectKnownPeripheral` treats as "already
+                // connecting" and no-ops — connecting `target` ourselves avoids that stall. (#35)
+                if self.reconnectWhenPoweredOn {
+                    self.reconnectWhenPoweredOn = false
+                    if let target = self.target {
+                        self.central.connect(target)
+                    } else {
+                        self.reconnectKnownPeripheral()
+                    }
+                }
                 // A session restored before the radio was up may have fired its discovery
                 // into the void (chars never matched → never `ready`). Re-kick it now. The
                 // session also self-heals on the first frame it receives (#reconnect).
@@ -271,9 +325,14 @@ extension RingScanner: CBCentralManagerDelegate {
             switch peripheral.state {
             case .connected:
                 // The link survived the relaunch — rebuild the session now; `didConnect`
-                // won't fire again. RingSession re-discovers services/characteristics.
+                // won't fire again. RingSession re-matches characteristics (skipping a full
+                // service re-discovery when they're already present, #42).
                 Self.savedPeripheralID = peripheral.identifier.uuidString
                 self.state = .connected(peripheral.name ?? "RingConn")
+                // Tear down any session that already exists (e.g. a later `didConnect` racing this
+                // restore) before replacing it, so its tasks don't keep writing to the peripheral
+                // behind the new session (#42).
+                self.teardownSession()
                 self.session = RingSession(peripheral: peripheral, localStore: self.localStore)
             case .connecting:
                 // Pending connect still in flight; `didConnect` will complete it.
@@ -323,8 +382,32 @@ extension RingScanner: CBCentralManagerDelegate {
             // cold launch or background relaunch.
             self.target = peripheral
             Self.savedPeripheralID = peripheral.identifier.uuidString
+            // A connect landed — stop any pending backoff timer and clear the calm "unreachable"
+            // note. (We don't reset the attempt COUNT yet: a charging ring can connect then
+            // immediately drop, so the backoff only truly resets once the link proves stable.) #35
+            self.reconnectTask?.cancel(); self.reconnectTask = nil
+            self.reconnectStalled = false
             self.state = .connected(peripheral.name ?? "RingConn")
+            // Tear down any prior session before replacing it so its keepalive/auto-measure/sync
+            // tasks can't keep driving the same peripheral behind the new session (#42).
+            self.teardownSession()
             self.session = RingSession(peripheral: peripheral, localStore: self.localStore)
+            self.armConnectStabilityReset()
+        }
+    }
+
+    /// Arm the backoff reset (#35). Only once a reconnected link has SURVIVED a beat AND delivered
+    /// a real frame (`session.lastFrameAt`) do we trust it and zero the attempt count — so a
+    /// charging ring's connect/reject loop (which never delivers a frame) keeps the backoff
+    /// climbing instead of resetting on every brief connect.
+    private func armConnectStabilityReset() {
+        connectStableTask?.cancel()
+        connectStableTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Self.connectStablePeriod))
+            guard let self, !Task.isCancelled else { return }
+            if case .connected = self.state, self.session?.lastFrameAt != nil {
+                self.reconnectAttempts = 0
+            }
         }
     }
 
@@ -332,16 +415,44 @@ extension RingScanner: CBCentralManagerDelegate {
                                     didDisconnectPeripheral peripheral: CBPeripheral,
                                     error: Error?) {
         Task { @MainActor in
-            self.session?.stopLiveMonitoring()
-            self.session = nil
-            // Auto-reconnect: CoreBluetooth's connect has no timeout — it reconnects
-            // (using the persisted bond) the moment the ring wakes/comes back in range,
-            // so the user never has to re-pair or open the official app again.
+            self.connectStableTask?.cancel(); self.connectStableTask = nil
+            self.teardownSession()   // cancel ALL of the session's tasks, persisting last reading (#42)
+            // Auto-reconnect: CoreBluetooth's connect has no timeout — it reconnects (using the
+            // persisted bond) the moment the ring wakes/comes back in range, so the user never has
+            // to re-pair or open the official app again. But we no longer re-issue it IMMEDIATELY:
+            // a ring on the charger that drops the link in a loop would keep the radio armed for
+            // hours. Back off with a growing delay instead (#35).
             if self.wantConnection {
-                self.state = .connecting(peripheral.name ?? "RingConn")
-                self.central.connect(peripheral)
+                self.scheduleReconnect(peripheral)
             } else {
                 self.state = .idle
+            }
+        }
+    }
+}
+
+extension RingScanner {
+    /// Schedule a backoff reconnect after a disconnect (#35). Each consecutive failure stretches
+    /// the delay (1 s → 5 s → 30 s cap); a stable, frame-delivering connect resets it. We keep the
+    /// cheap standing pending connect — we just delay re-issuing it and do NOT actively re-scan
+    /// during the wait. After a few failures the UI switches to a calm "unreachable" note.
+    private func scheduleReconnect(_ peripheral: CBPeripheral) {
+        reconnectTask?.cancel()
+        reconnectAttempts += 1
+        let delay = ReconnectBackoff.delay(forAttempt: reconnectAttempts)
+        reconnectStalled = ReconnectBackoff.shouldSurfaceCalmState(attempts: reconnectAttempts)
+        target = peripheral
+        state = .connecting(peripheral.name ?? "RingConn")
+        reconnectTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard let self, !Task.isCancelled, self.wantConnection else { return }
+            // Don't fight a link that already came back during the wait.
+            if case .connected = self.state { return }
+            if self.central.state == .poweredOn {
+                self.central.connect(peripheral)   // single standing pending connect (no scan)
+            } else {
+                // Radio not up yet — let the poweredOn handler complete the reconnect-by-identifier.
+                self.reconnectWhenPoweredOn = true
             }
         }
     }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -39,6 +39,11 @@ final class RingSession: NSObject {
     private(set) var liveTemperature: Double?   // skin temp °C (0x10/0x87 [6:8]/[8:10], §5.4)
     private(set) var batteryPercent: Int?       // ring battery % (0x10/0x87 [1], §5.4 🟢)
     private(set) var liveMode: LiveMode = .hr
+    /// Wall-clock time of the most recent frame actually received from the ring (#36). Lets the
+    /// UI detect a silently-dropped link (values stop updating before CoreBluetooth fires
+    /// `didDisconnect`) and stamps the persisted last live reading with when it was REALLY
+    /// measured — not `Date()`, which would push a minutes-old reading into HealthKit "now".
+    private(set) var lastFrameAt: Date?
     private(set) var monitoring = false
     /// True during the open→drain phase before the live stream starts. The ring won't
     /// emit live frames until its history backlog is fully drained, so we surface this
@@ -51,6 +56,21 @@ final class RingSession: NSObject {
     /// True while the periodic auto-measure (not a user tap) is driving a live read, so the
     /// UI can show a subtle "auto-updating" cue instead of reading as a user measurement.
     private(set) var autoMeasuring = false
+
+    /// True when frames have stopped for long enough that the live readings (HR/SpO₂/battery/
+    /// steps/temp) should read as STALE rather than current (#36). A silently-dropped link keeps
+    /// its last values until CoreBluetooth eventually fires `didDisconnect`; this lets the UI
+    /// show "Xm ago" instead of a minutes-old value masquerading as live. Thresholds are mode-
+    /// aware: while monitoring, frames stream ~every 2 s, so a 30 s gap means the stream stalled;
+    /// while idle the only frames are the slow keepalive descriptor (up to ~5 min apart in
+    /// battery saver), so allow a much longer gap before crying stale.
+    var liveReadingsStale: Bool {
+        guard let at = lastFrameAt else { return false }   // no frame yet — nothing to call stale
+        let gap = Date().timeIntervalSince(at)
+        return gap > (monitoring ? Self.liveStaleAfter : Self.idleStaleAfter)
+    }
+    private static let liveStaleAfter: TimeInterval = 30
+    private static let idleStaleAfter: TimeInterval = 360
 
     private var monitorTask: Task<Void, Never>?
     private var keepaliveTask: Task<Void, Never>?
@@ -95,6 +115,7 @@ final class RingSession: NSObject {
     private var syncSession = EpochSyncSession()
     private let epochDecodingEnabled = false
 
+    private let dataServiceUUID = CBUUID(string: OpenRingKit.Transport.dataServiceUUID)
     private let notifyUUID = CBUUID(string: OpenRingKit.Transport.notifyCharUUID)
     private let writeUUID = CBUUID(string: OpenRingKit.Transport.writeCharUUID)
 
@@ -103,7 +124,37 @@ final class RingSession: NSObject {
         self.localStore = localStore
         super.init()
         peripheral.delegate = self
-        peripheral.discoverServices(nil)
+        // Re-discovery guard (#42): on a restored / already-connected peripheral the data service
+        // is usually already discovered, so re-scanning ALL services on every relaunch is wasted
+        // work. If the data service is already present, go straight to (re-)matching its
+        // characteristics — that still re-fires `didDiscoverCharacteristicsFor`, so `ready` lands.
+        // Only fall back to a full `discoverServices` when we've never seen the service.
+        if let dataService = peripheral.services?.first(where: { $0.uuid == dataServiceUUID }) {
+            peripheral.discoverCharacteristics(nil, for: dataService)
+        } else {
+            peripheral.discoverServices(nil)
+        }
+    }
+
+    /// Hard teardown (#42): cancel EVERY task this session owns so a session that's being
+    /// replaced (a second `didConnect`/`willRestoreState`) or torn down on disconnect can't keep
+    /// writing to the SHARED peripheral behind a newer session — which would race the delegate
+    /// routing and leak the keepalive/auto-measure/sync loops. Callers persist the last live
+    /// reading via `stopLiveMonitoring()` BEFORE this where that matters; `invalidate()` itself is
+    /// a pure cancel + detach. Idempotent.
+    func invalidate() {
+        monitorTask?.cancel(); monitorTask = nil
+        keepaliveTask?.cancel(); keepaliveTask = nil
+        autoMeasureTask?.cancel(); autoMeasureTask = nil
+        syncTask?.cancel(); syncTask = nil
+        monitoring = false
+        livePreparing = false
+        syncing = false
+        autoMeasuring = false
+        // Stop CoreBluetooth callbacks routing to a torn-down session. Only clear the delegate if
+        // it's still us — a newer session for the same peripheral reassigns it in its own `init`,
+        // and we must not clobber that.
+        if peripheral.delegate === self { peripheral.delegate = nil }
     }
 
     /// Begin live monitoring. The proven enter sequence (PROTOCOL.md §5.1 / livehr.py) is
@@ -473,11 +524,14 @@ final class RingSession: NSObject {
             persistSleepAndSteps()
             bulkFinalized = true
         }
-        // Persist the last live reading so the dashboard shows it after disconnect.
-        let now = Date()
+        // Persist the last live reading so the dashboard shows it after disconnect. Stamp it with
+        // WHEN the ring last actually sent a frame, not `Date()` (#36): on a silently-dropped link
+        // the last value can be minutes old, and stamping "now" would push a wrong timestamp into
+        // HealthKit. Fall back to now only if we somehow never recorded a frame.
+        let stamp = lastFrameAt ?? Date()
         var last: [QuantitySample] = []
-        if let hr = liveHR { last.append(QuantitySample(kind: .heartRate, start: now, value: Double(hr))) }
-        if let spo2 = liveSpO2 { last.append(QuantitySample(kind: .spo2, start: now, value: Double(spo2) / 100)) }
+        if let hr = liveHR { last.append(QuantitySample(kind: .heartRate, start: stamp, value: Double(hr))) }
+        if let spo2 = liveSpO2 { last.append(QuantitySample(kind: .spo2, start: stamp, value: Double(spo2) / 100)) }
         persist(last)
     }
 
@@ -607,6 +661,7 @@ extension RingSession: CBPeripheralDelegate {
         let bytes = [UInt8](data)
         Task { @MainActor in
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
+            self.lastFrameAt = Date()   // freshness anchor for staleness + last-reading timestamp (#36)
             // Frames arriving while the link isn't `ready` mean discovery didn't land on this
             // (restored) reconnect — re-run it so we can ack and the buttons enable. #reconnect
             if !self.ready { self.rediscoverIfNeeded() }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -140,11 +140,20 @@ struct ContentView: View {
                     Text(hrWarmupText).font(.caption).foregroundStyle(.secondary)
                 }
                 Spacer()
-                // Ring battery (a device stat, not a body vital) sits with the connection.
+                // Ring battery (a device stat, not a body vital) sits with the connection. When
+                // the link has gone quiet (no frames), gray it and show "as of Xm ago" so a
+                // minutes-old % from a silently-dropped link doesn't read as current (#36).
                 if let b = session?.batteryPercent {
-                    Label("\(b)%", systemImage: batteryIcon(b))
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(b <= 20 ? .red : .secondary)
+                    let stale = session?.liveReadingsStale == true
+                    VStack(alignment: .trailing, spacing: 0) {
+                        Label("\(b)%", systemImage: batteryIcon(b))
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(stale ? AnyShapeStyle(.tertiary)
+                                             : AnyShapeStyle(b <= 20 ? Color.red : Color.secondary))
+                        if let asOf = batteryAsOf {
+                            Text(asOf).font(.caption2).foregroundStyle(.tertiary)
+                        }
+                    }
                 }
             }
             if !connected {
@@ -170,6 +179,17 @@ struct ContentView: View {
         if let w = session?.liveHRWarmup { return "Warming up HR… (\(w))" }
         return "Measuring HR…"
     }
+
+    /// "as of Xm ago" for the connection-header battery, shown only once the link has gone quiet
+    /// (#36) — a dropped link can otherwise show a minutes-old battery % as if it were current.
+    private var batteryAsOf: String? {
+        guard session?.liveReadingsStale == true, let at = session?.lastFrameAt else { return nil }
+        return "as of " + Self.rel.localizedString(for: at, relativeTo: Date())
+    }
+
+    private static let rel: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter(); f.unitsStyle = .abbreviated; return f
+    }()
 
     /// SF Symbol for the ring's battery level.
     private func batteryIcon(_ pct: Int) -> String {
@@ -392,7 +412,13 @@ struct ContentView: View {
         case .poweredOff: return "Bluetooth off"
         case .unauthorized: return "Bluetooth not authorized"
         case .scanning: return "Scanning…"
-        case .connecting(let n): return "Connecting to \(n)…"
+        case .connecting(let n):
+            // After repeated failed reconnects (e.g. the ring is on the charger / out of range),
+            // swap the permanent "Connecting…" for a calm note so normal charging doesn't read as
+            // a stuck connection (#35). Heuristic on elapsed attempts — not a charging byte (#41).
+            return scanner.reconnectStalled
+                ? "Ring unreachable or charging — will reconnect automatically"
+                : "Connecting to \(n)…"
         case .connected(let n): return n
         }
     }

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -131,11 +131,11 @@ struct VitalsTableView: View {
         VStack(alignment: .leading, spacing: 0) {
             measurableRow("Heart Rate", value: hrText, mode: .hr, active: hrActive,
                           time: hrActive && session?.liveHR == nil
-                              ? "measuring…" : timeFor(.heartRate, live: session?.liveHR != nil))
+                              ? "measuring…" : timeFor(.heartRate, live: hrLive))
             divider
             measurableRow("SpO₂", value: spo2Text, mode: .spo2, active: spo2Active,
                           time: spo2Active && session?.liveSpO2 == nil
-                              ? "measuring…" : timeFor(.spo2, live: session?.liveSpO2 != nil))
+                              ? "measuring…" : timeFor(.spo2, live: spo2Live))
             divider
             skinTempRow
             divider
@@ -199,6 +199,11 @@ struct VitalsTableView: View {
     private var hrActive: Bool { session?.monitoring == true && session?.liveMode == .hr }
     private var spo2Active: Bool { session?.monitoring == true && session?.liveMode == .spo2 }
 
+    /// True when the link has gone quiet so a lingering live value must NOT read as "live" (#36).
+    /// A silently-dropped link keeps its last HR/SpO₂/steps/temp until CoreBluetooth fires
+    /// `didDisconnect`; staleness lets us show "Xm ago" instead of a minutes-old value as current.
+    private var liveStale: Bool { session?.liveReadingsStale == true }
+
     /// A vitals row carrying an inline start/stop measure control for an on-demand metric.
     private func measurableRow(_ label: String, value: String, mode: RingSession.LiveMode,
                                active: Bool, time: String?) -> some View {
@@ -242,12 +247,18 @@ struct VitalsTableView: View {
 
     // MARK: value formatting (live overrides stored)
 
+    /// HR/SpO₂ count as "live" only while we're actively measuring that metric AND frames are
+    /// still arriving. A leftover value after monitoring stops, or a silently-dropped link, falls
+    /// back to the stored sample's timestamp instead of a false "live" caption (#36).
+    private var hrLive: Bool { hrActive && session?.liveHR != nil && !liveStale }
+    private var spo2Live: Bool { spo2Active && session?.liveSpO2 != nil && !liveStale }
+
     private var hrText: String {
-        if let hr = session?.liveHR { return "\(hr) bpm" }
+        if hrLive, let hr = session?.liveHR { return "\(hr) bpm" }
         return valueText(.heartRate) { "\(Int($0)) bpm" }
     }
     private var spo2Text: String {
-        if let s = session?.liveSpO2 { return "\(s) %" }
+        if spo2Live, let s = session?.liveSpO2 { return "\(s) %" }
         return valueText(.spo2) { "\(Int(($0 * 100).rounded())) %" }
     }
     // MARK: Skin temp (headline = latest reading; overnight average shown as context)
@@ -282,7 +293,7 @@ struct VitalsTableView: View {
     /// ("live" when connected, else relative time) and the overnight average for context.
     private var skinTempSecondary: String? {
         var parts: [String] = []
-        if session?.liveTemperature != nil {
+        if session?.liveTemperature != nil, !liveStale {
             parts.append("live")
         } else if latestTemp != nil, let s = latest[.temperature] {
             parts.append(Self.rel.localizedString(for: s.start, relativeTo: Date()))
@@ -333,10 +344,11 @@ struct VitalsTableView: View {
         guard let s = effectiveSteps else { return "—" }
         return "\(s)"
     }
-    /// "live" while connected; else the relative time of today's stored count (nil if the
-    /// only stored count is from a prior day — `effectiveSteps` shows "—" then).
+    /// "live" while the descriptor is fresh; else the relative time of today's stored count (nil
+    /// if the only stored count is from a prior day — `effectiveSteps` shows "—" then). A quiet
+    /// link no longer reads as "live" (#36) — it shows when the count was last updated instead.
     private var stepsTime: String? {
-        if session?.steps != nil { return "live" }
+        if session?.steps != nil, !liveStale { return "live" }
         let today = Calendar.current.startOfDay(for: Date())
         guard let d = storedDaily.first, d.day == today, d.steps > 0 else { return nil }
         return Self.rel.localizedString(for: d.updatedAt, relativeTo: Date())

--- a/ios/OpenRingKit/Sources/OpenRingKit/ReconnectBackoff.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/ReconnectBackoff.swift
@@ -1,0 +1,35 @@
+// Auto-reconnect backoff policy (#35). RingScanner re-issues `central.connect` on every
+// disconnect; left unbounded, a ring on the charger (it accepts a connect then immediately
+// drops it) keeps the radio armed in a tight reconnect loop for hours. This grows the delay
+// between consecutive failed reconnects and tells the UI when to stop saying "Connecting…"
+// and surface a calm "ring unreachable / charging" note instead. Pure (no CoreBluetooth) so
+// it unit-tests on the CLI; the scanner owns the attempt counter and resets it on a real,
+// frame-delivering connection.
+//
+// NOTE: the calm state is derived from elapsed *attempts*, NOT a decoded charging-flag byte —
+// that descriptor bit is protocol-blocked (#41), so we never claim to know the ring is charging.
+
+import Foundation
+
+public enum ReconnectBackoff {
+    /// Delay (seconds) before the next reconnect, indexed by consecutive failed attempts:
+    /// 1 s → 5 s → 30 s, then capped at 30 s. Reset the attempt counter on a successful,
+    /// frame-delivering connect.
+    public static let delays: [TimeInterval] = [1, 5, 30]
+
+    /// Backoff delay before reconnect attempt `attempt` (1-based). Attempt 0 (or less) means
+    /// "no failures yet" → reconnect immediately. Past the table it stays at the cap.
+    public static func delay(forAttempt attempt: Int) -> TimeInterval {
+        guard attempt > 0 else { return 0 }
+        return delays[min(attempt - 1, delays.count - 1)]
+    }
+
+    /// After this many consecutive failed reconnect attempts, the UI should swap the permanent
+    /// "Connecting…" for a calm "ring unreachable / charging — will reconnect automatically".
+    public static let calmStateAttemptThreshold = 3
+
+    /// Whether enough reconnects have failed to surface the calm state (vs. "Connecting…").
+    public static func shouldSurfaceCalmState(attempts: Int) -> Bool {
+        attempts >= calmStateAttemptThreshold
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/ReconnectBackoffTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/ReconnectBackoffTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import OpenRingKit
+
+// Auto-reconnect backoff (#35): grows the gap between consecutive failed reconnects so a ring
+// left on the charger isn't hammered, and flips to the calm "unreachable" state after a few
+// tries. Asserts the schedule + thresholds so a regression (e.g. reverting to immediate retry)
+// is caught.
+final class ReconnectBackoffTests: XCTestCase {
+
+    func testScheduleGrowsThenCaps() {
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 1), 1)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 2), 5)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 3), 30)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 4), 30)   // capped
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 99), 30)  // stays capped
+    }
+
+    func testZeroOrNegativeAttemptIsImmediate() {
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 0), 0)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: -3), 0)
+    }
+
+    func testDelayIsMonotonicNonDecreasing() {
+        var prev = ReconnectBackoff.delay(forAttempt: 0)
+        for attempt in 1...12 {
+            let d = ReconnectBackoff.delay(forAttempt: attempt)
+            XCTAssertGreaterThanOrEqual(d, prev)
+            prev = d
+        }
+    }
+
+    func testCalmStateOnlyAfterThreshold() {
+        XCTAssertFalse(ReconnectBackoff.shouldSurfaceCalmState(attempts: 0))
+        XCTAssertFalse(ReconnectBackoff.shouldSurfaceCalmState(attempts: 2))
+        XCTAssertTrue(ReconnectBackoff.shouldSurfaceCalmState(attempts: 3))
+        XCTAssertTrue(ReconnectBackoff.shouldSurfaceCalmState(attempts: 10))
+    }
+}


### PR DESCRIPTION
## Summary

Lane D hardens the BLE connection lifecycle. Three tickets, surgical changes to `RingScanner`/`RingSession`/`ContentView`/`VitalsTableView` plus one new pure-logic helper + test in OpenRingKit.

### #42 — Session teardown / deinit (no zombie sessions)
- `RingSession.invalidate()` cancels all four owned tasks (monitor / keepalive / auto-measure / sync) and detaches the CB delegate only if it's still ours.
- New `teardownSession()` (`stopLiveMonitoring` → `invalidate` → `session = nil`) runs **before every** session replace/drop — both branches of `didConnect`/`willRestoreState` and on disconnect — so a stale session's keepalive/auto-measure/sync loops can never keep writing to the peripheral behind a newer session.
- All session create/teardown is `@MainActor`-serialized, so the `willRestoreState`-vs-`didConnect` race can't leave two sessions coexisting; re-discovery is guarded.

### #35 — Reconnect backoff (battery-safe, honest UI)
- New pure `ReconnectBackoff` (1 s → 5 s → 30 s cap) in OpenRingKit, unit-tested (`ReconnectBackoffTests`: grows-then-caps, immediate at attempt ≤ 0, monotonic, calm-state threshold).
- Single standing pending connect, delayed (no active re-scan during the wait); radio stays idle through the backoff.
- Backoff resets **only** once a reconnected link survives a beat **and** delivers a real frame (`connectStableTask` gated on `session.lastFrameAt`), so a charging ring's connect/reject loop keeps the cadence stretching instead of resetting.
- After enough failures the UI shows a calm "ring unreachable / charging — will reconnect automatically" note. This is driven by elapsed attempts (`ReconnectBackoff.shouldSurfaceCalmState`), **NOT** any decoded charging byte (that descriptor bit is protocol-blocked, #41) — we never claim to *know* the ring is charging.

### #36 — Stale-state guards (correct HealthKit timestamps)
- The load-bearing fix: a terminal `stopLiveMonitoring` persists the last live reading stamped at **`lastFrameAt`** (when the data actually arrived) instead of `Date()`, eliminating a wrong HealthKit timestamp on a silent link drop.
- Vitals/battery readouts expose time-based freshness (`liveReadingsStale` / `batteryAsOf`) so a minutes-old reading is shown as aged rather than "live".

### Post-review fixup
Adversarial peer review verdict was **approve** (no mustFix). Addressed the one endorsed one-line correctness item: `resetReconnectBackoff()` now also clears `reconnectWhenPoweredOn`, so a user `disconnect()` during a radio-off backoff can't be silently re-armed by the next `.poweredOn` (which would contradict disconnect()'s "STOP auto-reconnecting" intent).

## Builds on Lane E
This stays **out of** Lane E's measurement logic: `KeepaliveCadence`, `rearmUserMeasure`, the `bulkFinalized` stop-time safety net, and the HR warm-up display are untouched and integrated *around*, not over.

## Verification
- `swift build` + `swift test` in `ios/OpenRingKit`: **98 tests, 0 failures** (incl. the 4 new `ReconnectBackoffTests`).
- Changed app Swift files parse-checked (`swiftc -parse`, iphoneos SDK); cross-module errors expected.
- xcodebuild / real device build is the orchestrator's gate (not runnable in this env) — covers the inserted `Task` closures and the `AnyShapeStyle` battery ternary.

## Adversarial review outcome
Approve. All three tickets correctly + surgically implemented; concurrency sound (MainActor-serialized teardown precedes every session assignment, `invalidate()` idempotent, delegate handoff safe, no leaked/stray-write tasks). Five non-blocking `shouldConsider` notes remain (most notably: the #36 staleness UI has no periodic render trigger, so the aged-reading state won't visibly update mid-silent-drop until the next render — the data-integrity half is fully fixed); deferred as follow-ups.

Closes #42
Closes #35
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)