### PR TITLE
Battery freshness indicator + honest connectivity/charging copy (#57, #60)

### DIFF
--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -73,6 +73,56 @@ final class RingSession: NSObject {
     /// UI can show a subtle "auto-updating" cue instead of reading as a user measurement.
     private(set) var autoMeasuring = false
 
+    // MARK: Battery freshness (#57)
+    //
+    // Battery % is updated ONLY on 0x10/0x87 descriptor frames (DeviceStatus.battery), which
+    // are solicited by the keepalive every 60–300 s. Using the global `lastFrameAt` (refreshed
+    // on every frame, including 2-s live-HR polls) would let the battery show as "live" for up
+    // to 6 minutes (idleStaleAfter) even though the reading is tens of minutes old during a long
+    // monitoring session. A dedicated per-read timestamp + a tighter 120 s window catches a
+    // silently stale reading after roughly 2 night-keepalive intervals.
+
+    /// Wall-clock of the most recent 0x10/0x87 frame that carried a valid battery % (#57).
+    /// Separate from `lastFrameAt` (updated on every frame) — battery freshness is independent
+    /// of live-HR polling.
+    private(set) var batteryFetchedAt: Date?
+
+    /// True when the last battery reading is old enough to display as stale — i.e. no
+    /// 0x10/0x87 descriptor arrived recently (#57). Tighter than `liveReadingsStale`
+    /// (idleStaleAfter 360 s), which covers all readings. Shows "as of Xm ago" in the
+    /// connection-header battery after `batteryStaleAfter` seconds of silence.
+    var batteryStale: Bool {
+        guard batteryPercent != nil else { return false }   // nothing to call stale yet
+        guard let at = batteryFetchedAt else { return false }
+        return Date().timeIntervalSince(at) > Self.batteryStaleAfter
+    }
+    /// ~2× the tightest keepalive interval (night: 60 s). Battery shows "as of Nm ago" when
+    /// no descriptor has arrived in this window. Daytime keepalive (180–300 s) means the battery
+    /// will accurately report as stale between keepalive firings — that IS correct, the reading
+    /// IS a few minutes old.
+    private static let batteryStaleAfter: TimeInterval = 120
+
+    // MARK: Charging inference (#60)
+    //
+    // The ring's charging byte is NOT on the wire in any confirmed field (PROTOCOL.md §5).
+    // A strictly rising battery % across consecutive 0x10/0x87 frames is the best 🟢 proxy.
+    // This window is private; `inferredCharging` is computed from it via the kit's pure function.
+    // The inference is persisted before session teardown (see `invalidate`) so the connection
+    // card can surface a hint during the reconnect backoff when session == nil.
+
+    /// Rolling battery % readings (oldest→newest, capped) for charging inference (#60).
+    private var batteryTrend: [Int] = []
+    private static let batteryTrendCapacity = 4
+
+    /// True when the last few battery readings are strictly rising — suggesting the ring may
+    /// be charging (🟢 proxy). The UI labels this "inferred" to avoid asserting certainty.
+    /// Never derived from the reconnect count (#60).
+    var inferredCharging: Bool { ChargingInference.inferred(from: batteryTrend) }
+
+    /// UserDefaults key for the last-persisted charging inference (#60). Written before session
+    /// teardown so ContentView can read it during the reconnect-backoff window (session == nil).
+    private static let inferredChargingKey = "battery.inferredCharging"
+
     /// True when frames have stopped for long enough that the live readings (HR/SpO₂/battery/
     /// steps/temp) should read as STALE rather than current (#36). A silently-dropped link keeps
     /// its last values until CoreBluetooth eventually fires `didDisconnect`; this lets the UI
@@ -171,6 +221,10 @@ final class RingSession: NSObject {
     /// reading via `stopLiveMonitoring()` BEFORE this where that matters; `invalidate()` itself is
     /// a pure cancel + detach. Idempotent.
     func invalidate() {
+        // Persist the charging inference BEFORE cancelling tasks (#60): the session is about
+        // to be nil-ed by the scanner; ContentView reads from UserDefaults during the
+        // reconnect-backoff window so the hint stays live while reconnecting.
+        UserDefaults.standard.set(inferredCharging, forKey: Self.inferredChargingKey)
         monitorTask?.cancel(); monitorTask = nil
         keepaliveTask?.cancel(); keepaliveTask = nil
         autoMeasureTask?.cancel(); autoMeasureTask = nil
@@ -831,7 +885,18 @@ extension RingSession: CBPeripheralDelegate {
                 }
             }
             // Ring battery % is descriptor byte[1] (§5.4 🟢, ground-truthed).
-            if let b = DeviceStatus.battery(bytes) { self.batteryPercent = b }
+            // Also stamps `batteryFetchedAt` (#57) and extends the charging-inference trend (#60).
+            if let b = DeviceStatus.battery(bytes) {
+                self.batteryPercent = b
+                self.batteryFetchedAt = Date()   // dedicated freshness anchor (#57)
+                // Charging inference: rolling window of distinct readings (#60).
+                if self.batteryTrend.last != b {
+                    self.batteryTrend.append(b)
+                    if self.batteryTrend.count > Self.batteryTrendCapacity {
+                        self.batteryTrend.removeFirst()
+                    }
+                }
+            }
             // Bulk history pages: accumulate + ack to continue draining (47→c7, 4c→cc).
             switch bytes.first {
             case 0x47:

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -188,10 +188,13 @@ struct ContentView: View {
                 }
                 Spacer()
                 // Ring battery (a device stat, not a body vital) sits with the connection. When
-                // the link has gone quiet (no frames), gray it and show "as of Xm ago" so a
-                // minutes-old % from a silently-dropped link doesn't read as current (#36).
+                // no 0x10/0x87 descriptor has arrived recently, gray it and show "as of Xm ago"
+                // so a minutes-old % doesn't read as current (#36 / #57). Uses the dedicated
+                // battery-freshness window (batteryStale, ~120 s) rather than the broader
+                // liveReadingsStale (360 s) — battery updates only on descriptor frames, not
+                // the 2-s live-HR polls that keep liveReadingsStale fresh during monitoring.
                 if let b = session?.batteryPercent {
-                    let stale = session?.liveReadingsStale == true
+                    let stale = session?.batteryStale == true   // (#57) dedicated battery freshness
                     VStack(alignment: .trailing, spacing: 0) {
                         Label("\(b)%", systemImage: batteryIcon(b))
                             .font(.subheadline.weight(.medium))
@@ -247,10 +250,12 @@ struct ContentView: View {
         return "Measuring HR…"
     }
 
-    /// "as of Xm ago" for the connection-header battery, shown only once the link has gone quiet
-    /// (#36) — a dropped link can otherwise show a minutes-old battery % as if it were current.
+    /// "as of Xm ago" for the connection-header battery, shown once the battery reading goes
+    /// stale (#36 / #57). Anchored to `batteryFetchedAt` (the last 0x10/0x87 descriptor that
+    /// carried a valid %) rather than `lastFrameAt` (any frame), so a 2-s HR poll doesn't
+    /// keep the timestamp artificially fresh while the actual battery reading is minutes old.
     private var batteryAsOf: String? {
-        guard session?.liveReadingsStale == true, let at = session?.lastFrameAt else { return nil }
+        guard session?.batteryStale == true, let at = session?.batteryFetchedAt else { return nil }
         return "as of " + Self.rel.localizedString(for: at, relativeTo: Date())
     }
 
@@ -512,14 +517,24 @@ struct ContentView: View {
         case .unauthorized: return "Bluetooth not authorized"
         case .scanning: return "Scanning…"
         case .connecting(let n):
-            // After repeated failed reconnects (e.g. the ring is on the charger / out of range),
-            // swap the permanent "Connecting…" for a calm note so normal charging doesn't read as
-            // a stuck connection (#35). Heuristic on elapsed attempts — not a charging byte (#41).
-            return scanner.reconnectStalled
-                ? "Ring unreachable or charging — will reconnect automatically"
-                : "Connecting to \(n)…"
+            // After repeated failed reconnects, swap the permanent "Connecting…" for a calm note
+            // (#35). The backoff count is NOT a charging signal — we never claim the ring is
+            // charging from the reconnect count (#41 / #60). "Ring unreachable" is the honest state.
+            // If the last session's battery trend was strictly rising (🟢 proxy), append an honest
+            // "inferred charging" hint — labeled so to avoid overstating certainty (#60).
+            if scanner.reconnectStalled {
+                let chargingHint = lastInferredCharging ? " · inferred charging" : ""
+                return "Ring unreachable\(chargingHint) — reconnecting automatically"
+            }
+            return "Connecting to \(n)…"
         case .connected(let n): return n
         }
+    }
+
+    /// The charging inference from the last session, persisted to UserDefaults before session
+    /// teardown (#60). Readable during the reconnect-backoff window when session == nil.
+    private var lastInferredCharging: Bool {
+        UserDefaults.standard.bool(forKey: "battery.inferredCharging")
     }
 }
 

--- a/ios/OpenRingKit/Sources/OpenRingKit/ChargingInference.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/ChargingInference.swift
@@ -1,0 +1,30 @@
+// Charging-state inference from the battery % trend (#60).
+//
+// The ring's charging state is NOT on the wire in any confirmed byte (PROTOCOL.md §5).
+// The closest 🟢 proxy is the battery % in the 0x10/0x87 descriptor: if a short window of
+// consecutive readings is strictly rising the ring is *inferred* to be charging. This is
+// deliberately conservative — "inferred" only fires when we hold ≥ 2 readings that are ALL
+// strictly rising; a single-reading window or any non-monotone pattern returns false.
+//
+// Rule: never claim CERTAINTY from this signal. Callers label the result "inferred".
+
+import Foundation
+
+public enum ChargingInference {
+
+    /// True when `trend` is a strictly rising sequence — every consecutive pair increases —
+    /// suggesting the ring may be charging (🟢 proxy). Requires ≥ 2 readings.
+    ///
+    /// Examples:
+    ///   - []          → false  (no data)
+    ///   - [75]        → false  (single reading)
+    ///   - [74, 76]    → true   (two rising readings)
+    ///   - [74, 76, 78]→ true   (three rising readings)
+    ///   - [75, 75]    → false  (flat — discharging or noise)
+    ///   - [80, 78]    → false  (falling — discharging)
+    ///   - [74, 76, 75]→ false  (not all rising)
+    public static func inferred(from trend: [Int]) -> Bool {
+        guard trend.count >= 2 else { return false }
+        return zip(trend, trend.dropFirst()).allSatisfy { $0 < $1 }
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/ChargingInferenceTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/ChargingInferenceTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import OpenRingKit
+
+// Charging inference from battery % trend (#60): fires only on a strictly rising
+// sequence of ≥ 2 readings; any flat, falling, or mixed pattern returns false.
+final class ChargingInferenceTests: XCTestCase {
+
+    // MARK: Degenerate inputs
+
+    func testEmptyTrendReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: []))
+    }
+
+    func testSingleReadingReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [75]))
+    }
+
+    // MARK: Rising (charging)
+
+    func testTwoRisingReadingsReturnsTrue() {
+        XCTAssertTrue(ChargingInference.inferred(from: [74, 76]))
+    }
+
+    func testThreeRisingReadingsReturnsTrue() {
+        XCTAssertTrue(ChargingInference.inferred(from: [74, 76, 78]))
+    }
+
+    func testFourRisingReadingsReturnsTrue() {
+        XCTAssertTrue(ChargingInference.inferred(from: [60, 65, 70, 75]))
+    }
+
+    func testRisingByOneReturnsTrueEachPair() {
+        // Single-unit increments still count as rising.
+        XCTAssertTrue(ChargingInference.inferred(from: [80, 81, 82]))
+    }
+
+    // MARK: Non-rising (not charging)
+
+    func testFlatTwoReadingsReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [75, 75]))
+    }
+
+    func testFlatThreeReadingsReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [75, 75, 75]))
+    }
+
+    func testFallingTwoReadingsReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [80, 78]))
+    }
+
+    func testFallingThreeReadingsReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [80, 78, 76]))
+    }
+
+    // MARK: Mixed (one pair not rising → whole sequence fails)
+
+    func testMixedRisingThenFlatReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [74, 76, 76]))
+    }
+
+    func testMixedRisingThenFallingReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [74, 76, 75]))
+    }
+
+    func testMixedFlatThenRisingReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [74, 74, 76]))
+    }
+}


### PR DESCRIPTION
## Summary

- **#57 Battery freshness**: The battery % in the connection header now has its own dedicated freshness window (120 s, ~2× the night keepalive interval) tracked by a new `batteryFetchedAt` timestamp. Previously the battery used `liveReadingsStale` / `lastFrameAt`, which refreshes on every frame — including 2-s live-HR polls — so a battery reading from 5 minutes ago could silently display as "current" during a long monitoring session. `batteryStale` drives the grey-out and "as of Xm ago" label; `batteryFetchedAt` provides the accurate reference timestamp. The battery decode in `DeviceStatus` (🟢 byte[1]) is unchanged.

- **#60 Honest connectivity copy**: "Ring unreachable or charging — will reconnect automatically" asserted charging from the reconnect count alone, which `ReconnectBackoff.swift` explicitly calls out as NOT a charging signal. The new text is "Ring unreachable — reconnecting automatically". An optional honest suffix "· inferred charging" is appended only when the last session's battery % trend was strictly rising (🟢 proxy: rising % across 0x10/0x87 descriptors → ring may be charging). This inference is computed by the new pure kit function `ChargingInference.inferred(from:)`, persisted to `UserDefaults` in `RingSession.invalidate()` (so it's readable during the reconnect-backoff window when session == nil), and labeled "inferred" throughout to avoid overstating certainty from an unconfirmed protocol field.

Closes #57
Closes #60

## Kit build / test results

```
swift build: Build complete! (3.73s)
swift test:  Executed 134 tests, with 0 failures (0 unexpected)
             (includes 13 new ChargingInferenceTests)
```

## New tests added

`ios/OpenRingKit/Tests/OpenRingKitTests/ChargingInferenceTests.swift` — 13 cases covering:
- empty / single-reading edge cases (both false)
- strictly rising 2-, 3-, 4-reading windows (true)
- flat, falling, and mixed (non-all-rising) windows (false)

## On-device verification needed

- **Battery grey-out timing**: after connecting and receiving a battery reading, wait 2+ minutes without triggering a manual action — battery % should grey out and show "as of Nm ago". Reconnecting should clear it within one keepalive cycle.
- **Honest status text**: disconnect from the ring (or simulate ring-out-of-range) and wait for 3+ reconnect backoff cycles — verify the status says "Ring unreachable — reconnecting automatically" (no "charging" assertion).
- **Inferred charging hint**: with the ring on the charger (battery rising), disconnect/reconnect after ≥ 2 descriptor reads — verify "· inferred charging" appears in the reconnect status. With a discharging ring, verify the hint does NOT appear.
- **`liveReadingsStale` unaffected**: HR/SpO₂/steps/temp staleness behavior should be unchanged (30 s monitoring / 360 s idle thresholds still apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
