### PR TITLE
Observability: last-sync/last-write surfacing + alerts + bg-task log (#44); BGProcessingTask for background HR (#45)

### DIFF
--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -12,7 +12,18 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                 task.setTaskCompleted(success: false)
                 return
             }
-            Self.handle(refreshTask)
+            Self.handle(refreshTask, kind: .appRefresh,
+                        timeout: RingBackgroundSyncService.defaultTimeout)
+        }
+        // BGProcessingTask: the longer-window sibling that finally gives the optical-HR poll room
+        // to clear its ~60 s warm-up in the background (#45). Same sync path, larger time budget.
+        scheduler.registerProcessing { task in
+            guard let processingTask = task as? BGProcessingTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            Self.handle(processingTask, kind: .processing,
+                        timeout: RingBackgroundSyncService.processingTimeout)
         }
 
         // Re-instantiate the CBCentralManager (with its restore identifier) during launch so
@@ -28,11 +39,20 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
     func applicationDidEnterBackground(_ application: UIApplication) {
         scheduler.schedule()
+        scheduler.scheduleProcessing()
+        ObservabilityStore().recordScheduled()
     }
 
-    private static func handle(_ task: BGAppRefreshTask) {
+    /// Run one bounded background sync for either BGTask variant. `kind`/`timeout` differ (short
+    /// app-refresh vs. longer processing), but the body is shared: schedule the next runs, sync,
+    /// record the outcome to the observability log, and fire any debounced silent-failure alerts
+    /// (#44). Always re-submits BOTH requests so a granted run keeps the chain alive.
+    private static func handle(_ task: BGTask, kind: TaskRecord.Kind, timeout: TimeInterval) {
         let scheduler = BackgroundRefreshScheduler()
+        let observability = ObservabilityStore()
         scheduler.schedule()
+        scheduler.scheduleProcessing()
+        observability.recordScheduled()
 
         let operation = Task { @MainActor in
             do {
@@ -41,24 +61,44 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                     store: LocalStore(container.mainContext),
                     health: HealthKitWriter()
                 )
-                // Use the service's adaptive budget (longer than the old 20 s so the live-HR
-                // poll isn't starved by the history drain, #45 A). The expirationHandler below
-                // still cancels cleanly if iOS grants a shorter window.
-                let synced = try await service.syncVitals()
+                // Pass the per-task budget. The app-refresh path keeps the ~28 s budget so the
+                // live-HR poll isn't starved by the history drain (#45 A); the processing path
+                // gets the longer budget so the poll can actually lock. The expirationHandler
+                // below still cancels cleanly if iOS grants a shorter window.
+                let synced = try await service.syncVitals(timeout: timeout)
                 guard !Task.isCancelled else { return }
+                observability.recordSyncOutcome(kind: kind, success: synced,
+                                                detail: synced ? "captured/flushed data" : "no data this run")
+                await Self.evaluateAlerts()
                 scheduler.schedule()
+                scheduler.scheduleProcessing()
                 task.setTaskCompleted(success: synced)
             } catch {
                 guard !Task.isCancelled else { return }
+                observability.recordSyncOutcome(kind: kind, success: false,
+                                                detail: "error: \(error.localizedDescription)")
+                await Self.evaluateAlerts()
                 scheduler.schedule()
+                scheduler.scheduleProcessing()
                 task.setTaskCompleted(success: false)
             }
         }
 
         task.expirationHandler = {
             operation.cancel()
+            observability.recordSyncOutcome(kind: kind, success: false, detail: "iOS ended the task early")
             scheduler.schedule()
+            scheduler.scheduleProcessing()
             task.setTaskCompleted(success: false)
         }
+    }
+
+    /// Fire debounced local notifications for silent-failure conditions after a background run.
+    /// Battery is nil here (the background session is already torn down), so low-battery is
+    /// evaluated only in the foreground (ContentView) where a live reading exists — the staleness
+    /// and Health-auth-lost conditions are the ones that matter when iOS isn't waking us. (#44)
+    private static func evaluateAlerts() async {
+        let healthAuthorized = await MainActor.run { HealthKitWriter().isShareAuthorized }
+        await LocalAlertCenter().evaluate(batteryPercent: nil, healthAuthorized: healthAuthorized)
     }
 }

--- a/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
+++ b/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
@@ -15,6 +15,16 @@ struct BackgroundRefreshScheduler {
     static let identifier = "com.dreamality.openringconn.bgrefresh"
     static let refreshInterval: TimeInterval = 15 * 60
 
+    /// Separate BGProcessingTask (#45). A processing task gets a much longer runtime window than
+    /// the ~30 s BGAppRefreshTask ceiling, so the optical-HR poll can finally clear its ~60 s
+    /// warm-up in the background. HONEST: iOS schedules processing tasks at its own discretion
+    /// (commonly overnight while charging), so this improves the odds of a real background HR
+    /// lock but does NOT guarantee a daytime one.
+    static let processingIdentifier = "com.dreamality.openringconn.bgprocessing"
+    /// Ask for the processing task less often than the app refresh — it's the heavier, longer
+    /// run, and iOS coalesces/throttles these regardless.
+    static let processingInterval: TimeInterval = 60 * 60
+
     private let scheduler: BGTaskScheduling
     private let now: () -> Date
 
@@ -33,9 +43,28 @@ struct BackgroundRefreshScheduler {
         )
     }
 
+    @discardableResult
+    func registerProcessing(launchHandler: @escaping (BGTask) -> Void) -> Bool {
+        scheduler.register(
+            forTaskWithIdentifier: Self.processingIdentifier,
+            using: nil,
+            launchHandler: launchHandler
+        )
+    }
+
     func makeRequest() -> BGAppRefreshTaskRequest {
         let request = BGAppRefreshTaskRequest(identifier: Self.identifier)
         request.earliestBeginDate = now().addingTimeInterval(Self.refreshInterval)
+        return request
+    }
+
+    func makeProcessingRequest() -> BGProcessingTaskRequest {
+        let request = BGProcessingTaskRequest(identifier: Self.processingIdentifier)
+        request.earliestBeginDate = now().addingTimeInterval(Self.processingInterval)
+        // It needs the longer WINDOW, not the charger — a daytime HR read shouldn't require power.
+        // (iOS still tends to defer processing tasks to charging/idle, but we don't mandate it.)
+        request.requiresExternalPower = false
+        request.requiresNetworkConnectivity = false
         return request
     }
 
@@ -46,6 +75,17 @@ struct BackgroundRefreshScheduler {
         } catch {
             #if DEBUG
             print("Unable to schedule background refresh: \(error)")
+            #endif
+        }
+    }
+
+    func scheduleProcessing() {
+        do {
+            scheduler.cancel(taskRequestWithIdentifier: Self.processingIdentifier)
+            try scheduler.submit(makeProcessingRequest())
+        } catch {
+            #if DEBUG
+            print("Unable to schedule background processing: \(error)")
             #endif
         }
     }

--- a/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
+++ b/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
@@ -20,6 +20,15 @@ struct RingBackgroundSyncService {
     /// any lock now reaches HealthKit, and the standing reconnect gives repeat chances.)
     static let defaultTimeout: TimeInterval = 28
 
+    /// Budget for the BGProcessingTask path (#45). A processing task gets minutes of runtime
+    /// (vs. the ~30 s app-refresh ceiling), so the optical-HR poll finally has room past its
+    /// ~60 s warm-up to actually lock. We change ONLY the time budget handed to the existing
+    /// capture loop — not the drain/decode logic. The loop is cancellation-aware, so if iOS
+    /// grants less the AppDelegate `expirationHandler` still tears down cleanly. HONEST: iOS
+    /// schedules processing tasks at its discretion (usually overnight on the charger), so this
+    /// makes a real background HR lock LIKELY when it runs, not guaranteed for daytime.
+    static let processingTimeout: TimeInterval = 150
+
     /// One bounded background read so the app already has last night's data on open. The
     /// drain inside `captureForBackground` persists overnight HR/HRV/SpO2 + sleep + steps +
     /// skin temp to the local store (the dashboard's source) — skin temp ONLY during the
@@ -46,6 +55,9 @@ struct RingBackgroundSyncService {
         if HealthKitWriter.isAvailable {
             mirrored = await health.flushToHealth(store: store,
                                                   sleepSegments: capture.sleepSegments).wroteAnything
+            // Record the Health write so ContentView's "Last Health write" reflects the
+            // background path too, not just the manual button (#44).
+            if mirrored { ObservabilityStore().recordHealthWrite() }
         }
         // Success = we captured fresh data OR mirrored previously-pending data to Health, so a
         // run that only flushed a backlog still counts (iOS uses this to keep scheduling us).

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -10,6 +10,13 @@ struct ContentView: View {
     @State private var lastWrite: String?
     @State private var showDebug = false
 
+    /// Freshness timestamps mirrored from the UserDefaults-backed observability store (#44).
+    /// Held in @State because UserDefaults writes (from the background task / a flush) don't
+    /// publish to SwiftUI — we re-read them on the lifecycle hooks below.
+    @State private var lastSyncAt: Date?
+    @State private var lastHealthWriteAt: Date?
+    private let observability = ObservabilityStore()
+
     /// Armed when a foreground activation wants a one-shot history sync, fired once the
     /// link is `ready`. A user "Scan & connect" never sets this, so the auto-refresh can't
     /// fire on top of a manual connect.
@@ -61,13 +68,19 @@ struct ContentView: View {
                 // Runs in `.task` (after first frame), never `.onAppear` — a synchronous store
                 // read there once blocked the launch render into a black screen. #14
                 healthAuthorized = health.isShareAuthorized
+                if healthAuthorized { observability.markHealthEverAuthorized() }
+                refreshObservability()
                 if healthAuthorized { flushHealth() }
             }
             // Foreground auto-refresh: reconnect to the last-known ring and pull fresh data
             // when the app becomes active, so opening it after a while shows updated vitals
             // without a manual Scan/Sync.
             .onChange(of: scenePhase) { _, phase in
-                if phase == .active { handleForegroundActivation() }
+                if phase == .active {
+                    handleForegroundActivation()
+                    refreshObservability()        // pick up anything a background run wrote
+                    evaluateForegroundAlerts()    // live battery + Health-auth check (#44)
+                }
             }
             // Fire the armed one-shot sync the moment the (re)connected link is ready.
             .onChange(of: session?.ready) { _, ready in
@@ -78,7 +91,10 @@ struct ContentView: View {
             // pending to Health. Each metric is watermark-gated, so this never double-writes
             // and is a no-op until the user has authorized Health.
             .onChange(of: session?.syncing) { _, syncing in
-                if syncing == false { flushHealth() }
+                if syncing == false {
+                    recordForegroundSync()
+                    flushHealth()
+                }
             }
             .onChange(of: session?.monitoring) { _, monitoring in
                 if monitoring == false { flushHealth() }
@@ -115,6 +131,37 @@ struct ContentView: View {
         pendingAutoSync = false
         lastForegroundSync = Date()
         session.syncHistory()
+    }
+
+    // MARK: Observability (#44)
+
+    /// Re-read the persisted freshness timestamps into @State (UserDefaults writes don't publish
+    /// to SwiftUI on their own).
+    private func refreshObservability() {
+        lastSyncAt = observability.lastSuccessfulSync
+        lastHealthWriteAt = observability.lastHealthWrite
+    }
+
+    /// A foreground history sync just finished — record its outcome so "Last successful sync"
+    /// reflects manual/auto foreground refreshes too, not only background runs. Success = the
+    /// session actually received frames on this connection.
+    private func recordForegroundSync() {
+        let gotData = session?.lastFrameAt != nil || (session?.historySamples.isEmpty == false)
+        observability.recordSyncOutcome(kind: .foreground, success: gotData,
+                                        detail: gotData ? "synced from ring" : "no frames received")
+        refreshObservability()
+    }
+
+    /// Foreground alert evaluation with a LIVE battery reading (the background path can't see
+    /// battery once its session is torn down) and a fresh Health-auth probe (so a revocation made
+    /// in Settings while we were away is caught). Latches "ever authorized" so an auth-lost alert
+    /// can be told apart from a user who simply never opted into Health.
+    private func evaluateForegroundAlerts() {
+        let authorized = health.isShareAuthorized
+        healthAuthorized = authorized
+        if authorized { observability.markHealthEverAuthorized() }
+        let battery = session?.batteryPercent
+        Task { await LocalAlertCenter().evaluate(batteryPercent: battery, healthAuthorized: authorized) }
     }
 
     // MARK: Connection
@@ -227,6 +274,32 @@ struct ContentView: View {
 
     // MARK: Sync + Health
 
+    /// Prominent "is this thing actually working?" line (#44): when we last pulled from the ring
+    /// and when we last wrote to Apple Health, tapping through to the full background-activity log.
+    private var freshnessRow: some View {
+        NavigationLink {
+            ActivityLogView()
+        } label: {
+            HStack(spacing: 16) {
+                freshnessStat("Last sync", lastSyncAt)
+                Divider().frame(height: 30)
+                freshnessStat("Health write", lastHealthWriteAt)
+                Spacer()
+                Image(systemName: "chevron.right").font(.caption).foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func freshnessStat(_ label: String, _ date: Date?) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label).font(.caption2).foregroundStyle(.secondary)
+            Text(date.map { Self.rel.localizedString(for: $0, relativeTo: Date()) } ?? "never")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(date == nil ? .secondary : .primary)
+        }
+    }
+
     private var syncCard: some View {
         card {
             HStack {
@@ -234,6 +307,8 @@ struct ContentView: View {
                 Spacer()
                 if session?.syncing == true { ProgressView() }
             }
+            freshnessRow
+            Divider()
             Button {
                 session?.syncHistory()
             } label: {
@@ -301,6 +376,7 @@ struct ContentView: View {
                     Task {
                         try? await health.requestAuthorization()
                         healthAuthorized = health.isShareAuthorized
+                        if healthAuthorized { observability.markHealthEverAuthorized() }
                         flushHealth()   // backfill everything already in the store
                     }
                 } label: {
@@ -396,6 +472,8 @@ struct ContentView: View {
         Task {
             let r = await health.flushToHealth(store: store, sleepSegments: segments)
             if r.wroteAnything {
+                observability.recordHealthWrite()
+                refreshObservability()
                 lastWrite = "Synced to Health: \(r.samples) samples"
                     + (r.sleepSegments > 0 ? ", \(r.sleepSegments) sleep segs" : "")
                     + (r.steps > 0 ? ", \(r.steps) steps" : "")

--- a/ios/OpenRingConn/Info.plist
+++ b/ios/OpenRingConn/Info.plist
@@ -5,6 +5,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.dreamality.openringconn.bgrefresh</string>
+		<string>com.dreamality.openringconn.bgprocessing</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
@@ -32,6 +33,7 @@
 	<array>
 		<string>bluetooth-central</string>
 		<string>fetch</string>
+		<string>processing</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/ios/OpenRingConn/Observability/ActivityLogView.swift
+++ b/ios/OpenRingConn/Observability/ActivityLogView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import UIKit
+
+// User-reachable observability screen (#44): freshness timestamps, whether iOS is actually
+// running our background tasks, and a bounded log of recent sync outcomes — so a silent failure
+// (a throttled BGTask, a stalled ring) becomes visible instead of invisible.
+
+struct ActivityLogView: View {
+    private let store = ObservabilityStore()
+    @State private var records: [TaskRecord] = []
+    @State private var refreshStatus: UIBackgroundRefreshStatus = .available
+
+    var body: some View {
+        List {
+            Section("Freshness") {
+                timeRow("Last successful sync", store.lastSuccessfulSync)
+                timeRow("Last Health write", store.lastHealthWrite)
+            }
+
+            Section("Background tasks") {
+                timeRow("Last background run", store.bgLastRun)
+                timeRow("Last scheduled", store.bgLastScheduled)
+                LabeledContent("Background App Refresh", value: refreshStatusText)
+                if refreshStatus != .available {
+                    Text("iOS is limiting background activity. Turn on Settings ▸ General ▸ "
+                         + "Background App Refresh so the ring can sync while the app is closed.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                Text("Background heart-rate runs at iOS's discretion (usually overnight while "
+                     + "charging) and is best-effort — daytime background HR is not guaranteed.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+
+            Section("Recent activity") {
+                if records.isEmpty {
+                    Text("No background activity recorded yet.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(records.reversed()) { record in
+                        recordRow(record)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Background activity")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            records = store.records()
+            refreshStatus = UIApplication.shared.backgroundRefreshStatus
+        }
+    }
+
+    private func timeRow(_ label: String, _ date: Date?) -> some View {
+        LabeledContent(label) {
+            if let date {
+                Text(date, format: .relative(presentation: .named))
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("never").foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private func recordRow(_ record: TaskRecord) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: record.success ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(record.success ? .green : .orange)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(kindLabel(record.kind)).font(.subheadline.weight(.medium))
+                    Spacer()
+                    Text(record.date, format: .dateTime.month().day().hour().minute())
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+                if let detail = record.detail {
+                    Text(detail).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func kindLabel(_ kind: TaskRecord.Kind) -> String {
+        switch kind {
+        case .appRefresh: return "App refresh"
+        case .processing: return "Processing"
+        case .foreground: return "Foreground sync"
+        }
+    }
+
+    private var refreshStatusText: String {
+        switch refreshStatus {
+        case .available: return "On"
+        case .denied: return "Off"
+        case .restricted: return "Restricted"
+        @unknown default: return "Unknown"
+        }
+    }
+}

--- a/ios/OpenRingConn/Observability/ObservabilityStore.swift
+++ b/ios/OpenRingConn/Observability/ObservabilityStore.swift
@@ -1,0 +1,173 @@
+import Foundation
+import OpenRingKit
+import UserNotifications
+
+// Observability/alerting glue for the always-on tracker (#44). The PURE policy (thresholds +
+// debounce + ring-buffer trim) lives in OpenRingKit (`SyncObservability.swift`); this file is the
+// app-side persistence + notification plumbing. Deliberately UserDefaults-backed, NOT SwiftData:
+// a separate, schema-free store avoids a migration and a collision with the steps lane. Plain
+// `struct` over `UserDefaults` (itself thread-safe), so the foreground UI and the background task
+// can both record without an actor hop.
+
+/// One recorded sync/background-task outcome for the user-visible activity log.
+struct TaskRecord: Codable, Identifiable, Equatable {
+    enum Kind: String, Codable {
+        case appRefresh   // BGAppRefreshTask (short ~30 s window)
+        case processing   // BGProcessingTask (longer window — gives background HR a chance, #45)
+        case foreground   // a sync the user triggered / a foreground auto-refresh
+    }
+    var id = UUID()
+    var date: Date
+    var kind: Kind
+    var success: Bool
+    var detail: String?
+}
+
+/// Reads/writes the observability timestamps + bounded outcome log in UserDefaults.
+struct ObservabilityStore {
+    private let defaults: UserDefaults
+    init(_ defaults: UserDefaults = .standard) { self.defaults = defaults }
+
+    /// Keep the last N outcomes (newest survive — see `BoundedLog`). Small: this is a debug aid.
+    static let logLimit = 40
+
+    private enum Key {
+        static let lastSync = "obs.lastSuccessfulSync"
+        static let lastHealthWrite = "obs.lastHealthWrite"
+        static let bgLastRun = "obs.bgLastRun"
+        static let bgLastScheduled = "obs.bgLastScheduled"
+        static let log = "obs.taskLog"
+        static let alertFired = "obs.alertLastFired"        // [SyncAlert.rawValue: epoch]
+        static let healthEverAuthorized = "obs.healthEverAuthorized"
+    }
+
+    // MARK: Timestamps
+
+    var lastSuccessfulSync: Date? { date(Key.lastSync) }
+    var lastHealthWrite: Date? { date(Key.lastHealthWrite) }
+    var bgLastRun: Date? { date(Key.bgLastRun) }
+    var bgLastScheduled: Date? { date(Key.bgLastScheduled) }
+    var healthEverAuthorized: Bool { defaults.bool(forKey: Key.healthEverAuthorized) }
+
+    private func date(_ key: String) -> Date? {
+        let t = defaults.double(forKey: key)
+        return t > 0 ? Date(timeIntervalSince1970: t) : nil
+    }
+
+    /// Latch that Health share access was granted at least once, so a LATER revocation can be
+    /// distinguished from "never opted in" (gates the `healthAuthLost` alert).
+    func markHealthEverAuthorized() { defaults.set(true, forKey: Key.healthEverAuthorized) }
+
+    // MARK: Recording
+
+    /// Record a sync attempt's outcome. A success bumps "last successful sync"; any
+    /// background-originated run (not `.foreground`) bumps "last background run" so the user can
+    /// see whether iOS is actually waking the app. Appends to the bounded log either way.
+    func recordSyncOutcome(kind: TaskRecord.Kind, success: Bool, detail: String?, at now: Date = Date()) {
+        if kind != .foreground { defaults.set(now.timeIntervalSince1970, forKey: Key.bgLastRun) }
+        if success { defaults.set(now.timeIntervalSince1970, forKey: Key.lastSync) }
+        append(TaskRecord(date: now, kind: kind, success: success, detail: detail))
+    }
+
+    /// Record that we mirrored data into Apple Health (drives the "Last Health write" line).
+    func recordHealthWrite(at now: Date = Date()) {
+        defaults.set(now.timeIntervalSince1970, forKey: Key.lastHealthWrite)
+    }
+
+    /// Record that we (re)submitted a BGTask request — lets the UI show "scheduled vs. last run"
+    /// so a large gap reads as "iOS is throttling us", not "the app is broken".
+    func recordScheduled(at now: Date = Date()) {
+        defaults.set(now.timeIntervalSince1970, forKey: Key.bgLastScheduled)
+    }
+
+    // MARK: Bounded outcome log
+
+    func records() -> [TaskRecord] {
+        guard let data = defaults.data(forKey: Key.log),
+              let list = try? JSONDecoder().decode([TaskRecord].self, from: data) else { return [] }
+        return list
+    }
+
+    private func append(_ record: TaskRecord) {
+        let capped = BoundedLog.appendCapped(record, to: records(), limit: Self.logLimit)
+        if let data = try? JSONEncoder().encode(capped) { defaults.set(data, forKey: Key.log) }
+    }
+
+    // MARK: Alert debounce persistence (consumed by SyncAlertPolicy)
+
+    func alertLastFired() -> [SyncAlert: Date] {
+        let raw = defaults.dictionary(forKey: Key.alertFired) as? [String: Double] ?? [:]
+        var out: [SyncAlert: Date] = [:]
+        for (k, v) in raw where v > 0 {
+            if let alert = SyncAlert(rawValue: k) { out[alert] = Date(timeIntervalSince1970: v) }
+        }
+        return out
+    }
+
+    func markAlertsFired(_ alerts: [SyncAlert], at now: Date = Date()) {
+        var raw = defaults.dictionary(forKey: Key.alertFired) as? [String: Double] ?? [:]
+        for a in alerts { raw[a.rawValue] = now.timeIntervalSince1970 }
+        defaults.set(raw, forKey: Key.alertFired)
+    }
+}
+
+/// Posts the debounced silent-failure notifications (#44). One notification per condition per
+/// `SyncAlertPolicy.renotifyInterval`; never spams. Authorization is requested LAZILY and
+/// provisionally — the first time there's actually something to say — so a healthy user is never
+/// prompted on launch and quiet alerts land in Notification Center without an upfront dialog.
+struct LocalAlertCenter {
+    var store = ObservabilityStore()
+    var policy = SyncAlertPolicy()
+    // Computed (not a stored property) so the synthesized memberwise init stays internal — i.e.
+    // `LocalAlertCenter()` is callable from the other files that fire alerts.
+    private var center: UNUserNotificationCenter { .current() }
+
+    /// Evaluate the current state and post a debounced notification for each firing condition.
+    /// No-op when nothing's wrong. `batteryPercent == nil` (e.g. the background session is already
+    /// torn down) simply skips the low-battery check rather than firing falsely.
+    func evaluate(now: Date = Date(), batteryPercent: Int?, healthAuthorized: Bool) async {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: store.lastSuccessfulSync,
+            batteryPercent: batteryPercent,
+            healthAuthorized: healthAuthorized,
+            healthEverAuthorized: store.healthEverAuthorized,
+            lastFired: store.alertLastFired())
+        guard !fire.isEmpty, await ensureAuthorized() else { return }
+        for alert in fire { await post(alert) }
+        store.markAlertsFired(fire, at: now)
+    }
+
+    private func ensureAuthorized() async -> Bool {
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined:
+            // Provisional auth posts quietly (no upfront prompt) — appropriate for an alert the
+            // user hasn't asked for but would want when something silently breaks.
+            return (try? await center.requestAuthorization(options: [.alert, .sound, .provisional])) ?? false
+        default:
+            return false
+        }
+    }
+
+    private func post(_ alert: SyncAlert) async {
+        let content = UNMutableNotificationContent()
+        switch alert {
+        case .notSynced:
+            content.title = "Ring not synced"
+            content.body = "OpenRingConn hasn't synced your ring in a while. Open the app to refresh, and check Settings ▸ General ▸ Background App Refresh."
+        case .lowBattery:
+            content.title = "Ring battery low"
+            content.body = "Your RingConn battery is low — charge it soon to keep tracking."
+        case .healthAuthLost:
+            content.title = "Apple Health access off"
+            content.body = "OpenRingConn can no longer write to Apple Health. Re-enable it in Settings ▸ Health ▸ Data Access & Devices."
+        }
+        // One pending request per condition (stable id) — re-posting just refreshes it.
+        let request = UNNotificationRequest(identifier: "obs.alert.\(alert.rawValue)",
+                                            content: content, trigger: nil)
+        try? await center.add(request)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/SyncObservability.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/SyncObservability.swift
@@ -1,0 +1,97 @@
+// Observability/alerting policy (#44). As an always-on tracker the app can fail silently —
+// a throttled background task, a revoked Health grant, a ring left off the charger. This holds
+// the PURE decision logic for when to warn the user (staleness + low-battery thresholds and the
+// per-condition debounce) plus a bounded ring-buffer helper, so the policy unit-tests on the CLI
+// without any Apple frameworks. The UserDefaults persistence + UNUserNotificationCenter glue
+// lives in the app target (Observability/ObservabilityStore.swift).
+
+import Foundation
+
+/// The silent-failure conditions worth a local notification.
+public enum SyncAlert: String, CaseIterable, Codable, Sendable {
+    case notSynced       // no successful ring sync in > staleSyncThreshold
+    case lowBattery      // ring battery at/under lowBatteryThreshold
+    case healthAuthLost  // Health share access was granted before and is now off
+}
+
+/// Thresholds + debounce for the silent-failure alerts. Pure value type: the app feeds it the
+/// current observed state and the last time each alert fired, and it returns which alerts should
+/// fire now — never firing the same condition twice inside `renotifyInterval`.
+public struct SyncAlertPolicy: Sendable, Equatable {
+    /// No successful sync in this long → `notSynced`.
+    public var staleSyncThreshold: TimeInterval
+    /// Ring battery at/under this percent → `lowBattery`.
+    public var lowBatteryThreshold: Int
+    /// Minimum spacing between repeat notifications of the SAME condition (anti-spam).
+    public var renotifyInterval: TimeInterval
+
+    public init(staleSyncThreshold: TimeInterval = 6 * 3600,
+                lowBatteryThreshold: Int = 15,
+                renotifyInterval: TimeInterval = 6 * 3600) {
+        self.staleSyncThreshold = staleSyncThreshold
+        self.lowBatteryThreshold = lowBatteryThreshold
+        self.renotifyInterval = renotifyInterval
+    }
+
+    /// The conditions currently true, ignoring debounce.
+    /// - `lastSuccessfulSync == nil` is treated as "no baseline yet" (a brand-new user who has
+    ///   never synced is NOT nagged) — staleness only fires relative to a prior success.
+    /// - `batteryPercent == nil` (e.g. the background session is torn down) skips the battery
+    ///   check rather than firing a false low-battery alert.
+    /// - `healthAuthLost` only fires when Health was authorized before (`healthEverAuthorized`)
+    ///   and is now off — so a user who simply never opted into Health isn't told it "broke".
+    public func activeConditions(now: Date,
+                                 lastSuccessfulSync: Date?,
+                                 batteryPercent: Int?,
+                                 healthAuthorized: Bool,
+                                 healthEverAuthorized: Bool) -> Set<SyncAlert> {
+        var conditions: Set<SyncAlert> = []
+        if let last = lastSuccessfulSync, now.timeIntervalSince(last) > staleSyncThreshold {
+            conditions.insert(.notSynced)
+        }
+        if let battery = batteryPercent, battery <= lowBatteryThreshold {
+            conditions.insert(.lowBattery)
+        }
+        if healthEverAuthorized && !healthAuthorized {
+            conditions.insert(.healthAuthLost)
+        }
+        return conditions
+    }
+
+    /// Which alerts to actually post now: an active condition whose last notification is older
+    /// than `renotifyInterval` (or never sent). Returned in a stable `SyncAlert.allCases` order.
+    public func alertsToFire(now: Date,
+                             lastSuccessfulSync: Date?,
+                             batteryPercent: Int?,
+                             healthAuthorized: Bool,
+                             healthEverAuthorized: Bool,
+                             lastFired: [SyncAlert: Date]) -> [SyncAlert] {
+        let active = activeConditions(now: now,
+                                      lastSuccessfulSync: lastSuccessfulSync,
+                                      batteryPercent: batteryPercent,
+                                      healthAuthorized: healthAuthorized,
+                                      healthEverAuthorized: healthEverAuthorized)
+        return SyncAlert.allCases.filter { alert in
+            guard active.contains(alert) else { return false }
+            if let fired = lastFired[alert], now.timeIntervalSince(fired) < renotifyInterval {
+                return false
+            }
+            return true
+        }
+    }
+}
+
+/// Append-and-cap helper for a fixed-size ring buffer (the background-task outcome log, #44).
+/// Trims from the FRONT so the newest `limit` entries survive. Pure so the app's JSON-in-
+/// UserDefaults log stays trivially testable.
+public enum BoundedLog {
+    public static func appendCapped<Element>(_ element: Element,
+                                             to list: [Element],
+                                             limit: Int) -> [Element] {
+        guard limit > 0 else { return [] }
+        var out = list
+        out.append(element)
+        if out.count > limit { out.removeFirst(out.count - limit) }
+        return out
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SyncObservabilityTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SyncObservabilityTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import OpenRingKit
+
+final class SyncObservabilityTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+    private let policy = SyncAlertPolicy(staleSyncThreshold: 6 * 3600,
+                                         lowBatteryThreshold: 15,
+                                         renotifyInterval: 6 * 3600)
+
+    // MARK: activeConditions
+
+    func testFreshSyncHealthyHasNoConditions() {
+        let active = policy.activeConditions(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-3600),  // 1h ago — fresh
+            batteryPercent: 80,
+            healthAuthorized: true,
+            healthEverAuthorized: true)
+        XCTAssertTrue(active.isEmpty)
+    }
+
+    func testNeverSyncedDoesNotFireStaleness() {
+        // No baseline yet — a brand-new user is not nagged about staleness.
+        let active = policy.activeConditions(
+            now: now, lastSuccessfulSync: nil, batteryPercent: 80,
+            healthAuthorized: true, healthEverAuthorized: true)
+        XCTAssertFalse(active.contains(.notSynced))
+    }
+
+    func testStaleSyncFires() {
+        let active = policy.activeConditions(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),  // 7h ago > 6h
+            batteryPercent: 80,
+            healthAuthorized: true, healthEverAuthorized: true)
+        XCTAssertTrue(active.contains(.notSynced))
+    }
+
+    func testLowBatteryFiresAtThresholdAndNotAbove() {
+        XCTAssertTrue(policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: 15,
+            healthAuthorized: true, healthEverAuthorized: true).contains(.lowBattery))
+        XCTAssertFalse(policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: 16,
+            healthAuthorized: true, healthEverAuthorized: true).contains(.lowBattery))
+    }
+
+    func testNilBatterySkipsBatteryCheck() {
+        let active = policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: nil,
+            healthAuthorized: true, healthEverAuthorized: true)
+        XCTAssertFalse(active.contains(.lowBattery))
+    }
+
+    func testHealthAuthLostOnlyWhenPreviouslyAuthorized() {
+        // Never authorized → not an "auth lost" condition.
+        XCTAssertFalse(policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: 80,
+            healthAuthorized: false, healthEverAuthorized: false).contains(.healthAuthLost))
+        // Was authorized, now off → fires.
+        XCTAssertTrue(policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: 80,
+            healthAuthorized: false, healthEverAuthorized: true).contains(.healthAuthLost))
+    }
+
+    // MARK: alertsToFire (debounce)
+
+    func testAlertFiresWhenNeverFiredBefore() {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),
+            batteryPercent: 80, healthAuthorized: true, healthEverAuthorized: true,
+            lastFired: [:])
+        XCTAssertEqual(fire, [.notSynced])
+    }
+
+    func testAlertSuppressedInsideRenotifyWindow() {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),
+            batteryPercent: 80, healthAuthorized: true, healthEverAuthorized: true,
+            lastFired: [.notSynced: now.addingTimeInterval(-3600)])  // fired 1h ago < 6h window
+        XCTAssertTrue(fire.isEmpty)
+    }
+
+    func testAlertReFiresAfterRenotifyWindow() {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),
+            batteryPercent: 80, healthAuthorized: true, healthEverAuthorized: true,
+            lastFired: [.notSynced: now.addingTimeInterval(-7 * 3600)])  // fired 7h ago > 6h window
+        XCTAssertEqual(fire, [.notSynced])
+    }
+
+    func testMultipleConditionsReturnedInStableOrder() {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),  // notSynced
+            batteryPercent: 5,                                      // lowBattery
+            healthAuthorized: false, healthEverAuthorized: true,    // healthAuthLost
+            lastFired: [:])
+        XCTAssertEqual(fire, [.notSynced, .lowBattery, .healthAuthLost])
+    }
+
+    // MARK: BoundedLog
+
+    func testBoundedLogAppendsUnderLimit() {
+        let out = BoundedLog.appendCapped(3, to: [1, 2], limit: 5)
+        XCTAssertEqual(out, [1, 2, 3])
+    }
+
+    func testBoundedLogTrimsOldestOverLimit() {
+        let out = BoundedLog.appendCapped(4, to: [1, 2, 3], limit: 3)
+        XCTAssertEqual(out, [2, 3, 4])  // newest survive, oldest (1) dropped
+    }
+
+    func testBoundedLogZeroLimitIsEmpty() {
+        XCTAssertEqual(BoundedLog.appendCapped(1, to: [1, 2], limit: 0), [])
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -27,12 +27,17 @@ targets:
         NSHealthUpdateUsageDescription: "OpenRingConn writes your ring's metrics into Apple Health."
         # BLE (Phase 3) — required to connect to the ring.
         NSBluetoothAlwaysUsageDescription: "OpenRingConn connects to your RingConn ring over Bluetooth Low Energy."
-        # Background sync while suspended (docs/HANDOFF_MACOS_IOS.md).
+        # Background sync while suspended (docs/HANDOFF_MACOS_IOS.md). `processing` enables the
+        # BGProcessingTask (longer runtime) so the optical-HR poll can clear its ~60 s warm-up in
+        # the background (#45/#50 follow-up). iOS still runs it at its discretion, so this is
+        # best-effort — not a guarantee of daytime background HR.
         UIBackgroundModes:
           - bluetooth-central
           - fetch
+          - processing
         BGTaskSchedulerPermittedIdentifiers:
           - com.dreamality.openringconn.bgrefresh
+          - com.dreamality.openringconn.bgprocessing
     # HealthKit entitlement enabled (2026-06-15) — signed under the paid Dreamality team
     # (DEVELOPMENT_TEAM below). The App ID com.dreamality.openringconn carries the HealthKit
     # capability in that account; automatic signing registers it on first build.


### PR DESCRIPTION
## Lane G — Observability/alerting (#44) + BGProcessingTask background-HR completion (#45)

Builds on the already-merged Wave 1 lanes (A/B/C/E/D) on `phase3-ios` and stays strictly in its lane — no touches to RingSession/RingScanner internals, OpenRingKit analytics, HealthKitWriter internals (one added `recordHealthWrite` call site), LocalStore step internals, or SyncCursor.

### #44 — Observability / silent-failure alerting (Closes #44)
As an always-on tracker the app can fail silently (iOS throttling background entirely, a revoked Health grant, a ring left off the charger). This lane surfaces that:
- **Last-sync / last-write surfacing** + a background-task **outcome log** (`ActivityLogView`, reachable via a `NavigationLink` inside `ContentView`'s `NavigationStack`).
- **Pure alert policy** in OpenRingKit (`SyncObservability.swift`): staleness (`notSynced`, >6h since last success), `lowBattery` (≤15%), and `healthAuthLost` — each with per-condition debounce (6h `renotifyInterval`) and a bounded ring-buffer helper (`BoundedLog`, trims from the front). Fully unit-tested on the CLI with no Apple frameworks (13 new `SyncObservabilityTests`).
- **Honest semantics**: a never-synced user is not nagged (staleness fires only relative to a prior success); `batteryPercent == nil` skips the battery check (no false low-battery after background teardown); `healthAuthLost` is latched behind an "ever authorized" flag and uses the reliable SHARE `authorizationStatus`, so no false auth-lost alerts.
- Glue (`ObservabilityStore.swift`): UserDefaults epoch-double persistence with a `0 → nil` guard, plus lazy/provisional notification authorization (no launch prompt; quiet delivery; only requested when there is something to post).

### #45 — BGProcessingTask for background HR (partial, in-lane)
- Adds the longer-window `BGProcessingTask` budget (identifier `com.dreamality.openringconn.bgprocessing`) registered in `didFinishLaunchingWithOptions` before `return true`, plus the `processing` `UIBackgroundMode`. Identifier matches exactly across Info.plist `BGTaskSchedulerPermittedIdentifiers`, `project.yml`, `BackgroundRefreshScheduler.processingIdentifier`, and the AppDelegate registration.
- `RingBackgroundSyncService` change is additive (one const + one `recordHealthWrite` call); drain/decode untouched.
- The on-demand re-arm / warm-up UI for #45 lives in the already-merged Lane E; this lane contributes the longer-window budget. **Honesty preserved**: every comment and `ActivityLogView` state that background HR runs at iOS's discretion (usually overnight on the charger) and daytime background HR is best-effort, NOT guaranteed. No guaranteed-HR claim anywhere.

### Verification
- `cd ios/OpenRingKit && swift build && swift test` → **111 tests, 0 failures** (13 new, non-vacuous: battery threshold boundary 15-fires/16-doesn't, never-synced suppression, debounce inside/outside renotify window, stable `allCases` ordering, bounded-log trim-from-front + zero-limit).
- All changed app `.swift` files parse clean via `swiftc -parse -target arm64-apple-ios17.0` (only the expected cross-module `No such module OpenRingKit` suppressed).
- On-device HR-lock verification and the xcodegen regenerate + real device build are the orchestrator's gate.

### Adversarial peer review
Verdict: **approve**, `mustFix: []`. No fabricated protocol values or BLE bytes — `SyncObservability.swift` is pure policy (thresholds/debounce/ring-buffer); the only constants are product thresholds and BGTask budgets, none presented as decoded protocol facts. `shouldConsider` items (time-triggered while-closed notification; tightening `lastSuccessfulSync` to require ring frames; a single-writer lock on the JSON log; while-closed low-battery; xcodegen plist regeneration) were reviewed and intentionally deferred as non-blocking per the approve verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
