### PR TITLE
Steps: cross-session delta persistence, reset/handoff disambiguation, sample-time day stamping (#34)

### DIFF
--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -98,8 +98,7 @@ final class RingSession: NSObject {
 
     private var bulkRecords: [BulkRecord] = []
     private var bulkFinalized = false    // captured pages already committed (sleep/vitals) — stop-time safety net skips re-commit
-    private var lastRawSteps: Int?       // last raw descriptor [4:6] counter (for delta accumulation)
-    private var dailyStepsTotal = 0      // accumulated daily step total (mirrors StoredDaily)
+    private var dailyStepsTotal = 0      // cached display total for the last sample day (mirrors StoredDaily)
     private var syncTask: Task<Void, Never>?
     private var syncDone = false        // 0x50 end-of-history seen
     private var syncQuietTicks = 0      // seconds since the last page arrived
@@ -441,6 +440,32 @@ final class RingSession: NSObject {
         // Steps are accumulated live in didUpdateValue (addDailySteps) — nothing to do here.
     }
 
+    // MARK: Step counter state (cross-session, #34)
+    //
+    // The ring's onboard step counter (descriptor [4:6]) is a since-handoff DELTA the official
+    // app resets; if that app isn't running it keeps climbing (it does NOT reset at midnight on
+    // its own). To compute a TRUE delta across a reconnect — instead of rebasing to the current
+    // counter and dropping every step taken while we were disconnected — we persist the last raw
+    // value AND the day it was seen in UserDefaults (not LocalStore: avoids a SwiftData migration
+    // and a per-day-row collision). The per-day TOTAL still lives in StoredDaily via addDailySteps.
+
+    private static let lastRawStepsKey = "steps.lastRawValue"      // Int: last raw [4:6] counter
+    private static let lastRawStepsDayKey = "steps.lastRawDay"     // Date: start-of-day it was observed
+
+    /// Last raw counter we recorded, or nil if we've never seen one (first run / cleared). Stored
+    /// as an object so a legitimate 0 reading is distinguishable from "unset".
+    private var persistedLastRawSteps: Int? {
+        UserDefaults.standard.object(forKey: Self.lastRawStepsKey) as? Int
+    }
+    /// Start-of-day the persisted raw counter was observed (for midnight-rollover detection).
+    private var persistedLastRawStepsDay: Date? {
+        UserDefaults.standard.object(forKey: Self.lastRawStepsDayKey) as? Date
+    }
+    private func persistStepRawState(raw: Int, day: Date) {
+        UserDefaults.standard.set(raw, forKey: Self.lastRawStepsKey)
+        UserDefaults.standard.set(day, forKey: Self.lastRawStepsDayKey)
+    }
+
     /// Start (or switch) live monitoring in a single mode. Guarantees only one metric
     /// reads at a time: switching to a mode puts the ring in `06 01`/`06 02`, so frames
     /// for the other metric stop arriving.
@@ -665,25 +690,40 @@ extension RingSession: CBPeripheralDelegate {
             // Frames arriving while the link isn't `ready` mean discovery didn't land on this
             // (restored) reconnect — re-run it so we can ack and the buttons enable. #reconnect
             if !self.ready { self.rediscoverIfNeeded() }
-            // The ring's onboard step counter (descriptor [4:6], §5.4) is a since-handoff DELTA that
-            // resets (the official app sums it in local memory). So accumulate observed deltas
-            // into a persistent daily total, reset-aware, rather than showing the raw counter
-            // (which reset to 0). NOTE: we only count steps while THIS app is connected, so the
-            // total lags the always-connected official app — but it never resets to 0.
+            // The ring's onboard step counter (descriptor [4:6], §5.4) is a since-handoff DELTA the
+            // official app resets; if that app isn't running it keeps climbing (it does NOT reset
+            // at midnight on its own). Fold each observed counter into a persistent per-day total,
+            // reset-aware, using the last raw value persisted ACROSS sessions — so a reconnect
+            // computes the TRUE delta since we last saw the ring instead of rebasing to the current
+            // counter and dropping every step taken while disconnected (#34). The pure, unit-tested
+            // StepAccumulator owns the reset/midnight math; this stays a thin caller.
             if let v = DeviceStatus.steps(bytes) {
-                if lastRawSteps == nil {
-                    // First reading this session — recover today's accumulated total from the
-                    // store and use this counter as the baseline (don't retro-count unseen steps).
-                    dailyStepsTotal = (try? localStore?.todaySteps()) ?? 0
-                } else if let last = lastRawSteps {
-                    let delta = v >= last ? v - last : v   // v < last => ring reset; v is the new count
-                    if delta > 0 {
-                        dailyStepsTotal += delta
-                        try? localStore?.addDailySteps(delta)
+                // Stamp by SAMPLE time (when the descriptor arrived), not ingest time, so a delta
+                // observed at 00:00:01 lands on the right day (#34). lastFrameAt was just set above.
+                let sampleDate = self.lastFrameAt ?? Date()
+                let sampleDay = Calendar.current.startOfDay(for: sampleDate)
+                let previousRaw = self.persistedLastRawSteps
+                let dayChanged = previousRaw != nil && self.persistedLastRawStepsDay != sampleDay
+                let update = StepAccumulator.update(previousRaw: previousRaw, newRaw: v, dayChanged: dayChanged)
+                if update.isReset {
+                    // Disambiguate a mid-day reset/handoff (unexpected — log loudly) from the
+                    // official app's normal midnight reset (expected) so we never silently miscount.
+                    if update.isAnomalousReset {
+                        ringLog.notice("steps: mid-day counter reset \(previousRaw ?? -1)→\(v) — counting \(v) as new (handoff/reboot/wrap)")
+                    } else {
+                        ringLog.debug("steps: counter reset across midnight \(previousRaw ?? -1)→\(v) — counting \(v) on new day (expected)")
                     }
                 }
-                lastRawSteps = v
+                if update.deltaToAdd > 0 {
+                    try? localStore?.addDailySteps(update.deltaToAdd, day: sampleDate)
+                }
+                // Re-read the sample day's total from the store as the live display value: a fresh
+                // row on midnight rollover reads its own total (no prior-day baseline bleed), and a
+                // baseline-only first reading recovers today's already-accumulated count.
+                dailyStepsTotal = (try? localStore?.todaySteps(day: sampleDate)) ?? dailyStepsTotal
                 self.steps = dailyStepsTotal
+                // Persist the raw counter + its day for the NEXT reading (cross-session, #34).
+                self.persistStepRawState(raw: v, day: sampleDay)
             }
             // Skin temperature rides the same 0x10/0x87 descriptor (§5.4). It streams live
             // (~30–60 s) and is NOT in the sleep sync, so capture + persist it here — but ONLY

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -698,8 +698,11 @@ extension RingSession: CBPeripheralDelegate {
             // counter and dropping every step taken while disconnected (#34). The pure, unit-tested
             // StepAccumulator owns the reset/midnight math; this stays a thin caller.
             if let v = DeviceStatus.steps(bytes) {
-                // Stamp by SAMPLE time (when the descriptor arrived), not ingest time, so a delta
-                // observed at 00:00:01 lands on the right day (#34). lastFrameAt was just set above.
+                // Stamp by SAMPLE time (when the descriptor arrived), not a hardcoded Date(), so a
+                // delta lands on the right StoredDaily row at a day boundary (#34). NOTE: on the LIVE
+                // path lastFrameAt was just set to now (line ~689), so sampleDate ≈ ingest time — this
+                // picks the correct day for the row/persist + display re-read, but it cannot back-date
+                // steps actually taken at 23:59 onto the prior day (no per-step timestamps on the wire).
                 let sampleDate = self.lastFrameAt ?? Date()
                 let sampleDay = Calendar.current.startOfDay(for: sampleDate)
                 let previousRaw = self.persistedLastRawSteps

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -428,11 +428,12 @@ struct LocalStore {
         return try context.fetch(descriptor).first
     }
 
-    /// Upsert the day's step count, keyed by start-of-day. The ring's onboard count only
-    /// grows within a day, so keep the max for the day; a new day gets its own row.
-    /// Accumulate a step DELTA into today's running total. The ring's onboard counter is a
-    /// since-handoff delta that RESETS (the official app sums the deltas in local memory), so
-    /// we sum observed deltas the same way rather than storing the raw counter. New day = new row.
+    /// Accumulate a step DELTA into the running total for `day`, UPSERTED by start-of-day. The
+    /// ring's onboard counter is a since-handoff delta that RESETS (the official app sums the
+    /// deltas in local memory), so we sum observed deltas the same way rather than storing the
+    /// raw counter — `StepAccumulator` (#34) computes the reset-aware delta. New day = new row.
+    /// `day` is the SAMPLE time of the reading (when the descriptor arrived), so a delta observed
+    /// just after midnight for late-night steps is stamped onto its own day, not the prior one.
     func addDailySteps(_ delta: Int, day: Date = Date()) throws {
         guard delta > 0 else { return }
         let dayStart = Calendar.current.startOfDay(for: day)

--- a/ios/OpenRingKit/Sources/OpenRingKit/StepAccumulator.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/StepAccumulator.swift
@@ -1,0 +1,70 @@
+// Step accumulation (#34). The ring's onboard step count (0x10/0x87 descriptor `[4:6]`,
+// 16-bit big-endian, DeviceStatus.steps) is a SINCE-HANDOFF delta, not a daily total: the
+// official app sums it in local memory and periodically RESETS the ring's counter. If the
+// official app isn't running, the ring's counter just keeps climbing (it does NOT reset at
+// midnight on its own). So a usable daily total has to be reconstructed by folding the
+// incremental deltas between successive raw readings — reset-aware, and stamped to the day
+// the reading was sampled.
+//
+// This type is the pure, unit-tested core of that fold. `RingSession` persists the last raw
+// counter + its day across sessions (UserDefaults) and `LocalStore` upserts the resulting
+// delta into the per-day rollup; both stay thin callers so the tricky reset/midnight cases
+// live here where they can be tested without CoreBluetooth or SwiftData.
+//
+// Pure (no Apple frameworks beyond Foundation) so it runs on the SwiftPM CLI.
+
+import Foundation
+
+/// Outcome of folding one raw counter observation into the running daily total.
+public struct StepUpdate: Equatable, Sendable {
+    /// Steps to add to the SAMPLE day's running total. Always `>= 0` — never negative, so a
+    /// caller can add it blindly without re-checking for a drop.
+    public let deltaToAdd: Int
+    /// The raw counter dropped below the last reading: the official app reset / took over the
+    /// since-handoff counter (or the ring rebooted, or the 16-bit counter wrapped). When true,
+    /// `newRaw` itself is taken as the post-reset count (`deltaToAdd == newRaw`), not
+    /// `newRaw - previousRaw`.
+    public let isReset: Bool
+    /// A reset that is NOT explained by a day rollover — i.e. the counter dropped *mid-day*.
+    /// A drop across midnight is the official app's expected daily reset; a drop within the
+    /// same day is unexpected (handoff/reboot/wrap) and worth logging (#34). Always false when
+    /// `isReset` is false.
+    public let isAnomalousReset: Bool
+
+    public init(deltaToAdd: Int, isReset: Bool, isAnomalousReset: Bool) {
+        self.deltaToAdd = deltaToAdd
+        self.isReset = isReset
+        self.isAnomalousReset = isAnomalousReset
+    }
+}
+
+public enum StepAccumulator {
+    /// Fold a freshly observed raw counter against the last one we recorded.
+    ///
+    /// - Parameters:
+    ///   - previousRaw: the last raw counter we persisted, or `nil` when there is no prior
+    ///     reading (first run ever / no persisted state). With no baseline we cannot know how
+    ///     many of the raw steps are "ours" vs. taken before we ever connected, so we count
+    ///     none and just adopt `newRaw` as the baseline (`deltaToAdd == 0`).
+    ///   - newRaw: the counter just observed (`DeviceStatus.steps`, 0…65535).
+    ///   - dayChanged: the sample's calendar day differs from the day `previousRaw` was
+    ///     observed. Only affects whether a reset is flagged as anomalous — the delta math is
+    ///     identical across midnight because the ring's counter is monotonic between resets, so
+    ///     the incremental delta is always the correct amount to credit the new (sample) day.
+    public static func update(previousRaw: Int?, newRaw: Int, dayChanged: Bool) -> StepUpdate {
+        guard let previous = previousRaw else {
+            // No baseline — adopt this reading as the baseline, count nothing.
+            return StepUpdate(deltaToAdd: 0, isReset: false, isAnomalousReset: false)
+        }
+        if newRaw >= previous {
+            // Monotonic climb (same day, or across midnight with the official app not running):
+            // the incremental delta is the steps taken since the last reading.
+            return StepUpdate(deltaToAdd: newRaw - previous, isReset: false, isAnomalousReset: false)
+        }
+        // Counter dropped: the official app reset/handed-off the since-handoff counter (or the
+        // ring rebooted, or the 16-bit counter wrapped). `newRaw` is the post-reset count. A
+        // mid-day drop is unexpected and surfaced as anomalous; a drop across midnight is the
+        // official app's normal daily reset.
+        return StepUpdate(deltaToAdd: newRaw, isReset: true, isAnomalousReset: !dayChanged)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/StepAccumulatorTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/StepAccumulatorTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import OpenRingKit
+
+// Step accumulation (#34): fold the ring's since-handoff raw counter into per-day deltas,
+// reset-aware and midnight-aware. These cases pin the behavior the live BLE path can't
+// easily test: a normal climb, the no-baseline first reading, a mid-day reset/handoff vs the
+// expected midnight reset, a 16-bit wraparound, and "no movement" (which must NOT double-count).
+final class StepAccumulatorTests: XCTestCase {
+
+    func testClimbCountsTheDelta() {
+        let u = StepAccumulator.update(previousRaw: 100, newRaw: 150, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 50)
+        XCTAssertFalse(u.isReset)
+        XCTAssertFalse(u.isAnomalousReset)
+    }
+
+    func testNoMovementAddsNothing() {
+        // Same raw counter twice in a row must add 0 — the keepalive re-reads the descriptor
+        // every cycle, so a flat counter must not keep crediting steps.
+        let u = StepAccumulator.update(previousRaw: 4321, newRaw: 4321, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 0)
+        XCTAssertFalse(u.isReset)
+    }
+
+    func testFirstReadingHasNoBaselineAndCountsNothing() {
+        // previousRaw == nil: we can't tell how many raw steps predate us, so adopt the reading
+        // as the baseline and count none (don't retro-count someone else's steps onto today).
+        let u = StepAccumulator.update(previousRaw: nil, newRaw: 8000, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 0)
+        XCTAssertFalse(u.isReset)
+        XCTAssertFalse(u.isAnomalousReset)
+    }
+
+    func testMidDayResetCountsNewValueAndFlagsAnomaly() {
+        // Counter dropped within the same day (official app took over / ring rebooted): the new
+        // value is the post-reset count, and it's surfaced as anomalous so the caller can log it.
+        let u = StepAccumulator.update(previousRaw: 5000, newRaw: 120, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 120)
+        XCTAssertTrue(u.isReset)
+        XCTAssertTrue(u.isAnomalousReset)
+    }
+
+    func testMidnightResetCountsNewValueButIsNotAnomalous() {
+        // A drop across midnight is the official app's normal daily reset — still a reset (add
+        // the new value to the new day), but NOT anomalous.
+        let u = StepAccumulator.update(previousRaw: 9000, newRaw: 50, dayChanged: true)
+        XCTAssertEqual(u.deltaToAdd, 50)
+        XCTAssertTrue(u.isReset)
+        XCTAssertFalse(u.isAnomalousReset)
+    }
+
+    func testMidnightClimbCreditsIncrementalDeltaToNewDay() {
+        // Official app NOT running: the ring's counter keeps climbing across midnight. The
+        // incremental delta (not the whole counter) is what the new day earns — anything else
+        // would bleed the prior day's accumulated baseline into the new day.
+        let u = StepAccumulator.update(previousRaw: 9000, newRaw: 9100, dayChanged: true)
+        XCTAssertEqual(u.deltaToAdd, 100)
+        XCTAssertFalse(u.isReset)
+        XCTAssertFalse(u.isAnomalousReset)
+    }
+
+    func testWraparoundIsTreatedAsAReset() {
+        // The counter is 16-bit (DeviceStatus.steps, max 65535). A wrap near the top reads as a
+        // drop and is treated as a reset (count the wrapped value) — indistinguishable from a
+        // real reset without more data, and a 65k-step handoff window is implausible anyway.
+        let u = StepAccumulator.update(previousRaw: 65500, newRaw: 30, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 30)
+        XCTAssertTrue(u.isReset)
+    }
+
+    func testResetFlagIsNeverSetOnAClimb() {
+        // isAnomalousReset must only ever be true alongside isReset.
+        for dayChanged in [true, false] {
+            let u = StepAccumulator.update(previousRaw: 10, newRaw: 20, dayChanged: dayChanged)
+            XCTAssertFalse(u.isReset)
+            XCTAssertFalse(u.isAnomalousReset)
+        }
+    }
+
+    func testSummingDeltasReconstructsADayOfSteps() {
+        // End-to-end fold: a session's worth of readings (a climb, a mid-day reset, more climb)
+        // should sum to the steps actually taken: 0→1200, reset, 0→800 = 2000.
+        let readings: [(prev: Int?, raw: Int)] = [
+            (nil, 0),      // baseline
+            (0, 400),      // +400
+            (400, 1200),   // +800
+            (1200, 0),     // reset (official app handed off) — counter back to 0
+            (0, 300),      // +300
+            (300, 800),    // +500
+        ]
+        var total = 0
+        for r in readings {
+            total += StepAccumulator.update(previousRaw: r.prev, newRaw: r.raw, dayChanged: false).deltaToAdd
+        }
+        XCTAssertEqual(total, 400 + 800 + 0 + 300 + 500)   // 2000
+    }
+}


### PR DESCRIPTION
Closes #34. Builds on the merged Wave 1 lanes (A/B/C/E/D) and stays strictly in its lane — touches only step accounting.

## What
The ring's onboard step counter (0x10/0x87 descriptor `[4:6]`, 16-bit big-endian, `DeviceStatus.steps` — §5.4 🟢) is a *since-handoff* delta, not a daily total: the official app sums it in local memory and periodically resets the ring's counter; with the official app not running it keeps climbing (it does NOT reset at midnight on its own). This lane reconstructs a usable per-day total from that counter and fixes the three bugs in #34:

1. **Cross-session delta persistence.** The old in-memory `lastRawSteps` baseline was lost on reconnect/app-restart, so the next reading rebased to the current counter and silently dropped every step taken while disconnected. The last raw value **and its day** are now persisted in `UserDefaults` (`steps.lastRawValue` / `steps.lastRawDay`), read on every frame, so a reconnect computes the TRUE delta `v - persistedRaw` and credits the gap.
2. **Reset vs. climb disambiguation.** A pure, unit-tested `StepAccumulator` decides: `newRaw < previousRaw` ⇒ reset (credit `newRaw`), else monotonic delta. A **mid-day** reset is anomalous (handoff/reboot/16-bit wrap) and logged `.notice`; a reset **across midnight** is the official app's expected daily reset and logged `.debug`. Never silently miscounts.
3. **Midnight display bleed.** The live display total is re-read from the **sample-day** `StoredDaily` row instead of an in-memory carry-over, so an in-session midnight rollover starts fresh with no prior-day bleed.

No SwiftData migration (`StoredDaily` unchanged). Step state lives in `UserDefaults`, not `LocalStore`, to avoid a migration and per-day-row collision.

## Files
- `ios/OpenRingKit/Sources/OpenRingKit/StepAccumulator.swift` — pure reset/midnight fold (new)
- `ios/OpenRingKit/Tests/OpenRingKitTests/StepAccumulatorTests.swift` — 9 cases (new)
- `ios/OpenRingConn/BLE/RingSession.swift` — thin caller: persist raw+day across sessions, sample-time stamping, reset logging
- `ios/OpenRingConn/Store/LocalStore.swift` — `addDailySteps(_:day:)` doc + sample-day stamping

## Tests / checks
- `cd ios/OpenRingKit && swift build && swift test` → **107 pass, 0 failures** (9 `StepAccumulatorTests`: climb, no-movement, no-baseline, mid-day reset+anomaly, midnight reset not-anomalous, midnight incremental climb, 16-bit wraparound, reset-flag-never-on-climb, end-to-end day sum = 2000). RingKitVerify ground-truth step vectors still pass.
- Changed app files parse-check clean (`swiftc -parse`, iphoneos). Device build is the orchestrator's gate.

## Deferred (protocol-blocked, honest)
The ideal fix — read the ring's authoritative daily/lifetime total from the `0x4c` activity payload `[15:22]` — is deferred as gated on captures #13/#9 and is **not** implemented here. No fabricated protocol values: every byte/opcode reference matches the pre-existing, ground-truthed `DeviceStatus.swift`.

## Adversarial review
Peer review verdict: **approve** (no mustFix), acceptance + fabrication checks passed, 107 tests run on the branch. This fixup commit addresses the top shouldConsider item — a comment clarifying that on the live path `sampleDate ≈ now` (sample-time == ingest-time), so a future reader doesn't assume measurement-time back-stamping (impossible without per-step timestamps the ring doesn't expose). Comment-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)