### PR TITLE
Wear-aware measurement + sleep wear-gate + "ring not worn" state (#56, #41)

### DIFF
--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -73,6 +73,35 @@ final class RingSession: NSObject {
     /// UI can show a subtle "auto-updating" cue instead of reading as a user measurement.
     private(set) var autoMeasuring = false
 
+    // MARK: Wear gate / not-worn proxy (#56, #41)
+    //
+    // `appearsNotWorn` is true when the ring reads as OFF-WRIST / ON THE CHARGER, inferred from
+    // PROVEN proxies only — periodic auto-measures that never lock (🟢) plus, when available, a
+    // cold raw skin-temp reading (🟡, AutoMeasureGate). NO charging-flag byte is consulted (that
+    // descriptor field is undecoded — #61). It gates only the AUTOMATIC HR/SpO₂ refresh (which on
+    // the charger just times out and drains battery, #56) and a small UI hint; manual Measure /
+    // Sync are never blocked by it. Reset per connection (a new RingSession each connect).
+    private(set) var appearsNotWorn = false
+    /// Consecutive periodic auto-measure cycles that never locked a reading — the 🟢 not-worn
+    /// signal. Reset to 0 on a lock (or cleared by a warm skin-temp reading).
+    private var consecutiveAutoMeasureNoLock = 0
+    /// Most recent RAW skin temp (°C) from the 0x10/0x87 descriptor, updated on EVERY temp frame
+    /// regardless of the night-window / worn persistence gates below — the 🟡 wear proxy. nil
+    /// until the first valid reading.
+    private var lastRawSkinTempC: Double?
+    /// In-memory log of the night's RAW skin-temp readings (worn AND cold), independent of the
+    /// worn-only persistence gate — the ONLY source of the cold readings the sleep wear-gate
+    /// (#41) needs to reclassify a charging block out of sleep (the store keeps worn temps only).
+    /// Bounded rolling buffer; consumed by `wearTemperatureSamples()`.
+    private var nightTemperatureLog: [TemperatureSample] = []
+    private static let nightTemperatureLogCap = 2000
+    /// Cap on the not-worn auto-measure backoff: a ring left on the charger is re-probed at most
+    /// this rarely, but never abandoned — a lock (or warm temp) resumes the base cadence (#56).
+    private static let autoMeasureMaxBackoff: TimeInterval = 2 * 3600
+    /// Cheap re-check cadence while SKIPPING the probe on a confirmed-cold (not-worn) ring: short,
+    /// since it costs no live-enter, so re-wear (temp warming) resumes measurement promptly (#56).
+    private static let autoMeasureColdRecheck: TimeInterval = 180
+
     /// True when frames have stopped for long enough that the live readings (HR/SpO₂/battery/
     /// steps/temp) should read as STALE rather than current (#36). A silently-dropped link keeps
     /// its last values until CoreBluetooth eventually fires `didDisconnect`; this lets the UI
@@ -264,7 +293,8 @@ final class RingSession: NSObject {
             // discards delivered pages, so this is the only chance to keep them.
             if let self, !self.bulkRecords.isEmpty {
                 self.historySamples = BulkSleep.samples(from: self.bulkRecords)
-                self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords)
+                self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords,
+                                                             temperatures: self.wearTemperatureSamples())   // wear gate (#41)
                 self.stagedSegments = BulkSleep.stagedSegments(from: self.bulkRecords)
                 self.persist(self.historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
                 self.persistSleepAndSteps()          // sleep summary + steps for offline display
@@ -391,21 +421,29 @@ final class RingSession: NSObject {
             try? await Task.sleep(for: .seconds(Self.autoMeasureFirstDelay))
             while !Task.isCancelled {
                 guard let self else { return }
-                if Self.autoMeasureEnabled, self.idleForAutoMeasure {
+                if Self.autoMeasureEnabled, self.idleForAutoMeasure, !self.skipAutoMeasureProbe {
                     // Refresh BOTH every cycle — HR locks in seconds when still; SpO₂ rides
                     // the same live path. (Was SpO₂ every 3rd cycle, but relaunches reset that
                     // counter so it rarely fired.) Each is bounded, so a moving hand just times
-                    // out that read rather than blocking the loop.
-                    await self.autoMeasureOnce(mode: .hr, timeout: 90)   // HR can need ~60s of stillness
-                    if self.idleForAutoMeasure {
-                        await self.autoMeasureOnce(mode: .spo2, timeout: 45)
+                    // out that read rather than blocking the loop. The HR result feeds the
+                    // not-worn inference (#56); a user takeover (nil) is not counted.
+                    if let hrLocked = await self.autoMeasureOnce(mode: .hr, timeout: 90) {   // HR can need ~60s of stillness
+                        self.noteAutoMeasureCycle(locked: hrLocked)
                     }
-                    try? await Task.sleep(for: .seconds(Self.autoMeasureInterval))
+                    // Skip SpO₂ if the HR miss above just flipped us to not-worn-with-cold-temp —
+                    // no point spending another live-enter we expect to time out (#56).
+                    if self.idleForAutoMeasure, !self.skipAutoMeasureProbe {
+                        _ = await self.autoMeasureOnce(mode: .spo2, timeout: 45)
+                    }
+                    // Cadence backs off once the ring is inferred not-worn (#56); a lock above
+                    // already reset it to the base interval.
+                    try? await Task.sleep(for: .seconds(self.nextAutoMeasureInterval))
                 } else {
-                    // Disabled, or busy with a user measure / sync — re-check soon rather than
-                    // deferring a full interval (a one-off open-sync shouldn't push the first
-                    // HR out by 10 min).
-                    try? await Task.sleep(for: .seconds(30))
+                    // Disabled, busy with a user measure / sync, or inferred not-worn with a cold
+                    // skin temp (#56) — re-check soon rather than deferring a full interval. A
+                    // not-worn ring is re-checked cheaply (no live-enter) until its temp warms;
+                    // a one-off open-sync shouldn't push the first HR out by 10 min.
+                    try? await Task.sleep(for: .seconds(self.skipAutoMeasureProbe ? Self.autoMeasureColdRecheck : 30))
                 }
             }
         }
@@ -417,25 +455,72 @@ final class RingSession: NSObject {
         ready && !monitoring && !livePreparing && syncTask == nil
     }
 
+    /// Next sleep between auto-measure cycles: the base interval while worn, exponentially backed
+    /// off once the ring is inferred not-worn (#56). Pure policy lives in `AutoMeasureGate`.
+    private var nextAutoMeasureInterval: TimeInterval {
+        AutoMeasureGate.interval(base: Self.autoMeasureInterval,
+                                 cap: Self.autoMeasureMaxBackoff,
+                                 consecutiveNoLock: consecutiveAutoMeasureNoLock,
+                                 rawSkinTempC: lastRawSkinTempC)
+    }
+
+    /// Skip the live-enter probe entirely this cycle (#56): we've inferred not-worn AND the raw
+    /// skin temp still reads cold, so a probe would only time out and burn battery. Requires a
+    /// COLD reading (positive evidence) — a missing temp falls back to probing so a sensor gap
+    /// can't silently stop measuring. Re-wear is caught when the temp warms (the keepalive keeps
+    /// it fresh), which clears `appearsNotWorn`.
+    private var skipAutoMeasureProbe: Bool {
+        appearsNotWorn && (lastRawSkinTempC.map { $0 < ActivityPeriod.wornMinTemperatureC } ?? false)
+    }
+
+    /// Fold one finished auto-measure cycle into the not-worn inference (#56): a lock proves the
+    /// ring is worn (reset the miss count); a miss accrues toward the backoff. Recomputes the
+    /// published `appearsNotWorn`.
+    private func noteAutoMeasureCycle(locked: Bool) {
+        consecutiveAutoMeasureNoLock = locked ? 0 : consecutiveAutoMeasureNoLock + 1
+        refreshWornState()
+    }
+
+    /// Recompute the published not-worn flag from the current proxies (#56). Called after each
+    /// auto-measure cycle and whenever a fresh raw skin temp arrives. Guarded so `@Observable`
+    /// doesn't republish on every (unchanged) temp frame.
+    private func refreshWornState() {
+        let notWorn = AutoMeasureGate.appearsNotWorn(
+            consecutiveNoLock: consecutiveAutoMeasureNoLock,
+            rawSkinTempC: lastRawSkinTempC)
+        if notWorn != appearsNotWorn { appearsNotWorn = notWorn }
+    }
+
+    /// The night's skin-temp samples for the sleep wear-gate (#41): the in-memory log, the only
+    /// place cold/charging readings survive (the store keeps worn temps only). Empty ⇒ detection
+    /// falls back to motion alone (absence of data is not evidence of being unworn).
+    private func wearTemperatureSamples() -> [TemperatureSample] {
+        nightTemperatureLog
+    }
+
     /// One bounded auto-measurement: enter `mode`'s live read, wait for a converged value (or
     /// time out), then stop — which persists the reading and lets ContentView mirror it to
     /// Health. If the user takes over mid-read (monitoring an unexpected mode), we leave their
     /// session alone rather than cancelling it.
-    private func autoMeasureOnce(mode: LiveMode, timeout: TimeInterval) async {
-        guard idleForAutoMeasure else { return }
+    /// Returns whether the read LOCKED, or nil if the cycle was ABORTED by a user takeover — the
+    /// caller must not count an abort toward the not-worn inference (#56).
+    private func autoMeasureOnce(mode: LiveMode, timeout: TimeInterval) async -> Bool? {
+        guard idleForAutoMeasure else { return nil }
         autoMeasuring = true
         startMonitoring(mode: mode, userInitiated: false)   // auto refresh: prompt enter, keep last value until it locks
         let deadline = Date().addingTimeInterval(timeout)
+        var locked = false
         while !Task.isCancelled && Date() < deadline {
-            if mode == .hr, liveHR != nil { break }
-            if mode == .spo2, liveSpO2 != nil { break }
+            if mode == .hr, liveHR != nil { locked = true; break }
+            if mode == .spo2, liveSpO2 != nil { locked = true; break }
             // Bail if a user tap switched the mode out from under us — don't fight them.
-            if !monitoring || liveMode != mode { autoMeasuring = false; return }
+            if !monitoring || liveMode != mode { autoMeasuring = false; return nil }
             try? await Task.sleep(for: .seconds(1))
         }
         // Only tear down if WE still own the live read (user didn't take over).
         if autoMeasuring, monitoring, liveMode == mode { stopLiveMonitoring() }
         autoMeasuring = false
+        return locked
     }
 
     /// Resolve and cache the nightly sleep window used to gate skin-temp capture. Re-resolves
@@ -596,7 +681,8 @@ final class RingSession: NSObject {
         // No-op once the drain already committed (bulkFinalized) or nothing was captured.
         if !bulkRecords.isEmpty, !bulkFinalized {
             historySamples = BulkSleep.samples(from: bulkRecords)
-            sleepSegments = BulkSleep.sleepSegments(from: bulkRecords)
+            sleepSegments = BulkSleep.sleepSegments(from: bulkRecords,
+                                                    temperatures: wearTemperatureSamples())   // wear gate (#41)
             stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
             persist(historySamples)
             persistSleepAndSteps()
@@ -661,7 +747,8 @@ final class RingSession: NSObject {
     private func finalizeSync() {
         guard syncing else { return }
         historySamples = BulkSleep.samples(from: bulkRecords)
-        sleepSegments = BulkSleep.sleepSegments(from: bulkRecords)
+        sleepSegments = BulkSleep.sleepSegments(from: bulkRecords,
+                                                temperatures: wearTemperatureSamples())   // wear gate (#41)
         stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
         persist(historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
         persistSleepAndSteps()    // sleep summary + steps for offline display
@@ -812,6 +899,11 @@ extension RingSession: CBPeripheralDelegate {
             // (activity, ambient swings, intermittent skin contact) to be a usable trend, so we
             // drop them and surface no live value outside the window.
             if let t = DeviceStatus.skinTemperature(bytes) {
+                // Wear proxy (#56/#41): record the RAW reading BEFORE the night-window / worn
+                // gates below. A cold (off-wrist/charging) reading is exactly what the not-worn
+                // inference and the sleep wear-gate need, and neither survives those gates.
+                self.lastRawSkinTempC = t.celsius
+                self.refreshWornState()
                 // Window-miss guard: if we're outside the cached window (or it's nil), the cache
                 // may simply be stale/expired (night just started, or midnight rolled the window
                 // forward). Force a synchronous re-resolve BEFORE deciding to drop — this whole
@@ -825,8 +917,21 @@ extension RingSession: CBPeripheralDelegate {
                     Task { await self.refreshNightWindowIfNeeded() }   // background, don't block the frame
                 }
                 let inNightWindow = self.nightWindow?.contains(Date()) ?? false
-                self.liveTemperature = inNightWindow ? t.celsius : nil
+                let worn = t.celsius >= ActivityPeriod.wornMinTemperatureC
+                // Keep EVERY night reading (worn AND cold) in-memory for the sleep wear-gate's
+                // median test (#41) — the cold ones are what reclassify a charging block out of
+                // sleep. The store (below) keeps worn temps only, so this log is their sole home.
                 if inNightWindow {
+                    self.nightTemperatureLog.append(TemperatureSample(time: Date(), celsius: t.celsius))
+                    if self.nightTemperatureLog.count > Self.nightTemperatureLogCap {
+                        self.nightTemperatureLog.removeFirst(self.nightTemperatureLog.count - Self.nightTemperatureLogCap)
+                    }
+                }
+                // Persist / display ONLY a worn reading: a cold charging reading isn't a skin
+                // temperature, so it must not pollute the nightly average or reach Apple Health
+                // (#41). The cold reading still drives the wear proxies above.
+                self.liveTemperature = (inNightWindow && worn) ? t.celsius : nil
+                if inNightWindow, worn {
                     self.persist([QuantitySample(kind: .temperature, start: Date(), value: t.celsius)])
                 }
             }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -207,6 +207,14 @@ struct ContentView: View {
             // un-activated/un-bonded signature. Until the activate step is reverse-engineered, the
             // only fix is to open the official app once; say so instead of spinning forever.
             if connected, session?.notStreaming == true { activationHint }
+            // Connected + streaming, but the ring reads off-wrist / on the charger (#56) — surface
+            // it (estimated) instead of silently backing the auto-measure off. notStreaming takes
+            // precedence (an un-activated ring's wear state is meaningless), and we hide it during
+            // an active measurement so it can't contradict the "measuring" cue.
+            if connected, session?.notStreaming != true, session?.monitoring != true,
+               session?.appearsNotWorn == true {
+                notWornHint
+            }
             if !connected {
                 Button {
                     scanner.start()
@@ -233,6 +241,18 @@ struct ContentView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(10)
         .background(RoundedRectangle(cornerRadius: 10).fill(Color.orange.opacity(0.12)))
+    }
+
+    /// Shown when `RingSession.appearsNotWorn` — connected but the ring reads off-wrist / on the
+    /// charger (a proxy from auto-measures that never lock + a cold skin-temp reading, #56). Honest
+    /// that it's an estimate; manual Measure/Sync are never blocked by it.
+    private var notWornHint: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "pause.circle").foregroundStyle(.secondary)
+            Text("Ring looks off-wrist or charging (estimated) — auto-measure paused")
+                .font(.caption).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// A user (non-auto) HR measurement that's converging but hasn't locked yet (#45 C). The

--- a/ios/OpenRingKit/Sources/OpenRingKit/AutoMeasureGate.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/AutoMeasureGate.swift
@@ -1,0 +1,59 @@
+// Auto-measure wear gate (#56). The ring reports HR/SpO₂ only on demand, so the app
+// periodically enters a brief live read to refresh them (RingSession.startAutoMeasure). On
+// the charger / off the wrist the ring never locks a reading, so a fixed-cadence probe just
+// times out every ~10 min and drains both the ring and the phone. This infers "not worn"
+// from PROVEN proxies and backs the probe off exponentially, resuming the normal cadence the
+// instant a reading locks (or the skin temperature reads warm) again.
+//
+// Proxies, honest about confidence:
+//   • consecutive auto-measures that never lock a reading (🟢 — the absence of ANY lock over
+//     several attempts is strong evidence the ring isn't on a finger).
+//   • the raw skin-temperature descriptor (🟡 — a worn Gen-2 reads ≳28 °C; off-wrist it falls
+//     toward room ambient ~20–24 °C). Used only to ACCELERATE the inference and to clear it
+//     promptly on re-wear.
+// It deliberately consults NO charging-flag byte — that descriptor field is undecoded
+// (#61 / PROTOCOL.md §5.4 🔴), so we never CLAIM to know the ring is charging. Pure (no Apple
+// frameworks) so it unit-tests on the CLI, mirroring ReconnectBackoff / KeepaliveCadence.
+
+import Foundation
+
+public enum AutoMeasureGate {
+    /// Consecutive auto-measure cycles with no lock after which the ring is inferred NOT WORN
+    /// when there's no temperature signal to lean on (🟢 fallback). With a cold reading a
+    /// single miss already confirms it (see `appearsNotWorn`).
+    public static let notWornAfterFailures = 2
+
+    /// Hard ceiling on how many times the base interval is doubled while not worn (base ×2^n).
+    public static let maxBackoffDoublings = 4
+
+    /// Whether the ring appears NOT WORN, from the consecutive no-lock count and (optionally)
+    /// the most recent raw skin temperature:
+    ///   • a warm reading (≥ `wornMinC`) is direct evidence of wear → not-worn = false;
+    ///   • a cold reading needs only ONE failed lock to confirm not-worn (we never declare it
+    ///     on a cold reading alone — a worn-but-cool ring would have LOCKED that one probe);
+    ///   • with no temperature signal we fall back to `notWornAfterFailures` consecutive misses.
+    public static func appearsNotWorn(consecutiveNoLock: Int,
+                                      rawSkinTempC: Double? = nil,
+                                      wornMinC: Double = ActivityPeriod.wornMinTemperatureC) -> Bool {
+        if let t = rawSkinTempC {
+            if t >= wornMinC { return false }            // warm skin ⇒ worn (🟡, direct)
+            return consecutiveNoLock >= 1                 // cold + a missed lock ⇒ not worn
+        }
+        return consecutiveNoLock >= notWornAfterFailures  // no temp ⇒ 🟢 failed-lock fallback
+    }
+
+    /// Next interval between auto-measure cycles. While worn (or not yet inferred not-worn) this
+    /// is `base`; once not worn it doubles per additional consecutive miss, capped at both
+    /// `base × 2^maxBackoffDoublings` and `cap`. A lock (consecutiveNoLock → 0) or a warm
+    /// reading drops it straight back to `base`.
+    public static func interval(base: TimeInterval,
+                                cap: TimeInterval,
+                                consecutiveNoLock: Int,
+                                rawSkinTempC: Double? = nil,
+                                wornMinC: Double = ActivityPeriod.wornMinTemperatureC) -> TimeInterval {
+        guard appearsNotWorn(consecutiveNoLock: consecutiveNoLock,
+                             rawSkinTempC: rawSkinTempC, wornMinC: wornMinC) else { return base }
+        let doublings = min(max(consecutiveNoLock - 1, 0), maxBackoffDoublings)
+        return min(base * pow(2, Double(doublings)), cap)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/AutoMeasureGateTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/AutoMeasureGateTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import OpenRingKit
+
+// Auto-measure wear gate (#56): infers "not worn" from consecutive auto-measures that never
+// lock (🟢) plus an optional cold raw skin-temp reading (🟡), and backs the probe interval off
+// exponentially so a ring on the charger isn't probed every 10 min. Asserts the inference +
+// the backoff schedule so a regression (e.g. reverting to a fixed cadence) is caught. No
+// charging-flag byte is consulted (undecoded — #61).
+final class AutoMeasureGateTests: XCTestCase {
+
+    // MARK: not-worn inference
+
+    func testWornUntilThresholdWithoutTemperature() {
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 0))
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 1),
+                       "one transient miss (e.g. a moving hand) is not yet not-worn")
+        XCTAssertTrue(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 2))
+        XCTAssertTrue(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 9))
+    }
+
+    func testWarmSkinTempIsAlwaysWorn() {
+        // A warm reading is direct evidence of wear even after many missed locks.
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 9, rawSkinTempC: 32))
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 0, rawSkinTempC: 30))
+    }
+
+    func testColdSkinTempConfirmsNotWornAfterOneMiss() {
+        // Cold alone (no miss yet) is NOT enough — a worn-but-cool ring would have locked.
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 0, rawSkinTempC: 22),
+                       "cold reading with no failed lock is not conclusive")
+        XCTAssertTrue(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 1, rawSkinTempC: 22),
+                      "cold + a missed lock ⇒ not worn")
+    }
+
+    func testThresholdBoundaryMatchesWornMinTemperature() {
+        let worn = ActivityPeriod.wornMinTemperatureC   // 28 °C
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 1, rawSkinTempC: worn),
+                       "exactly at the worn threshold counts as worn")
+        XCTAssertTrue(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 1, rawSkinTempC: worn - 0.1))
+    }
+
+    // MARK: backoff schedule
+
+    private let base: TimeInterval = 600     // 10 min
+    private let cap: TimeInterval = 7200     // 2 h
+
+    func testIntervalStaysAtBaseWhileWorn() {
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 0), base)
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 1), base,
+                       "a single miss without temp evidence does not back off yet")
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 9, rawSkinTempC: 33),
+                       base, "warm skin ⇒ keep the normal cadence")
+    }
+
+    func testIntervalDoublesOnceNotWornThenCaps() {
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 2), 1200) // ×2
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 3), 2400) // ×4
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 4), 4800) // ×8
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 5), cap,  // ×16 → cap 7200
+                       "base ×16 = 9600 is clamped to the 2 h cap")
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 99), cap,
+                       "stays capped")
+    }
+
+    func testColdTempBacksOffFromTheFirstConfirmedMiss() {
+        // Cold + 1 miss is not-worn, but the first backed-off interval is still `base`
+        // (0 doublings) — it ramps from there.
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 1, rawSkinTempC: 21), base)
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 2, rawSkinTempC: 21), 1200)
+    }
+
+    func testIntervalIsMonotonicNonDecreasing() {
+        var prev = AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 0)
+        for n in 1...12 {
+            let v = AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: n)
+            XCTAssertGreaterThanOrEqual(v, prev)
+            prev = v
+        }
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
@@ -198,4 +198,54 @@ final class BulkSleepTests: XCTestCase {
         XCTAssertEqual(r.heartRate, 68, "but HR survives")
         XCTAssertEqual(r.hrvRMSSD, 77)
     }
+
+    // MARK: #41 — wear gate WIRED through BulkSleep.sleepSegments / mainSleep
+    //
+    // SleepDetection's temperature path is covered in SleepDetectionTests; these assert the
+    // `temperatures:` overload that RingSession actually calls threads that gate end-to-end, so
+    // a charging/off-wrist still night doesn't get committed (to the dashboard or Apple Health)
+    // as a night of sleep.
+
+    /// A synthetic night: 20 active epochs, ~9 h still (216 epochs), 20 active. One temperature
+    /// sample per epoch at `celsius`, spanning the records' real time range.
+    private func night() -> [BulkRecord] {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<20 { recs.append(rec(c, motion: 0x14, sub: 0x12)); c += 150 }
+        for _ in 0..<216 { recs.append(rec(c, motion: 0x01, sub: 0x62)); c += 150 }
+        for _ in 0..<20 { recs.append(rec(c, motion: 0x14, sub: 0x12)); c += 150 }
+        return recs
+    }
+    private func temps(for recs: [BulkRecord], celsius: Double) -> [TemperatureSample] {
+        recs.map { TemperatureSample(time: $0.date(), celsius: celsius) }
+    }
+
+    func testSleepSegmentsWearGateDropsColdNight() {
+        let recs = night()
+        // Motion-only (status quo): the still block reads as a night of sleep.
+        XCTAssertTrue(BulkSleep.sleepSegments(from: recs).contains { $0.stage == .inBed },
+                      "motion-only: still block reads as sleep")
+        // Worn (32 °C): still a night of sleep.
+        XCTAssertTrue(BulkSleep.sleepSegments(from: recs, temperatures: temps(for: recs, celsius: 32))
+                        .contains { $0.stage == .inBed },
+                      "worn temps keep the night")
+        // Cold (22 °C, off-wrist / charging): no sleep night survives the gate.
+        XCTAssertTrue(BulkSleep.sleepSegments(from: recs, temperatures: temps(for: recs, celsius: 22)).isEmpty,
+                      "cold (unworn) still block must not produce a sleep night")
+    }
+
+    func testMainSleepWearGateDropsColdNight() {
+        let recs = night()
+        XCTAssertNotNil(BulkSleep.mainSleep(from: recs, temperatures: temps(for: recs, celsius: 32)),
+                        "worn night has a main sleep block")
+        XCTAssertNil(BulkSleep.mainSleep(from: recs, temperatures: temps(for: recs, celsius: 22)),
+                     "cold night yields no main sleep block")
+    }
+
+    func testSleepSegmentsEmptyTemperaturesUnchanged() {
+        let recs = night()
+        XCTAssertEqual(BulkSleep.sleepSegments(from: recs, temperatures: []).count,
+                       BulkSleep.sleepSegments(from: recs).count,
+                       "no temp coverage ⇒ identical to motion-only (absence ≠ unworn)")
+    }
 }


### PR DESCRIPTION
## Summary

Make measurement **wear-aware**: stop the periodic auto-measure from entering live HR/SpO₂ on an off-wrist / charging ring (#56), and wire the existing-but-dead sleep wear gate so a cold, still ring on the nightstand no longer logs a night of "sleep" (#41). Uses **proven proxies only** — no charging byte (that descriptor field is undecoded; RE tracked in **#61**).

Closes #56
Addresses #41 (wear gate + not-worn UI; charging-byte RE tracked in #61)

## What changed

### Part A — wire the dead wear gate (#41)
The `BulkSleep.sleepSegments(from:temperatures:)` / `mainSleep(...temperatures:)` overloads already existed and were unit-tested, but **no production call site passed them** — every call used the no-arg overload, so a charging/cold ring's still epochs were still classified `.sleep`.
- Threaded the night's skin-temp samples into **all three** `sleepSegments` call sites in `RingSession` (live-enter drain, stop-time safety net, `finalizeSync`). Cold-still epochs now reclassify to `.active` via `SleepDetection.detectFromMotion`'s temperature path (`wornMinTemperatureC = 28`).
- Capture **every** night reading (worn **and** cold) in an in-memory `nightTemperatureLog` — the cold readings are the gate's evidence and (by design, below) don't survive the persistence gate.
- **Gate skin-temp persist + live display on worn** (`≥ wornMinTemperatureC`): a cold charging reading isn't a skin temperature, so it no longer pollutes the nightly average or reaches Apple Health.

> Honest limitation: the in-memory cold log is the source for the wear gate because persisted skin temp is now worn-only. So the gate is fully effective on the **live overnight capture** path (the keepalive holds the link and sees the cold readings live). A cross-session `finalizeSync` of a *past* charging night may lack cold-temp coverage → it then falls back to motion-only (which matches the kit's documented "absence of data ≠ unworn" semantics). No regression vs. today.

### Part B — auto-measure gate (#56)
`idleForAutoMeasure` had no worn/charging gate, so on the charger the ~10-min auto-measure entered live HR/SpO₂ every cycle and timed out, burning battery.
- New pure, unit-tested **`OpenRingKit.AutoMeasureGate`** (mirrors `ReconnectBackoff` / `KeepaliveCadence`): infers not-worn from **consecutive auto-measures that never lock** (🟢) plus an **optional cold raw skin-temp reading** (🟡), and backs the interval off exponentially (base 10 min → cap 2 h). A lock (or a warm temp) resets to the base cadence.
- `RingSession` reads the **raw descriptor temp independent of the night-window persistence gate** for the wear decision (as the scope suggested). When inferred not-worn **and** the temp reads cold, it **skips the live-enter entirely** and re-checks cheaply (no 90 s timeout), so re-wear (temp warming, kept fresh by the keepalive) resumes measurement promptly.
- `autoMeasureOnce` now returns `Bool?` (locked / aborted-by-user-takeover) so a user takeover is never miscounted toward not-worn.

### Part C — UI
- Minimal, honest indicator in `ContentView`'s connection card: **"Ring looks off-wrist or charging (estimated) — auto-measure paused"**, shown only when connected + streaming + idle + `appearsNotWorn`. `notStreaming` (#54) takes precedence; hidden during an active measurement.

New `@Observable` state on `RingSession` is grouped in a `// MARK: Wear gate / not-worn proxy (#56, #41)` block to ease later merges.

## Out of scope (untouched)
User manual-measure poll loop (#55), battery freshness, `statusText` charging copy (#57/#60), empty states, SpO₂ caveat, and the charging-byte RE (#61).

## Kit build / test
- `cd ios/OpenRingKit && swift build` → **Build complete**
- `swift test` → **132 tests, 0 failures** (includes **+8** `AutoMeasureGateTests` and **+3** `BulkSleepTests` wear-gate cases covering the wired `temperatures:` path).
- App target: `xcodebuild -scheme OpenRingConn -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**, **0 warnings** on the changed files.

## Needs on-device verification
- On the **charger**: confirm the auto-measure stops re-entering live mode and the connection card shows the not-worn note; verify the exponential backoff/skip behaves (logs: `com.dreamality.openringconn`).
- **Re-wear**: put the ring on → the skin temp warms → the note clears and auto-measure resumes within a cycle.
- **Worn night**: a normal night still logs sleep + writes skin temp to Health; **charging night**: no bogus "sleep" night and no cold skin-temp samples reach Health.
- The skin-temp **wear threshold (28 °C, 🟡)** is a heuristic — sanity-check it against a real worn vs. charging capture; a worn-but-cool finger near the boundary could read as not-worn (only suppresses *auto* refresh — manual Measure/Sync are never blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
