### PR TITLE
Wave 1: APK gap-analysis backlog — 18 features (sleep/vitals/activity/workouts/women's health/device)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Health** — no cloud, no subscription.
 | `desktop/openringconn/` | RE workbench: scan/enumerate/listen/replay/decode-log/guess-checksum |
 | `docs/PROTOCOL.md` | Living protocol spec (the Phase 1 deliverable) |
 | `docs/REVERSE_ENGINEERING.md` | Capture + decode workflow |
+| `docs/RUNBOOK_OVERNIGHT_TEMP.md` | **Overnight capture for skin temp / sleep stages / HRV (#7,#9,#12)** |
 | `docs/HEALTHKIT_MAPPING.md` | Each metric → HealthKit type |
 | `docs/HANDOFF_MACOS_IOS.md` | **Pickup instructions for the iOS work on macOS** |
 | `docs/ROADMAP.md` | Phases + risks |

--- a/desktop/analyze_0x81.py
+++ b/desktop/analyze_0x81.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Issue #4: is `81 00 <XX> <xor>` byte[2] a session token or battery %?
+
+For every decoded capture given on argv (or a default set), find:
+  - every `81 00 XX YY` notification (response to `01 00 00`) and its byte[2],
+  - the surrounding session boundary (each new connection / status handshake),
+  - the battery % from any `0x10`/`0x87`/`0x4c` descriptor byte[1] in the SAME
+    capture, so byte[2] can be cross-checked against a known battery level.
+
+Within a single session the FIRST `01 00 00` is the cold status read; the app may
+issue more `01 00 00` later. We report byte[2] per occurrence AND per session so
+"constant within a session" can be judged.
+
+Battery cross-check: PROTOCOL.md §5.4 says `0x10`/`0x87` byte[1] = battery %.
+We pull those too and report the battery seen in each capture.
+
+Usage: python analyze_0x81.py [decoded.txt ...]
+"""
+from __future__ import annotations
+import sys, glob, os
+
+def hexbytes(tail: str) -> list[int]:
+    out = []
+    for t in tail.split():
+        if len(t) == 2:
+            try:
+                out.append(int(t, 16))
+            except ValueError:
+                break
+        else:
+            break
+    return out
+
+def parse(path: str):
+    """Yield (time, dir, conn, op, handle, payload[list[int]]) for each line."""
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if "Notification" not in line and "WriteReq" not in line:
+                continue
+            parts = line.split()
+            if len(parts) < 5:
+                continue
+            t = parts[0]
+            d = parts[1]
+            conn = parts[2]
+            op = parts[3]
+            # handle column may be '—' or 0xXXXX; payload after it
+            # find the index where hex payload begins: look for handle token
+            # layout: time dir conn op handle payload...
+            # but op can be multi? In decode it's single token (Notification/WriteReq/...)
+            try:
+                idx = 4
+                handle = parts[idx]
+                payload = hexbytes(" ".join(parts[idx+1:]))
+            except IndexError:
+                continue
+            rows.append((t, d, conn, op, handle, payload))
+    return rows
+
+def main():
+    paths = sys.argv[1:]
+    if not paths:
+        paths = sorted(glob.glob("captures/*_decoded.txt"))
+    print(f"{'capture':32} {'time':12} {'conn':6} {'81[2]':>6} {'hex':>14}")
+    print("-" * 80)
+    summary = {}
+    for path in paths:
+        name = os.path.basename(path).replace("_decoded.txt", "")
+        rows = parse(path)
+        # battery from descriptors
+        batt = []
+        for (t, d, conn, op, handle, pl) in rows:
+            if d == "RX" and pl and pl[0] in (0x10, 0x87) and len(pl) >= 2:
+                batt.append((t, pl[1]))
+        # 81 00 frames
+        b2s = []
+        # also track session: a new "01 00 00" TX precedes the 81 00
+        last_status_tx = None
+        for (t, d, conn, op, handle, pl) in rows:
+            if d == "TX" and pl[:3] == [0x01, 0x00, 0x00]:
+                last_status_tx = (t, conn)
+            if d == "RX" and pl[:2] == [0x81, 0x00] and len(pl) >= 4:
+                xx = pl[2]
+                xor = pl[3]
+                calc = pl[0] ^ pl[1] ^ pl[2]
+                ok = "ok" if calc == xor else f"BAD(want {calc:02x})"
+                hexs = " ".join(f"{b:02x}" for b in pl[:4])
+                print(f"{name:32} {t:12} {conn:6} {xx:6d} {hexs:>14}  xor={ok}")
+                b2s.append((t, conn, xx))
+        summary[name] = (b2s, batt)
+    print()
+    print("=" * 80)
+    print("PER-CAPTURE SUMMARY")
+    print("=" * 80)
+    for name, (b2s, batt) in summary.items():
+        if not b2s and not batt:
+            continue
+        xx_vals = [x[2] for x in b2s]
+        batt_vals = sorted(set(b[1] for b in batt))
+        print(f"\n{name}:")
+        print(f"  81 00 byte[2] occurrences ({len(xx_vals)}): {xx_vals}")
+        if xx_vals:
+            print(f"    distinct={sorted(set(xx_vals))}  min={min(xx_vals)} max={max(xx_vals)} >100 count={sum(1 for v in xx_vals if v>100)}")
+        # per-conn (session) grouping
+        byconn = {}
+        for (t, conn, xx) in b2s:
+            byconn.setdefault(conn, []).append(xx)
+        for conn, vals in byconn.items():
+            const = "CONSTANT" if len(set(vals)) == 1 else "VARIES"
+            print(f"    conn {conn}: {vals}  -> {const} within this connection-handle")
+        if batt:
+            print(f"  battery (0x10/0x87 byte[1]) distinct: {batt_vals}  (first={batt[0][1]} last={batt[-1][1]}, n={len(batt)})")
+        else:
+            print(f"  battery: NONE in this capture")
+
+if __name__ == "__main__":
+    main()

--- a/desktop/analyze_counters.py
+++ b/desktop/analyze_counters.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Analyze capture files to resolve GitHub issues #3, #5, and #4.
+
+#3 – Counter time unit: confirm +0x96 = 150s per 0x4c record.
+#5 – 12h offset: compare decoded counter wall-clock to capture timestamps.
+#4 – 0x81 byte[2]: token or battery?
+
+Run from desktop/:
+    python analyze_counters.py
+"""
+
+from __future__ import annotations
+import struct, sys, os
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(__file__))
+from openringconn.sniff import _iter_att
+
+RING_EPOCH = 1577793600  # 2019-12-31 12:00:00 UTC
+CAPTURES = os.path.join(os.path.dirname(__file__), "captures")
+
+
+def decode_cursor(data: bytes, off: int) -> int:
+    """Read a 4-byte BE cursor starting at `off`."""
+    return struct.unpack_from(">I", data, off)[0]
+
+
+def cursor_to_utc(cursor: int) -> datetime:
+    return datetime.fromtimestamp(RING_EPOCH + cursor, tz=timezone.utc)
+
+
+def analyze_file(path: str) -> None:
+    print(f"\n{'='*70}")
+    print(f"FILE: {os.path.basename(path)}")
+    print(f"{'='*70}")
+
+    with open(path, "rb") as f:
+        blob = f.read()
+
+    events = list(_iter_att(blob))
+
+    # ── Issue #4: 0x81 00 byte[2] ────────────────────────────────────────────
+    print("\n── Issue #4: 0x81 00 byte[2] across all sessions ──")
+    print(f"  {'time_utc':<15} {'conn':<6} {'byte[2]':>8} {'hex':>5}")
+    status_vals = []
+    for ev in events:
+        if not ev.sent and ev.opcode == 0x1B and ev.value[:2] == bytes([0x81, 0x00]):
+            ts = datetime.fromtimestamp(ev.ts_unix, tz=timezone.utc)
+            b2 = ev.value[2] if len(ev.value) >= 3 else None
+            if b2 is not None:
+                status_vals.append((ev.ts_unix, ev.conn_handle, b2))
+                print(f"  {ts.strftime('%H:%M:%S'):<15} 0x{ev.conn_handle:03x}  "
+                      f"{b2:>8}   0x{b2:02x}")
+    if status_vals:
+        vals = [x[2] for x in status_vals]
+        print(f"  min={min(vals)} max={max(vals)} range={max(vals)-min(vals)}"
+              f" (>100 → cannot be battery%; full 8-bit range)")
+        # Check if any same-connection repeated
+        from collections import Counter
+        conn_counts = Counter(x[1] for x in status_vals)
+        multi = {h: [x[2] for x in status_vals if x[1] == h]
+                 for h, c in conn_counts.items() if c > 1}
+        if multi:
+            print("  Same-connection multiple reads:")
+            for h, vs in multi.items():
+                print(f"    conn 0x{h:03x}: {vs}")
+
+    # ── Issue #3 & #5: counter analysis ──────────────────────────────────────
+    print("\n── Issue #3/#5: 0x4c record counters ──")
+    four_c_records = []  # list of (unix_ts, cursor)
+    for ev in events:
+        if not ev.sent and ev.opcode == 0x1B and ev.value and ev.value[0] == 0x4c:
+            # Page: [0]=4c [1]=00 [2]=countdown [3:]=body
+            body = ev.value[3:]  # body has 6×23-byte records each starting 0c
+            pos = 0
+            while pos + 23 <= len(body):
+                if body[pos] != 0x0c:
+                    break
+                # [1:5] = 4-byte BE cursor (0c is the first byte of the 4-byte cursor)
+                cursor = decode_cursor(bytes([0x0c]) + body[pos+1:pos+4], 0)
+                four_c_records.append((ev.ts_unix, cursor))
+                pos += 23
+
+    if four_c_records:
+        print(f"  Total 0x4c records decoded: {len(four_c_records)}")
+        # Show first and last
+        ts_first, c_first = four_c_records[0]
+        ts_last, c_last = four_c_records[-1]
+        dt_first = cursor_to_utc(c_first)
+        dt_last = cursor_to_utc(c_last)
+        print(f"  First record: cursor=0x{c_first:08x} → {dt_first}")
+        print(f"  Last  record: cursor=0x{c_last:08x} → {dt_last}")
+
+        # Check counter steps
+        steps = []
+        for i in range(1, min(30, len(four_c_records))):
+            delta = four_c_records[i][1] - four_c_records[i-1][1]
+            steps.append(delta)
+        from collections import Counter
+        step_counts = Counter(steps)
+        print(f"  Counter steps (first 29): {dict(step_counts.most_common(5))}")
+        print(f"  0x96=150? Matches: {step_counts.get(0x96, 0)}/{len(steps)}")
+
+        # Issue #5: Does the decoded counter time match capture wall-clock?
+        # Use the sync-open TX event to anchor
+        print("\n── Issue #5: counter vs capture wall-clock ──")
+        # Find sync-open command (TX: 02 00 <cursor:4> ...)
+        for ev in events:
+            if ev.sent and ev.opcode == 0x12 and ev.att_handle == 0x0802:
+                if ev.value and ev.value[0] == 0x02 and len(ev.value) >= 6:
+                    cursor_bytes = ev.value[2:6]  # bytes 2-5 of the write value
+                    sync_cursor = struct.unpack_from(">I", cursor_bytes, 0)[0]
+                    if sync_cursor != 0xFFFFFFFF:  # skip the "all" cursor
+                        cap_ts = datetime.fromtimestamp(ev.ts_unix, tz=timezone.utc)
+                        ring_ts = cursor_to_utc(sync_cursor)
+                        diff_s = ring_ts.timestamp() - ev.ts_unix
+                        print(f"  Sync-open TX at cap-time {cap_ts}")
+                        print(f"  Cursor 0x{sync_cursor:08x} → ring-time {ring_ts}")
+                        print(f"  Difference: {diff_s:.1f} s ({diff_s/3600:.2f} h)")
+                        if abs(diff_s) < 600:
+                            print(f"  → No 12 h offset; counter tracks UTC wall-clock. 🟢")
+                        elif abs(diff_s - 43200) < 600 or abs(diff_s + 43200) < 600:
+                            print(f"  → 12 h offset CONFIRMED. 🟡")
+                        else:
+                            print(f"  → Unexpected offset: {diff_s/3600:.2f} h")
+
+        # Also check 0x50 end-of-history
+        print("\n── 0x50 end-of-history cursors ──")
+        for ev in events:
+            if not ev.sent and ev.opcode == 0x1B and ev.value and ev.value[0] == 0x50:
+                payload = ev.value  # 50 00 00 | entries
+                cap_ts = datetime.fromtimestamp(ev.ts_unix, tz=timezone.utc)
+                print(f"  At {cap_ts.strftime('%H:%M:%S')} (cap), raw: {payload.hex(' ')[:60]}")
+                # entries of 6B: [type][sub][cursor:4]
+                pos = 3
+                while pos + 6 <= len(payload):
+                    entry_type = payload[pos]
+                    entry_sub = payload[pos+1]
+                    c = decode_cursor(payload, pos+2)
+                    ring_ts = cursor_to_utc(c)
+                    print(f"    type=0x{entry_type:02x} sub=0x{entry_sub:02x} "
+                          f"cursor=0x{c:08x} → {ring_ts}")
+                    pos += 6
+
+    # ── Issue #3: 0x47 counter steps ────────────────────────────────────────
+    print("\n── Issue #3: 0x47 counter steps ──")
+    four_seven_records = []
+    for ev in events:
+        if not ev.sent and ev.opcode == 0x1B and ev.value and ev.value[0] == 0x47:
+            body = ev.value[3:]
+            pos = 0
+            while pos + 47 <= len(body):
+                if body[pos] != 0x0c:
+                    break
+                cursor = decode_cursor(bytes([0x0c]) + body[pos+1:pos+4], 0)
+                four_seven_records.append(cursor)
+                pos += 47
+    if four_seven_records:
+        steps47 = [four_seven_records[i] - four_seven_records[i-1]
+                   for i in range(1, min(20, len(four_seven_records)))]
+        from collections import Counter as C2
+        sc = C2(steps47)
+        print(f"  0x47 records: {len(four_seven_records)}, counter steps: {dict(sc.most_common(5))}")
+        print(f"  0x384=900? Matches: {sc.get(0x384, 0)}/{len(steps47)}")
+
+
+if __name__ == "__main__":
+    files = [
+        "morning_temp_20260615_btsnoop.log",
+        "sleep_sync_btsnoop.log",
+        "btsnoop_hr.log",
+        "fresh_btsnoop.log",
+    ]
+    for fname in files:
+        path = os.path.join(CAPTURES, fname)
+        if os.path.exists(path):
+            analyze_file(path)
+        else:
+            print(f"\nSKIP (not found): {fname}")

--- a/desktop/analyze_cursor.py
+++ b/desktop/analyze_cursor.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Pin the 0x02 sync-cursor semantics from a decoded official-app capture.
+
+For each sync the app does (an `02 00 <cursor> <flag> 01 00` open), report:
+  - the open cursor,
+  - the counter RANGE of the records the ring actually returned (0x4c and 0x47),
+  - the 0x50 end-of-history frame(s).
+
+The record 4-byte value is [0c][3-byte counter], the SAME shape as the cursor
+(PROTOCOL.md §3), so they're directly comparable. This tells us what "open at
+cursor X" really returns — the question my incremental-cursor fix got wrong.
+
+Usage: python analyze_cursor.py captures/ppg_align_20260616_decoded.txt
+"""
+from __future__ import annotations
+import sys
+
+def toks_after(line: str, marker: str) -> list[int]:
+    if marker not in line:
+        return []
+    tail = line.split(marker, 1)[1].strip()
+    out = []
+    for t in tail.split():
+        if len(t) == 2:
+            try:
+                out.append(int(t, 16))
+            except ValueError:
+                break
+        else:
+            break
+    return out
+
+def records(body: list[int], opcode: int, rec_len: int) -> list[int]:
+    """Return the 4-byte [0c|3-counter] values of each record in a page body."""
+    if len(body) < 4 or body[0] != opcode:
+        return []
+    recs = body[3:-1]  # drop [op][00][countdown] and trailing xor
+    out = []
+    for off in range(0, len(recs) - rec_len + 1, rec_len):
+        r = recs[off:off + rec_len]
+        if r[0] == 0x0c:
+            out.append((r[0] << 24) | (r[1] << 16) | (r[2] << 8) | r[3])
+    return out
+
+def main() -> None:
+    path = sys.argv[1] if len(sys.argv) > 1 else "captures/ppg_align_20260616_decoded.txt"
+    syncs = []          # each: dict(open, flag, c4=[], c47=[], eoh=[])
+    cur = None
+    with open(path) as f:
+        for line in f:
+            if "0802 02 00" in line:                      # sync-open
+                b = toks_after(line, "0x0802")
+                if len(b) >= 7 and b[0] == 0x02:
+                    cursor = (b[2] << 24) | (b[3] << 16) | (b[4] << 8) | b[5]
+                    cur = dict(open=cursor, flag=b[6], c4=[], c47=[], eoh=[])
+                    syncs.append(cur)
+                continue
+            if cur is None:
+                continue
+            if "0x0804 4c " in line:
+                cur["c4"] += records(toks_after(line, "0x0804"), 0x4c, 23)
+            elif "0x0804 47 " in line:
+                cur["c47"] += records(toks_after(line, "0x0804"), 0x47, 47)
+            elif "0x0804 50 " in line:
+                cur["eoh"].append(toks_after(line, "0x0804"))
+
+    def rng(xs):
+        return f"{min(xs):08x}..{max(xs):08x}" if xs else "—"
+
+    print(f"{path}: {len(syncs)} syncs\n")
+    print(f"{'open cursor':>10}  fl  {'#4c':>4} {'4c counter range':>20}  {'#47':>4} {'47 counter range':>20}  rel")
+    for s in syncs:
+        allc = s["c4"] + s["c47"]
+        if allc:
+            mn, mx = min(allc), max(allc)
+            # where does the open cursor sit vs the returned records?
+            if s["open"] < mn:   rel = "open < all recs"
+            elif s["open"] > mx: rel = f"open > all recs (+{s['open']-mx})"
+            else:                rel = "open INSIDE range"
+        else:
+            rel = "no records"
+        print(f"{s['open']:08x}  {s['flag']:02x}  {len(s['c4']):>4} {rng(s['c4']):>20}  "
+              f"{len(s['c47']):>4} {rng(s['c47']):>20}  {rel}")
+    # show the 0x50 frames distinctly
+    print("\n0x50 end-of-history frames seen (sub-byte after 50 00 00 → cursor entries):")
+    seen = set()
+    for s in syncs:
+        for e in s["eoh"]:
+            key = tuple(e)
+            if key in seen:
+                continue
+            seen.add(key)
+            print("  " + " ".join(f"{x:02x}" for x in e))
+
+if __name__ == "__main__":
+    main()

--- a/desktop/crack_f.py
+++ b/desktop/crack_f.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Try to identify f(challenge)->3 bytes from 24 known pairs by testing common constructions."""
+import hashlib, zlib, itertools
+
+PAIRS = {
+    0x0f:"4bcce6",0x1f:"9bc931",0x3b:"4bee0c",0x3f:"6797a8",0x49:"0b206f",0x52:"277d7f",
+    0x78:"da5d57",0x80:"a9a3ef",0x81:"4cc4ae",0x86:"db2b80",0x94:"71e959",0x96:"0860ce",
+    0x9d:"6b6e2c",0xa3:"5eb61e",0xb0:"318267",0xbc:"1252f2",0xc2:"053317",0xc4:"a2f827",
+    0xcb:"09889c",0xd8:"9c6191",0xda:"f01e88",0xe3:"1be985",0xe5:"520be1",0xf9:"3609b2",
+}
+items = list(PAIRS.items())
+
+def hx(b): return b.hex()
+
+# Candidate input encodings of the 1-byte challenge
+def encodings(c):
+    return {
+        "byte": bytes([c]),
+        "str": str(c).encode(),
+        "hexlow": f"{c:02x}".encode(),
+        "hexup": f"{c:02X}".encode(),
+        "0xhex": f"0x{c:02x}".encode(),
+    }
+
+def test_hash(name, hfun):
+    for enc_name in ["byte","str","hexlow","hexup","0xhex"]:
+        for sl_name, sl in [("first3", slice(0,3)), ("last3", slice(-3,None))]:
+            ok = all(hfun(encodings(c)[enc_name])[sl].hex()==r for c,r in items)
+            if ok: print(f"  HIT: {name} {enc_name} {sl_name}")
+
+print("=== truncated hashes (keyless) ===")
+for name, h in [("md5",hashlib.md5),("sha1",hashlib.sha1),("sha224",hashlib.sha224),
+                ("sha256",hashlib.sha256),("sha384",hashlib.sha384),("sha512",hashlib.sha512),
+                ("sha3_256",hashlib.sha3_256),("blake2b",hashlib.blake2b),("blake2s",hashlib.blake2s)]:
+    test_hash(name, lambda b, h=h: h(b).digest())
+
+print("=== CRC variants (output = 3 bytes; try crc32 truncations + crc-any-24) ===")
+# crc32 then take 3 bytes various ways
+for c,r in items[:1]: pass
+def crc32_variants():
+    for enc in ["byte","str","hexlow","hexup"]:
+        for take in ["lo3le","lo3be","hi3"]:
+            def f(c, enc=enc, take=take):
+                v=zlib.crc32(encodings(c)[enc]) & 0xffffffff
+                b=v.to_bytes(4,"big")
+                return {"lo3le":v.to_bytes(4,"little")[:3],"lo3be":b[1:4],"hi3":b[0:3]}[take]
+            ok=all(hx(f(c))==r for c,r in items)
+            if ok: print(f"  HIT: crc32 {enc} {take}")
+crc32_variants()
+
+# Generic CRC-24: brute common polys/inits/refin/refout/xorout
+def crc24(data, poly, init, refin, refout, xorout):
+    def rev(x,n):
+        r=0
+        for _ in range(n): r=(r<<1)|(x&1); x>>=1
+        return r
+    crc=init
+    for byte in data:
+        b=rev(byte,8) if refin else byte
+        crc ^= b<<16
+        for _ in range(8):
+            crc<<=1
+            if crc & 0x1000000: crc ^= poly
+        crc &= 0xffffff
+    if refout: crc=rev(crc,24)
+    return (crc ^ xorout) & 0xffffff
+
+print("=== brute CRC-24 (common polys × init × refin/out × xorout × encodings) ===")
+polys=[0x864cfb,0x5d6dcb,0x328b63,0x1864cfb & 0xffffff,0x800063,0x00065b,0xC3267D,0x800FE3,0x00BAAD]
+found=False
+for poly in polys:
+    for init in [0x000000,0xffffff,0xB704CE,0xFEDCBA,0xABCDEF]:
+        for refin in (False,True):
+            for refout in (False,True):
+                for xorout in [0x000000,0xffffff]:
+                    for enc in ["byte","str","hexlow"]:
+                        ok=all(crc24(encodings(c)[enc],poly,init,refin,refout,xorout).to_bytes(3,"big").hex()==r
+                               for c,r in items)
+                        if ok:
+                            print(f"  HIT CRC24 poly={poly:#08x} init={init:#08x} refin={refin} refout={refout} xorout={xorout:#08x} enc={enc}")
+                            found=True
+if not found: print("  no CRC-24 match")
+print("\n(if no HIT above, f() is keyed/custom — needs the binary)")

--- a/desktop/decode_0x47.py
+++ b/desktop/decode_0x47.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Decode 0x47 PPG payloads from a decoded-capture txt and prep them for #8 alignment.
+
+#8 = "Capture: realtime PPG alignment -> decode 0x47 payload". Geometry is 🟢 (47-byte
+records, +0x384 counter, 38-byte payload at record[9:47]); the SAMPLE decode (bit width +
+channel) is 🔴 and can ONLY be proven by aligning to an external reference (the official
+app's PPG trace + a deliberate finger-on/off sequence + a reference HR). This tool does the
+mechanical part: extract records, decode the payload BOTH plausible ways (10-bit and 12-bit
+big-endian), and emit per-record amplitude + CSVs so the on->off amplitude collapse can be
+overlaid on the finger-off timestamps.
+
+⚠️ It does NOT prove anything on its own. A "smooth"/"self-consistent" array is NOT evidence
+(see #8 pitfalls + the project no-fabrication rule). Run it on a FIDUCIAL capture and align.
+
+Usage:
+  # 1. turn the btsnoop into a decoded txt with the existing tool:
+  python -m openringconn decode-log captures/ppg_align_btsnoop.log > captures/ppg_align_decoded.txt
+  # 2. decode the 0x47 payloads both ways:
+  python decode_0x47.py captures/ppg_align_decoded.txt
+"""
+from __future__ import annotations
+
+import sys
+import statistics
+from dataclasses import dataclass
+
+SYNC_EPOCH = 1_577_793_600  # PROTOCOL.md §5.6
+PPG_RECORD_LEN = 47
+PAYLOAD_OFF = 9             # record[9:47] = 38 payload bytes (EpochRecord.PPGRecord)
+MARKER = 0x0C
+
+
+@dataclass
+class Rec:
+    counter: int            # cursor-space seconds (ring clock)
+    payload: list[int]      # 38 bytes
+
+
+def _bits_to_samples(payload: list[int], width: int) -> list[int]:
+    """Big-endian bitstream -> consecutive `width`-bit samples (drops a partial tail)."""
+    bitstr = "".join(f"{b:08b}" for b in payload)
+    n = len(bitstr) // width
+    return [int(bitstr[i * width:(i + 1) * width], 2) for i in range(n)]
+
+
+def _extract_0x47(path: str) -> list[Rec]:
+    """Pull 0x47 records out of a `decode-log` txt (lines: '... 0x0804 47 00 <cd> <recs> <xor>')."""
+    out: list[Rec] = []
+    with open(path) as f:
+        for line in f:
+            if "0x0804 47 " not in line:
+                continue
+            hexpart = line.split("0x0804", 1)[1].strip()
+            toks = [t for t in hexpart.split() if len(t) == 2]
+            try:
+                body = bytes(int(t, 16) for t in toks)
+            except ValueError:
+                continue
+            if len(body) < 4 or body[0] != 0x47:
+                continue
+            recs = body[3:-1]  # drop [47][00][countdown] header and the trailing xor
+            for off in range(0, len(recs) - PPG_RECORD_LEN + 1, PPG_RECORD_LEN):
+                r = recs[off:off + PPG_RECORD_LEN]
+                if r[0] != MARKER:
+                    continue
+                counter = (r[0] << 24) | (r[1] << 16) | (r[2] << 8) | r[3]   # full 4-byte (incl 0x0c MSB) — matches analyze_cursor / extract_last_night
+                out.append(Rec(counter=counter, payload=list(r[PAYLOAD_OFF:PPG_RECORD_LEN])))
+    return out
+
+
+def _smoothness(samples: list[int]) -> float:
+    """mean|Δ| / std — a PULSATILE PPG is smooth (low); noise is high. A HINT, not proof."""
+    if len(samples) < 3:
+        return float("nan")
+    sd = statistics.pstdev(samples)
+    if sd == 0:
+        return 0.0
+    diffs = [abs(samples[i + 1] - samples[i]) for i in range(len(samples) - 1)]
+    return (sum(diffs) / len(diffs)) / sd
+
+
+def main() -> None:
+    path = sys.argv[1] if len(sys.argv) > 1 else "captures/fresh_decoded.txt"
+    recs = _extract_0x47(path)
+    if not recs:
+        print(f"No 0x47 records found in {path}. Generate it with `decode-log` first.")
+        return
+
+    span = (recs[-1].counter - recs[0].counter) if len(recs) > 1 else 0
+    print(f"{path}: {len(recs)} × 0x47 records, counter span {span}s "
+          f"(~{span/60:.1f} min of ring time)\n")
+
+    for width, expect in ((10, 30), (12, 25)):
+        allsamp: list[int] = []
+        amps: list[int] = []
+        per_rec_counts = set()
+        for r in recs:
+            s = _bits_to_samples(r.payload, width)
+            per_rec_counts.add(len(s))
+            allsamp += s
+            if s:
+                amps.append(max(s) - min(s))
+        sm = _smoothness(allsamp)
+        print(f"  {width}-bit BE  → {sorted(per_rec_counts)} samples/rec (expect ~{expect}); "
+              f"range {min(allsamp)}–{max(allsamp)}; "
+              f"median per-record p2p amplitude {statistics.median(amps):.0f}; "
+              f"smoothness {sm:.2f}")
+        csv = path.rsplit('.', 1)[0] + f".0x47_{width}bit.csv"
+        with open(csv, "w") as out:
+            out.write("ring_counter_s,sample_index,value\n")
+            for r in recs:
+                for i, v in enumerate(_bits_to_samples(r.payload, width)):
+                    out.write(f"{r.counter},{i},{v}\n")
+        print(f"             wrote {csv}")
+
+    print("\n⚠️  Structural only. Proof = align the amplitude envelope to your finger-on/off")
+    print("    timestamps + match FFT bpm to the reference HR (per issue #8). Not done here.")
+
+
+if __name__ == "__main__":
+    main()

--- a/desktop/decode_bulk.py
+++ b/desktop/decode_bulk.py
@@ -9,14 +9,28 @@ Each 0x4c notification: [0]=0x4c [1]=00 [2]=remaining-record countdown,
 then 6 x 23-byte records, then a 1-byte XOR trailer. Records concatenate
 across packets (strip the 3-byte header AND the 1-byte trailer per packet).
 
-Record (23 B), confirmed against captures/sleep_sync_btsnoop.log (FR02.018):
-  [0:4]   big-endian counter, +0x96 (150) per record  -> 150 s epochs
-  [4:8]   4-byte field (varies; secondary counter / packed) 🟡
-  [8]     subtype tag: 0x12 common; 0x5a-0x63 periodic markers 🟡
-  [9]     small int (mostly 0x0a) 🟡
-  [10:15] 5 x per-30 s MOTION/activity counts (decays awake->asleep) 🟢-ish
-  [15:22] 7-byte per-epoch physiology payload (HR/HRV/SpO2?) 🟡
-  [22]    trailer flags 🟡
+Record (23 B), confirmed against captures/sleep_sync_btsnoop.log (FR02.018),
+aligned to the RingConn app's readout for the 2026-06-13 night. Two layouts,
+keyed on [8]:
+
+  Sleep-vitals epoch ([8] in 0x57..0x63):
+    [0:4]   BE counter, +0x96 (150 s) per record
+    [4]     heart rate (bpm)            CONFIRMED
+    [5]     HRV / RMSSD (ms)            CONFIRMED
+    [6]     ~1-10, signal quality?      unresolved
+    [7]     ~120, pulse amplitude?      unresolved
+    [8]     SpO2 (%)                    CONFIRMED
+    [9]     ~0x0a                       flag
+    [10:15] 5x per-30s motion counts (01 baseline = still)
+    [15:22] ~zero during sleep
+    [22]    trailer flags
+
+  Activity/awake epoch ([8]=0x12/0x13):
+    [10:15] 5x motion counts (elevated when moving)
+    [15:22] 7-byte activity/physiology payload (unresolved)
+
+Respiratory rate + skin temp are NOT per-epoch here (derived/summary).
+Sleep stages are app-computed from these signals, not stored on the wire.
 
 Usage:
   python -m openringconn decode-log captures/foo.log --addr <mac> > /tmp/dec.txt
@@ -58,6 +72,10 @@ def is_idle(r):
     return r[10:15] == bytes([1, 1, 1, 1, 1]) and r[15:22] == bytes(7)
 
 
+def is_sleep_vitals(r):
+    return 0x57 <= r[8] <= 0x63
+
+
 def main(path):
     lines = open(path).read().splitlines()
     recs = reassemble_4c(notif_payloads(lines, 0x4c))
@@ -89,10 +107,14 @@ def main(path):
             c = int.from_bytes(r[0:4], "big")
             mot = r[10:15]
             msum = sum(v for v in mot if v != 1)
-            tag = "IDLE" if is_idle(r) else f"{r[8]:#04x}"
-            bar = "#" * min(msum, 40)
-            print(f"  {ts(c):%H:%M}  mot={mot.hex()} phys={r[15:22].hex()} "
-                  f"{tag:>4} {bar}")
+            if is_idle(r):
+                line = "IDLE"
+            elif is_sleep_vitals(r):
+                line = f"HR={r[4]:3d}bpm  HRV={r[5]:3d}ms  SpO2={r[8]:2d}%"
+            else:
+                bar = "#" * min(msum, 40)
+                line = f"activity mot={mot.hex()} {bar}"
+            print(f"  {ts(c):%H:%M}  {line}")
         print()
     return 0
 

--- a/desktop/decode_bulk.py
+++ b/desktop/decode_bulk.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Decode the RingConn Gen 2 bulk activity/sleep stream (`0x4c` pages).
+
+Reads the text output of `python -m openringconn decode-log <btsnoop>` and
+reassembles the `0x4c` record stream into per-epoch records, converting the
+24-bit counter to wall-clock via the §5.6 epoch.
+
+Each 0x4c notification: [0]=0x4c [1]=00 [2]=remaining-record countdown,
+then 6 x 23-byte records, then a 1-byte XOR trailer. Records concatenate
+across packets (strip the 3-byte header AND the 1-byte trailer per packet).
+
+Record (23 B), confirmed against captures/sleep_sync_btsnoop.log (FR02.018):
+  [0:4]   big-endian counter, +0x96 (150) per record  -> 150 s epochs
+  [4:8]   4-byte field (varies; secondary counter / packed) 🟡
+  [8]     subtype tag: 0x12 common; 0x5a-0x63 periodic markers 🟡
+  [9]     small int (mostly 0x0a) 🟡
+  [10:15] 5 x per-30 s MOTION/activity counts (decays awake->asleep) 🟢-ish
+  [15:22] 7-byte per-epoch physiology payload (HR/HRV/SpO2?) 🟡
+  [22]    trailer flags 🟡
+
+Usage:
+  python -m openringconn decode-log captures/foo.log --addr <mac> > /tmp/dec.txt
+  python decode_bulk.py /tmp/dec.txt
+"""
+import re
+import sys
+import datetime
+
+EPOCH = 1577793600  # §5.6: 2019-12-31 12:00:00 UTC
+RECLEN = 23
+STEP = 0x96  # 150 s
+
+
+def notif_payloads(lines, opcode):
+    out = []
+    for ln in lines:
+        m = re.search(r"Notification\s+0x0804\s+(.*)$", ln)
+        if not m:
+            continue
+        b = bytes(int(x, 16) for x in m.group(1).split())
+        if b and b[0] == opcode:
+            out.append(b)
+    return out
+
+
+def reassemble_4c(payloads):
+    """Strip 3-byte header + 1-byte XOR trailer per packet, concat, split to records."""
+    stream = b"".join(p[3:-1] for p in payloads)
+    return [stream[i:i + RECLEN] for i in range(0, len(stream), RECLEN)
+            if len(stream[i:i + RECLEN]) == RECLEN]
+
+
+def ts(counter):
+    return datetime.datetime.utcfromtimestamp(counter + EPOCH)
+
+
+def is_idle(r):
+    return r[10:15] == bytes([1, 1, 1, 1, 1]) and r[15:22] == bytes(7)
+
+
+def main(path):
+    lines = open(path).read().splitlines()
+    recs = reassemble_4c(notif_payloads(lines, 0x4c))
+    if not recs:
+        print("no 0x4c records found", file=sys.stderr)
+        return 1
+    print(f"{len(recs)} records ({sum(is_idle(r) for r in recs)} idle)\n")
+
+    # segment into sessions (gap > 600 s)
+    prev = None
+    seg = []
+    sessions = []
+    for r in recs:
+        c = int.from_bytes(r[0:4], "big")
+        if prev is not None and c - prev > 600:
+            sessions.append(seg)
+            seg = []
+        seg.append(r)
+        prev = c
+    sessions.append(seg)
+
+    for s in sessions:
+        c0 = int.from_bytes(s[0][0:4], "big")
+        c1 = int.from_bytes(s[-1][0:4], "big")
+        worn = sum(1 for r in s if not is_idle(r))
+        print(f"== session {ts(c0)} -> {ts(c1)} UTC | {len(s)} epochs, "
+              f"{worn} worn / {len(s)-worn} idle ==")
+        for r in s:
+            c = int.from_bytes(r[0:4], "big")
+            mot = r[10:15]
+            msum = sum(v for v in mot if v != 1)
+            tag = "IDLE" if is_idle(r) else f"{r[8]:#04x}"
+            bar = "#" * min(msum, 40)
+            print(f"  {ts(c):%H:%M}  mot={mot.hex()} phys={r[15:22].hex()} "
+                  f"{tag:>4} {bar}")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/desktop/decode_ppg.py
+++ b/desktop/decode_ppg.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Decode the RingConn Gen 2 bulk PPG stream (`0x47` pages).
+
+Reads the text output of `python -m openringconn decode-log <btsnoop>` and
+reassembles the `0x47` record stream into 10-bit PPG samples.
+
+A 0x47 page: [0]=0x47 [1]=00 [2]=remaining-record countdown, then N×47-byte
+records, then a 1-byte XOR trailer. Strip the 3-byte header AND the 1-byte
+trailer per page; records do not span pages.
+
+Record (47 B), confirmed against captures/sleep_sync_btsnoop.log (FR02.018):
+  [0:4]   BE counter, +0x0384 (900 s) per record
+  [4:6]   16-bit baseline ([4]=0x02 const, [5] drifts)
+  [6:9]   usually 00 00 00 (per-record flags)
+  [9:47]  38 B = 30 × 10-bit big-endian samples (+ 4 zero pad-bits), interleaved
+          as 2 channels × 15 (red/IR-like, tightly correlated). 10-bit is the
+          minimum-jitter width vs 8/12/16.
+
+Usage:
+  python -m openringconn decode-log captures/foo.log --addr <mac> > /tmp/dec.txt
+  python decode_ppg.py /tmp/dec.txt
+"""
+import re
+import sys
+import datetime
+
+EPOCH = 1577793600  # §5.6
+RECLEN = 47
+SAMPLE_BITS = 10
+N_SAMPLES = 30
+
+
+def notif_payloads(lines, opcode):
+    out = []
+    for ln in lines:
+        m = re.search(r"Notification\s+0x0804\s+(.*)$", ln)
+        if not m:
+            continue
+        b = bytes(int(x, 16) for x in m.group(1).split())
+        if b and b[0] == opcode:
+            out.append(b)
+    return out
+
+
+def reassemble_47(payloads):
+    stream = b"".join(p[3:-1] for p in payloads)
+    return [stream[i:i + RECLEN] for i in range(0, len(stream), RECLEN)
+            if len(stream[i:i + RECLEN]) == RECLEN]
+
+
+def samples(record):
+    """30 × 10-bit big-endian samples from record[9:47]."""
+    val = 0
+    for byte in record[9:47]:
+        val = (val << 8) | byte
+    nbits = (RECLEN - 9) * 8
+    return [(val >> (nbits - (i + 1) * SAMPLE_BITS)) & 0x3FF for i in range(N_SAMPLES)]
+
+
+def ts(counter):
+    return datetime.datetime.utcfromtimestamp(counter + EPOCH)
+
+
+def main(path):
+    lines = open(path).read().splitlines()
+    recs = reassemble_47(notif_payloads(lines, 0x47))
+    if not recs:
+        print("no 0x47 records found", file=sys.stderr)
+        return 1
+    print(f"{len(recs)} PPG records "
+          f"({ts(int.from_bytes(recs[0][0:4], 'big')):%Y-%m-%d %H:%M} → "
+          f"{ts(int.from_bytes(recs[-1][0:4], 'big')):%Y-%m-%d %H:%M} UTC)\n")
+    for r in recs:
+        c = int.from_bytes(r[0:4], "big")
+        s = samples(r)
+        rng = max(s) - min(s)
+        chA, chB = s[0::2], s[1::2]   # two interleaved channels
+        flag = "" if rng > 5 else "  (flat/idle)"
+        print(f"{ts(c):%m-%d %H:%M}  base={r[4:6].hex()} range={rng:4d}{flag}")
+        if rng > 5:
+            print(f"           red/A: {chA}")
+            print(f"           IR /B: {chB}")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/desktop/extract_last_night.py
+++ b/desktop/extract_last_night.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Extract the sleep/vitals the ring actually held — the data our app failed to sync.
+
+Decodes the 0x4c sleep-vitals epochs from a `decode-log` txt into REAL HR / HRV /
+SpO2 / respiratory-rate values, faithfully mirroring OpenRingKit's BulkSleep.swift
+(the on-device decoder) so the numbers match what the app would have surfaced. No
+fabrication: every value is a byte off the wire; out-of-band values are flagged, not
+clamped or invented (project rule — tag 🟢/🟡/🔴).
+
+0x4c record geometry (PROTOCOL.md §5.3, BulkSleep.swift):
+  23-byte records, counter [0:4] BE = seconds since 1577793600, epoch step 0x96=150s.
+  Layouts keyed structurally:
+    idle        : [4:8]=05 00 0c 00, [9]=0a, motion 01x5, [15:22]=00x7  (unworn/charging)
+    activity    : [8]=0x12/0x13                                          (awake/active)
+    sleepVitals : everything else → HR=[4], HRV=[5], RR=[7]/8, SpO2=[8]
+Skin temp / steps are NOT in 0x4c (they ride the 0x10/0x87 descriptor), so they are
+not recovered here — they are a live-descriptor metric, not history.
+
+Usage: python3 extract_last_night.py captures/ppg_align_20260616_decoded.txt
+"""
+from __future__ import annotations
+import sys
+import statistics
+from datetime import datetime, timezone, timedelta
+
+SYNC_EPOCH = 1_577_793_600       # PROTOCOL.md §5.6
+REC_LEN = 23
+MARKER = 0x0C
+# Display in the machine's LOCAL timezone (DST-correct), not a hardcoded offset — a fixed
+# UTC-7 mislabels every timestamp by an hour in PST (winter) and can push a late-evening onset
+# across midnight onto the wrong calendar night. Counters/spans use raw UTC seconds throughout.
+LOCAL = datetime.now().astimezone().tzinfo
+
+
+def toks_after(line: str, marker: str) -> list[int]:
+    if marker not in line:
+        return []
+    tail = line.split(marker, 1)[1].strip()
+    out = []
+    for t in tail.split():
+        if len(t) == 2:
+            try:
+                out.append(int(t, 16))
+            except ValueError:
+                break
+        else:
+            break
+    return out
+
+
+def page_records(body: list[int]) -> list[list[int]]:
+    """[0x4c][00][countdown][N x 23][xor] → list of 23-byte records (0x0c-delimited)."""
+    if len(body) < 4 or body[0] != 0x4C:
+        return []
+    recs = body[3:-1]
+    out = []
+    for off in range(0, len(recs) - REC_LEN + 1, REC_LEN):
+        r = recs[off:off + REC_LEN]
+        if r[0] == MARKER:
+            out.append(r)
+    return out
+
+
+def layout(r: list[int]) -> str:
+    if (r[4] == 0x05 and r[5] == 0x00 and r[6] == 0x0c and r[7] == 0x00 and r[9] == 0x0a
+            and r[10:15] == [1, 1, 1, 1, 1] and r[15:22] == [0, 0, 0, 0, 0, 0, 0]):
+        return "idle"
+    if r[8] in (0x12, 0x13):
+        return "activity"
+    return "sleepVitals"
+
+
+def counter(r: list[int]) -> int:
+    return (r[0] << 24) | (r[1] << 16) | (r[2] << 8) | r[3]
+
+
+def decode(r: list[int]) -> dict:
+    lay = layout(r)
+    d = {"counter": counter(r), "layout": lay}
+    if lay == "sleepVitals":
+        d["hr"] = r[4] if r[4] > 0 else None
+        d["hrv"] = r[5] if r[5] > 0 else None
+        d["rr"] = round(r[7] / 8.0, 1) if r[7] > 0 else None
+        spo2 = r[8]
+        d["spo2"] = spo2 if 70 <= spo2 <= 100 else None
+        d["spo2_raw"] = spo2
+        d["motion"] = r[10:15]
+    return d
+
+
+def fmt(ts: int) -> str:
+    return datetime.fromtimestamp(ts, LOCAL).strftime("%Y-%m-%d %H:%M")
+
+
+def stat_line(name: str, vals: list[float], unit: str) -> str:
+    vals = [v for v in vals if v is not None]
+    if not vals:
+        return f"  {name:<16} —  (no epochs carried this field)"
+    return (f"  {name:<16} n={len(vals):<4} "
+            f"min={min(vals):g}  median={statistics.median(vals):g}  max={max(vals):g} {unit}")
+
+
+def main() -> None:
+    path = sys.argv[1] if len(sys.argv) > 1 else "captures/ppg_align_20260616_decoded.txt"
+    records: list[list[int]] = []
+    with open(path) as f:
+        for line in f:
+            if "0x0804 4c " in line:
+                records += page_records(toks_after(line, "0x0804"))
+    if not records:
+        print(f"No 0x4c records in {path}.")
+        return
+
+    # Dedup by counter (the same epoch can appear across overlapping app syncs) and order.
+    seen, uniq = set(), []
+    for r in records:
+        c = counter(r)
+        if c not in seen:
+            seen.add(c)
+            uniq.append(r)
+    uniq.sort(key=counter)
+    decoded = [decode(r) for r in uniq]
+
+    sv = [d for d in decoded if d["layout"] == "sleepVitals"]
+    idle = [d for d in decoded if d["layout"] == "idle"]
+    act = [d for d in decoded if d["layout"] == "activity"]
+
+    t0, t1 = counter(uniq[0]) + SYNC_EPOCH, counter(uniq[-1]) + SYNC_EPOCH
+    print(f"{path}")
+    print(f"{len(uniq)} unique 0x4c epochs  ({len(records)} raw, {len(records)-len(uniq)} dup)")
+    print(f"span {fmt(t0)} → {fmt(t1)}  ({(t1-t0)/3600:.1f} h of ring history)")
+    print(f"layouts: {len(sv)} sleep-vitals · {len(idle)} idle/unworn · {len(act)} activity\n")
+
+    print("Decoded sleep-vitals (🟢 HR/HRV/SpO2/RR per BulkSleep.swift):")
+    print(stat_line("Heart rate", [d.get("hr") for d in sv], "bpm"))
+    print(stat_line("HRV (RMSSD)", [d.get("hrv") for d in sv], "ms"))
+    print(stat_line("SpO2", [d.get("spo2") for d in sv], "%"))
+    print(stat_line("Respiratory", [d.get("rr") for d in sv], "brpm"))
+
+    # Physiological sanity (flag, never clamp).
+    warns = []
+    for d in sv:
+        if d.get("hr") and not (30 <= d["hr"] <= 180):
+            warns.append(f"HR {d['hr']} @ {fmt(d['counter']+SYNC_EPOCH)}")
+        if d.get("spo2_raw") and not (70 <= d["spo2_raw"] <= 100):
+            warns.append(f"SpO2_raw {d['spo2_raw']} @ {fmt(d['counter']+SYNC_EPOCH)} (dropped)")
+    if warns:
+        print(f"\n  ⚠️ {len(warns)} out-of-band readings (flagged, not clamped): " + "; ".join(warns[:6]))
+
+    # Contiguous worn runs (epochs ≤ 2 epochs apart). Report the MOST RECENT substantial run —
+    # the tool is "last night," so the longest run ANYWHERE in a multi-week backlog is the wrong
+    # answer (an older night could be longer). Also note the longest separately when it differs.
+    runs = [r for r in contiguous_runs(sv) if len(r) >= 8]   # ≥ ~20 min worn
+    if runs:
+        recent = runs[-1]                       # latest in time (sv is sorted)
+        longest = max(runs, key=len)
+        def report(label: str, run: list[dict]) -> None:
+            a, b = run[0]["counter"] + SYNC_EPOCH, run[-1]["counter"] + SYNC_EPOCH
+            hrs = [d["hr"] for d in run if d.get("hr")]
+            line = f"\n{label}: {fmt(a)} → {fmt(b)}  ({(b-a)/3600:.1f} h, {len(run)} epochs)"
+            if hrs:
+                line += f"\n  HR {min(hrs)}–{max(hrs)} bpm (median {statistics.median(hrs):g})"
+            print(line)
+        report("Most recent worn block (≈ last night if the capture ends in the morning)", recent)
+        if longest is not recent:
+            report("Longest worn block in the capture (an EARLIER night)", longest)
+        print("  ↑ this is the kind of sleep data our app dropped while history opened with syncAll.")
+
+    # Sample rows.
+    print("\nFirst 8 sleep-vitals epochs:")
+    print(f"  {'time':<17}{'HR':>4}{'HRV':>5}{'SpO2':>6}{'RR':>6}  motion")
+    for d in sv[:8]:
+        print(f"  {fmt(d['counter']+SYNC_EPOCH):<17}"
+              f"{(d.get('hr') or '-'):>4}{(d.get('hrv') or '-'):>5}"
+              f"{(d.get('spo2') or '-'):>6}{(str(d.get('rr')) if d.get('rr') else '-'):>6}  "
+              f"{d.get('motion')}")
+
+    csv = "captures/last_night_extracted.csv"
+    with open(csv, "w") as out:
+        out.write("utc_iso,local,counter,layout,hr_bpm,hrv_ms,spo2_pct,rr_brpm,motion\n")
+        for d in decoded:
+            ts = d["counter"] + SYNC_EPOCH
+            iso = datetime.fromtimestamp(ts, timezone.utc).isoformat()
+            out.write(f"{iso},{fmt(ts)},{d['counter']},{d['layout']},"
+                      f"{d.get('hr','')},{d.get('hrv','')},{d.get('spo2','')},"
+                      f"{d.get('rr','')},\"{d.get('motion','')}\"\n")
+    print(f"\nwrote {csv}")
+
+
+def contiguous_runs(sv: list[dict], max_gap_epochs: int = 2) -> list[list[dict]]:
+    """All runs of sleep-vitals epochs spaced ≤ max_gap_epochs * 150 s apart, in time order."""
+    if not sv:
+        return []
+    runs, cur = [], [sv[0]]
+    for prev, d in zip(sv, sv[1:]):
+        if d["counter"] - prev["counter"] <= max_gap_epochs * 150:
+            cur.append(d)
+        else:
+            runs.append(cur)
+            cur = [d]
+    runs.append(cur)
+    return runs
+
+
+if __name__ == "__main__":
+    main()

--- a/desktop/find_table.py
+++ b/desktop/find_table.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Locate the RingConn auth table f(challenge)->3 bytes inside libapp.so by spacing.
+
+If f() is a flat challenge-indexed byte table, response(c) sits at base + c*stride.
+We know 24 (challenge,response) pairs; find a (base,stride) that explains many of them.
+"""
+import sys
+
+PAIRS = {
+    0x0f:(0x4b,0xcc,0xe6),0x1f:(0x9b,0xc9,0x31),0x3b:(0x4b,0xee,0x0c),0x3f:(0x67,0x97,0xa8),
+    0x49:(0x0b,0x20,0x6f),0x52:(0x27,0x7d,0x7f),0x78:(0xda,0x5d,0x57),0x80:(0xa9,0xa3,0xef),
+    0x81:(0x4c,0xc4,0xae),0x86:(0xdb,0x2b,0x80),0x94:(0x71,0xe9,0x59),0x96:(0x08,0x60,0xce),
+    0x9d:(0x6b,0x6e,0x2c),0xa3:(0x5e,0xb6,0x1e),0xb0:(0x31,0x82,0x67),0xbc:(0x12,0x52,0xf2),
+    0xc2:(0x05,0x33,0x17),0xc4:(0xa2,0xf8,0x27),0xcb:(0x09,0x88,0x9c),0xd8:(0x9c,0x61,0x91),
+    0xda:(0xf0,0x1e,0x88),0xe3:(0x1b,0xe9,0x85),0xe5:(0x52,0x0b,0xe1),0xf9:(0x36,0x09,0xb2),
+}
+
+def find_all(data, pat):
+    out, i = [], data.find(pat)
+    while i != -1:
+        out.append(i); i = data.find(pat, i+1)
+    return out
+
+def main():
+    data = open(sys.argv[1] if len(sys.argv)>1 else "lib/arm64-v8a/libapp.so","rb").read()
+    print(f"{len(data)} bytes")
+    occ = {c: find_all(data, bytes(t)) for c,t in PAIRS.items()}
+    for c,offs in sorted(occ.items()):
+        if not offs: print(f"  challenge {c:#04x} {bytes(PAIRS[c]).hex()} : NOT FOUND")
+    # Try strides; anchor on each occurrence of challenge 0xb0, hypothesize base, count hits.
+    best=None
+    for stride in (1,2,3,4,8):
+        for anchor_c,anchor_offs in occ.items():
+            for ao in anchor_offs:
+                base = ao - anchor_c*stride
+                if base < 0: continue
+                hits = []
+                for c,t in PAIRS.items():
+                    pos = base + c*stride
+                    if 0 <= pos <= len(data)-3 and data[pos:pos+3]==bytes(t):
+                        hits.append(c)
+                if best is None or len(hits) > len(best[2]):
+                    best = (base, stride, hits)
+    base,stride,hits = best
+    print(f"\nBEST: base={base:#x} stride={stride}  explains {len(hits)}/{len(PAIRS)} known pairs: {[hex(h) for h in sorted(hits)]}")
+    if len(hits) >= 6:
+        print(f"\n>>> TABLE FOUND. Dumping 256 entries (stride {stride}) from base {base:#x}:")
+        tbl = {}
+        for c in range(256):
+            pos = base + c*stride
+            tbl[c] = data[pos:pos+3].hex()
+        # sanity: all known pairs match?
+        ok = all(tbl[c]==bytes(t).hex() for c,t in PAIRS.items())
+        print(f"all 24 known pairs match table: {ok}")
+        for c in range(256):
+            end = " " if (c%8)!=7 else "\n"
+            print(f"{c:02x}:{tbl[c]}", end=end)
+    else:
+        print("No flat byte-table found (f() is likely computed, not a table).")
+
+if __name__=="__main__":
+    main()

--- a/desktop/probe_temp.py
+++ b/desktop/probe_temp.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Active probe (verbose): learn whether the Mac can drive DATA commands at all,
+then sweep the 0x02 sync-open flag for a temperature/summary stream.
+
+Findings so far: an unbonded CoreBluetooth central gets replies to the 0x01
+handshake but (so far) nothing to 0x02/0x07/0x95. This script tests that
+explicitly in ONE warm connection (the ring sleeps within seconds), trying a
+known-good real cursor before the flag sweep.
+
+Run it the instant the ring is awake (off charger, just tapped), phone BT off,
+no other process holding the link:
+  .venv/bin/python probe_temp.py
+"""
+import asyncio
+import collections
+import sys
+
+from bleak import BleakClient
+from openringconn import ble, session
+
+ADDR = sys.argv[1] if len(sys.argv) > 1 else "63E2C4D4-7E06-CA73-568B-062FAA032213"
+GOOD_CURSOR = "0c2298c3"   # known to return data on the phone (FR02.018 capture)
+
+
+async def main():
+    q: asyncio.Queue = asyncio.Queue()
+    dev = await session._resolve(ADDR, timeout=15.0)
+    async with BleakClient(dev) as client:
+        print("connected:", client.is_connected)
+        _ = client.services.get_characteristic(ble.NOTIFY_CHAR)   # force discovery
+        await client.start_notify(ble.NOTIFY_CHAR, lambda _s, d: q.put_nowait(bytes(d)))
+        await asyncio.sleep(0.5)
+
+        async def w(h):
+            await client.write_gatt_char(ble.WRITE_CHAR, bytes.fromhex(h), response=True)
+            print(f"  TX {h}")
+
+        async def drain(timeout, auto_ack=True, tag=""):
+            frames = []
+            while True:
+                try:
+                    b = await asyncio.wait_for(q.get(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    break
+                frames.append(b)
+                print(f"     RX {b.hex(' ')}")
+                if auto_ack and b[0] == 0x47:
+                    await w("c70000")
+                elif auto_ack and b[0] == 0x4C:
+                    await w("cc0000")
+            if tag:
+                print(f"  [{tag}] {len(frames)} frames")
+            return frames
+
+        print("# init handshake"); await w("010000"); await w("010131826700")
+        await drain(2.0, False, "init")
+
+        print("# 0x02 with KNOWN-GOOD real cursor + flag 00"); await w(f"0200{GOOD_CURSOR}000100")
+        await drain(1.5, False, "02-realcursor"); await w("070000"); await drain(3.0, True, "fetch")
+
+        print("# 0x02 with 0xFFFFFFFF (SYNC_ALL)"); await w("0200ffffffff000100")
+        await drain(1.5, False, "02-syncall"); await w("070000"); await drain(3.0, True, "fetch")
+
+        print("# poll 95 00 00"); await w("950000"); await drain(1.5, False, "poll")
+
+        # Only sweep flags if data commands actually responded above.
+        print("# flag sweep (real cursor)")
+        for flag in range(0, 8):
+            await w(f"0200{GOOD_CURSOR}{flag:02x}0100"); await drain(0.8, False)
+            await w("070000"); frames = await drain(2.5, True)
+            ops = collections.Counter(b[0] for b in frames)
+            s4c = b"".join(b[3:-1] for b in frames if b[0] == 0x4C)
+            recs = [s4c[i:i+23] for i in range(0, len(s4c), 23) if len(s4c[i:i+23]) == 23]
+            nonact = [r for r in recs if not (r[8] in (0x12, 0x13) or 0x57 <= r[8] <= 0x63)]
+            print(f"  flag={flag:#04x} ops={ {hex(k): v for k, v in ops.items()} } 4c={len(recs)} nonact={len(nonact)}")
+            for r in nonact[:6]:
+                print(f"      NONACT {r.hex()} [8]={r[8]:#04x}")
+
+        await client.stop_notify(ble.NOTIFY_CHAR)
+    print("\nDone.")
+
+
+asyncio.run(main())

--- a/desktop/scan_smp.py
+++ b/desktop/scan_smp.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Scan a btsnoop_hci.log for BLE SMP (pairing/bonding) PDUs + encryption-change events.
+
+Tells us whether the ring's "activation" is a fresh LE-SC bond (SMP PairingRequest at login)
+vs. just re-encryption from a stored LTK (no new pairing). SMP rides L2CAP CID 0x0006.
+
+Usage: python3 scan_smp.py captures/login_activate_20260616_btsnoop.log
+"""
+from __future__ import annotations
+import struct, sys
+from datetime import datetime, timezone, timedelta
+
+# btsnoop microsecond epoch → unix: subtract microseconds from 0000-01-01 to 1970-01-01.
+BTSNOOP_EPOCH_DELTA = 0x00dcddb30f2f8000
+LOCAL = datetime.now().astimezone().tzinfo
+
+SMP_OP = {
+    0x01: "PairingRequest", 0x02: "PairingResponse", 0x03: "PairingConfirm",
+    0x04: "PairingRandom", 0x05: "PairingFailed", 0x06: "EncryptionInformation(LTK)",
+    0x07: "MasterIdentification", 0x08: "IdentityInformation", 0x09: "IdentityAddrInfo",
+    0x0a: "SigningInformation", 0x0b: "SecurityRequest", 0x0c: "PairingPublicKey",
+    0x0d: "PairingDHKeyCheck", 0x0e: "KeypressNotification",
+}
+
+def ts_local(us: int) -> str:
+    unix_us = us - BTSNOOP_EPOCH_DELTA
+    try:
+        return datetime.fromtimestamp(unix_us / 1e6, LOCAL).strftime("%H:%M:%S")
+    except Exception:
+        return "??"
+
+def main() -> None:
+    path = sys.argv[1]
+    with open(path, "rb") as f:
+        hdr = f.read(16)
+        if not hdr.startswith(b"btsnoop\x00"):
+            print("not a btsnoop file"); return
+        # datalink type at hdr[12:16]
+        events = []
+        hci_cmd_pairing = 0
+        while True:
+            rh = f.read(24)
+            if len(rh) < 24:
+                break
+            orig_len, incl_len, flags, drops, ts = struct.unpack(">IIIIq", rh)
+            pkt = f.read(incl_len)
+            if len(pkt) < incl_len or not pkt:
+                break
+            # H4: first byte = type (0x01 cmd, 0x02 ACL, 0x04 event). Some snoops omit it for
+            # ACL and use flags for type; handle the common H4-with-type case.
+            t = pkt[0]
+            body = pkt[1:]
+            if t == 0x02 and len(body) >= 8:  # ACL data
+                # body: handle(2) + total_len(2) + l2cap_len(2) + cid(2) + payload
+                cid = struct.unpack("<H", body[6:8])[0]
+                if cid == 0x0006 and len(body) >= 9:  # SMP
+                    op = body[8]
+                    events.append((ts, "SMP", SMP_OP.get(op, f"0x{op:02x}"), flags & 1))
+            elif t == 0x04 and len(body) >= 2:  # HCI event
+                evt = body[0]
+                if evt == 0x08:  # Encryption Change
+                    events.append((ts, "HCI", "EncryptionChange", 0))
+                elif evt == 0x3e:  # LE Meta
+                    sub = body[2] if len(body) > 2 else 0
+                    if sub == 0x05:  # LE Long Term Key Request
+                        events.append((ts, "HCI", "LE_LTK_Request", 0))
+
+    if not events:
+        print("No SMP / encryption events found."); return
+    print(f"{path}: {len(events)} SMP/encryption events\n")
+    pairings = [e for e in events if e[2] == "PairingRequest"]
+    print(f"PairingRequests (fresh bonds): {len(pairings)}  at "
+          + ", ".join(ts_local(e[0]) for e in pairings))
+    encs = [e for e in events if e[2] == "EncryptionChange"]
+    print(f"EncryptionChange events: {len(encs)}  "
+          + ("(re-encrypt from stored LTK each reconnect)" if encs else ""))
+    print(f"\nAll SMP/enc events ({'dir 1=rx' }):")
+    last_t = None
+    for ts, kind, name, d in events:
+        gap = ""
+        if last_t is not None and ts - last_t > 5_000_000:
+            gap = f"   (+{(ts-last_t)/1e6:.0f}s gap)"
+        print(f"  {ts_local(ts)}  {kind:4} {name:28} {'rx' if d else 'tx'}{gap}")
+        last_t = ts
+
+if __name__ == "__main__":
+    main()

--- a/docs/HANDOFF_MACOS_IOS.md
+++ b/docs/HANDOFF_MACOS_IOS.md
@@ -50,14 +50,37 @@ CoreBluetooth notes:
 - Background BLE sync needs the `bluetooth-central` background mode + state
   restoration if you want sync while the app is suspended.
 
-## HealthKit (Phase 4)
-- Add HealthKit capability; set `NSHealthShareUsageDescription` and
-  `NSHealthUpdateUsageDescription` in Info.plist.
-- Request write auth per type, then save samples with the **device's own
-  timestamps** so history backfills correctly. Dedup via the per-metric sync cursor
-  + a stable bundle id. Full type table: `docs/HEALTHKIT_MAPPING.md`.
-- Gotchas already noted there: HealthKit stores **SDNN** (not RMSSD); sleep is many
-  per-stage `sleepAnalysis` category samples, not one record.
+## HealthKit (Phase 4) — already built; gated on a paid account
+
+The write path is complete: `HealthKitWriter` (auth + per-type units), `LocalStore`
+(cursor dedup, backfill/incremental), `BulkSleep.samples`/`sleepSegments`, wired in
+`RingSession` + `ContentView`. Info.plist already has the `NSHealth*UsageDescription`
+strings. The **only** missing piece is the HealthKit entitlement, which **requires a
+paid Apple Developer Program membership** — a free personal team cannot provision it
+(the app still builds/runs on a free team, but HealthKit auth no-ops at runtime).
+
+### Turn it on when you have the paid account
+1. Join the Apple Developer Program ($99/yr); add your Apple ID to Xcode.
+2. Generate the project WITH the entitlement (one command, no YAML edit):
+   ```
+   cd ios
+   HEALTHKIT_ENTITLEMENTS=OpenRingConn/OpenRingConn.entitlements xcodegen generate
+   ```
+   (Unset = free-team default, no entitlement. The flag bakes
+   `OpenRingConn/OpenRingConn.entitlements` — which sets `com.apple.developer.healthkit` —
+   into `CODE_SIGN_ENTITLEMENTS`.)
+3. Open `OpenRingConn.xcodeproj` → OpenRingConn target → Signing & Capabilities → pick
+   your **Team** (sets `DEVELOPMENT_TEAM`). Automatic signing registers the App ID
+   `com.openringconn.app` and enables the HealthKit capability for it.
+4. Build+run on the iPhone. In the app: **Authorize Apple Health** (grant all types) →
+   **Sync history** → **Write to Apple Health**.
+5. Open **Bevel** — it reads HR / HRV / SpO2 / sleep from Apple Health.
+
+Notes: HealthKit stores **SDNN** (we write the ring's RMSSD value there — that's the
+number Bevel shows). Sleep is many per-stage `sleepAnalysis` category samples. The
+experimental Deep/REM staging is display-only and NOT written to Health (only the coarse
+inBed/asleep/awake segments are). Skin temp is unresolved (cloud-derived; issue #12).
+Full type table: `docs/HEALTHKIT_MAPPING.md`.
 
 ## Definition of done per phase
 See `docs/ROADMAP.md` "Exit" lines. Phase 3 exit: the iOS app pulls the same data

--- a/docs/HANDOFF_MACOS_IOS.md
+++ b/docs/HANDOFF_MACOS_IOS.md
@@ -61,14 +61,13 @@ paid Apple Developer Program membership** — a free personal team cannot provis
 
 ### Turn it on when you have the paid account
 1. Join the Apple Developer Program ($99/yr); add your Apple ID to Xcode.
-2. Generate the project WITH the entitlement (one command, no YAML edit):
+2. In `ios/project.yml`, **uncomment the `entitlements:` block** under the OpenRingConn
+   target (it's right above `settings:`), then regenerate:
    ```
-   cd ios
-   HEALTHKIT_ENTITLEMENTS=OpenRingConn/OpenRingConn.entitlements xcodegen generate
+   cd ios && xcodegen generate
    ```
-   (Unset = free-team default, no entitlement. The flag bakes
-   `OpenRingConn/OpenRingConn.entitlements` — which sets `com.apple.developer.healthkit` —
-   into `CODE_SIGN_ENTITLEMENTS`.)
+   (Do NOT set `CODE_SIGN_ENTITLEMENTS` on a free team — it breaks device launch with a
+   pre-main libxpc crash. Only add the entitlement once you actually have the paid team.)
 3. Open `OpenRingConn.xcodeproj` → OpenRingConn target → Signing & Capabilities → pick
    your **Team** (sets `DEVELOPMENT_TEAM`). Automatic signing registers the App ID
    `com.openringconn.app` and enables the HealthKit capability for it.

--- a/docs/HEALTHKIT_MAPPING.md
+++ b/docs/HEALTHKIT_MAPPING.md
@@ -10,7 +10,7 @@ device's own timestamps (so historical sync backfills correctly).
 | Resting heart rate | `.restingHeartRate` | Quantity | count/min | daily, derived on-device (sleep mean → low-activity floor); see notes |
 | HRV (RMSSD) | `.heartRateVariabilitySDNN` | Quantity | ms | ring reports **RMSSD**; written into the SDNN field and **tagged via metadata** (no fake conversion) — see notes |
 | Blood oxygen (SpO₂) | `.oxygenSaturation` | Quantity | % (0–1.0) | HealthKit wants a fraction |
-| Skin / sleeping-wrist temperature | `.appleSleepingWristTemperature` | Quantity | °C | sleep-scoped: temp is captured only in the nightly window, so this (not `.bodyTemperature`) is correct — see notes |
+| Skin / sleeping-wrist temperature | `.basalBodyTemperature` | Quantity | °C | sleep-scoped writable type; the ideal `.appleSleepingWristTemperature` is Apple-computed/read-only for third parties — see notes |
 | Respiratory rate | `.respiratoryRate` | Quantity | count/min | |
 | Steps | `.stepCount` | Quantity | count | cumulative; avoid double-counting with phone |
 | Active energy | `.activeEnergyBurned` | Quantity | kcal | |
@@ -33,14 +33,24 @@ device's own timestamps (so historical sync backfills correctly).
 - **No HealthKit on desktop/macOS.** This mapping is only realized in the iOS app;
   the desktop workbench just dumps to SQLite/CSV for validation.
 
-### Temperature → `.appleSleepingWristTemperature` (#29)
+### Temperature → `.basalBodyTemperature` (#29)
 
 OpenRingConn only captures skin temperature during the nightly sleep window
-(`RingSession` gates temp frames to the detected/scheduled night). That makes
-`.appleSleepingWristTemperature` (iOS 16+; deployment target is iOS 17) the correct
-destination — it's the sleep-scoped wrist-temp type Apple's own sleep apps and Bevel's
-wrist-temp baseline read. `.bodyTemperature` is a clinical oral/core type; writing
-skin-temp values (~5 °C below core) there would corrupt that chart. Values stay in °C.
+(`RingSession` gates temp frames to the detected/scheduled night), so it belongs in a
+rest-oriented type — NOT clinical `.bodyTemperature`, whose oral/core chart a skin reading
+(~5 °C below core) would corrupt.
+
+The *ideal* home is `.appleSleepingWristTemperature` (what Apple's own sleep apps and
+Bevel's wrist-temp baseline read), but that type is **Apple-computed and read-only for
+third-party apps**: a `save()` of it would fail, and — worse — listing it in the
+`toShare` set of `requestAuthorization` raises an Obj-C `NSInvalidArgumentException`
+("Authorization to share the following types is disallowed"), which crashes the auth
+flow or, once swallowed by the call site's `try?`, silently disables writeback for *every*
+metric. So we write the writable, rest-scoped **`.basalBodyTemperature`** instead
+(`HealthKitWriter.quantityType(for: .temperature)`), and `requestAuthorization` is
+hardened to drop the temperature type rather than poison the whole share request if it is
+ever refused. Trade-off: third-party apps simply cannot populate the sleeping-wrist chart,
+so a wrist-temp baseline reader won't see ring temperature there. Values stay in °C.
 
 ### HRV: RMSSD stored in the SDNN field, labeled via metadata (#37)
 

--- a/docs/HEALTHKIT_MAPPING.md
+++ b/docs/HEALTHKIT_MAPPING.md
@@ -7,10 +7,10 @@ device's own timestamps (so historical sync backfills correctly).
 | RingConn metric | HealthKit type | Kind | Unit | Notes |
 |---|---|---|---|---|
 | Heart rate | `HKQuantityType(.heartRate)` | Quantity | count/min | live + history |
-| Resting heart rate | `.restingHeartRate` | Quantity | count/min | daily, derived |
-| HRV (RMSSD) | `.heartRateVariabilitySDNN` | Quantity | ms | HealthKit stores **SDNN**, not RMSSD — convert or store SDNN if the ring reports it |
+| Resting heart rate | `.restingHeartRate` | Quantity | count/min | daily, derived on-device (sleep mean → low-activity floor); see notes |
+| HRV (RMSSD) | `.heartRateVariabilitySDNN` | Quantity | ms | ring reports **RMSSD**; written into the SDNN field and **tagged via metadata** (no fake conversion) — see notes |
 | Blood oxygen (SpO₂) | `.oxygenSaturation` | Quantity | % (0–1.0) | HealthKit wants a fraction |
-| Skin / body temperature | `.bodyTemperature` or `.appleSleepingWristTemperature` | Quantity | °C | wrist-temp type is sleep-scoped |
+| Skin / sleeping-wrist temperature | `.appleSleepingWristTemperature` | Quantity | °C | sleep-scoped: temp is captured only in the nightly window, so this (not `.bodyTemperature`) is correct — see notes |
 | Respiratory rate | `.respiratoryRate` | Quantity | count/min | |
 | Steps | `.stepCount` | Quantity | count | cumulative; avoid double-counting with phone |
 | Active energy | `.activeEnergyBurned` | Quantity | kcal | |
@@ -32,3 +32,49 @@ device's own timestamps (so historical sync backfills correctly).
   Decide per-metric whether the ring already reports it or we derive it.
 - **No HealthKit on desktop/macOS.** This mapping is only realized in the iOS app;
   the desktop workbench just dumps to SQLite/CSV for validation.
+
+### Temperature → `.appleSleepingWristTemperature` (#29)
+
+OpenRingConn only captures skin temperature during the nightly sleep window
+(`RingSession` gates temp frames to the detected/scheduled night). That makes
+`.appleSleepingWristTemperature` (iOS 16+; deployment target is iOS 17) the correct
+destination — it's the sleep-scoped wrist-temp type Apple's own sleep apps and Bevel's
+wrist-temp baseline read. `.bodyTemperature` is a clinical oral/core type; writing
+skin-temp values (~5 °C below core) there would corrupt that chart. Values stay in °C.
+
+### HRV: RMSSD stored in the SDNN field, labeled via metadata (#37)
+
+The ring reports HRV as **RMSSD** (`BulkSleep` / `HRV.rmssd`), but HealthKit only has a
+single HRV field, `.heartRateVariabilitySDNN`. RMSSD and SDNN are **not** related by a
+fixed constant (their ratio depends on the RR spectrum), so we do **not** apply a made-up
+conversion. Instead each HRV sample is written to the SDNN field with metadata
+`OpenRingConnHRVStatistic = "RMSSD"` (`HealthKitWriter.metadata(for:)`), so the value is
+honest and a reader can tell which statistic it actually is. If a future capture shows the
+ring also reports true SDNN, switch to writing that directly and drop the tag.
+
+### Resting HR: derived daily, idempotent (#18, #37)
+
+The ring does not transmit resting HR; `OpenRingKit.RestingHR` derives a daily value:
+preferred = mean HR across the night's `asleep*` segments; fallback = the lowest sustained
+(5-min rolling-mean) HR, the same basis Apple Health uses, so the values sit side by side.
+`HealthKitWriter.flushRestingHR` writes one `.restingHeartRate` sample per day, anchored at
+start-of-day, finalizing a day only once it's ~12 h old (so a pre-dawn sync can't freeze a
+partial-night value while last night's RHR still lands by midday).
+
+### Calories: passive (BMR) + active (TRIMP), idempotent (#37)
+
+`flushToHealth` also writes energy: **passive** = hourly BMR (`Calories.bmrKcalPerHour`) to
+`.basalEnergyBurned`, one sample per completed hour; **active** = the day's Edwards-TRIMP
+kcal (`Calories.activeKcal`) to `.activeEnergyBurned`, written as the delta over what was
+already written today (HealthKit SUMS energy, so deltas land the running total). Active
+energy needs dense HR (Edwards TRIMP requires ≥10 min of readings), so it's ~0 on sparse
+auto-measure days and meaningful during live monitoring. Body inputs (age/weight/height/sex)
+come from the user profile; the ring transmits none of them.
+
+### Idempotency for derived writes
+
+Raw samples and sleep dedupe through the LocalStore sync cursor. The **derived** writes
+above are not stored samples, so each carries its own high-water mark in `UserDefaults`
+(resting-HR day, basal next-hour, active-energy day + written-kcal). Marks advance only after
+a confirmed save and are shared across the foreground + background writer instances, so
+repeated foreground/background syncs never double-write.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -156,11 +156,22 @@ in the HR-only capture). First sample is a warm-up sentinel (byte[2] ≈ 8); tre
 Page: `[0]`=`0x47` · `[1]`=`00` · **`[2]`=remaining-RECORD countdown** (−5/full page,
 0 on last; e.g. `1c 17 12 0d 08 03 00`) · body = N×**47-byte records** · `[last]`=XOR
 (valid 11/11). 🟢
-Record (47 B): `[0]`=`0x0c` · `[1:4]`=BE counter **+0x0384/rec** (cursor space) 🟢 ·
-`[4:6]`=16-bit field drifting with baseline 🟡 · `[6:9]`=usually `00 00 00`, else
-per-record flag/event 🟡 · `[9:47]`=**38 B ≈ 30 samples × 10-bit BE** (self-consistent
-but unproven; 10-vs-12-bit ambiguous) 🟡. Waveform is flat/settling when idle,
-oscillatory (pulsatile-like) when worn — not globally monotonic.
+Record (47 B): `[0]`=`0x0c` · `[1:4]`=BE counter **+0x0384/rec = 900 s** (cursor space) 🟢 ·
+`[4:6]`=16-bit baseline (`[4]`=`02` const, `[5]` drifts) 🟡 · `[6:9]`=usually `00 00 00`,
+else per-record flag/event 🟡 · `[9:47]`=**38 B = 30 × 10-bit big-endian samples**
+(300 bits + 4 zero pad-bits) 🟢.
+
+**Bit-width resolved (10-bit), 2026-06-13 capture.** Decoding `[9:47]` as 10-bit BE
+gives the lowest sample-to-sample jitter of all widths (0.32 vs 0.39–0.42 for 8/12/16)
+and clean pulsatile waveforms on worn records (counter `0c22…`). The 30 samples are
+**two interleaved channels × 15** (even/odd): splitting them lowers jitter further
+(0.13–0.15) and the two tracks are near-identical (e.g. `553/553 → 629/623 → 646/647`)
+— consistent with **red + IR PPG** (the pair SpO2's ratio-of-ratios needs; SpO2 itself
+lands in `0x4c[8]`, §5.3). 🟢
+Cadence: ~80 records span 20 days (very **sparse** — occasional optical snapshots, not a
+continuous trace); 30 samples per 900 s record ≈ 1/channel/min, so this is a
+perfusion/amplitude trend, not pulse-resolution waveform 🟡. Reproduce with
+`desktop/decode_ppg.py`.
 
 ### 5.3 `0x4c` — bulk activity/sleep page (ACK each with `cc 00 00`)
 Page: `[0]`=`0x4c` · `[1]`=`00` · **`[2]`=remaining-RECORD countdown** (−6/page) ·
@@ -195,8 +206,14 @@ time (no 12 h offset in this capture; bears on §5.6/§6.6). Reassemble + decode
   matching the app's "lowest 93 % around 2:30–3 am" — the decisive temporal anchor.
 - `[6]` (1–10, ~9) and `[7]` (~120) unresolved 🟡 — candidate signal-quality / pulse
   amplitude. `[9]`≈`0x0a` and `[22]` (low-nibble `4`, high-nibble varies) flags 🟡.
-- **Respiratory rate (15 bpm) and skin temp (35.88 °C) are NOT in the per-epoch record**
-  — no byte matches; they are derived/summary values (separate frame or app-computed) 🔴.
+- **Respiratory rate (15 bpm) and skin temp (35.88 °C) are NOT in ANY frame this
+  sync captured** 🔴 — checked every byte and 16-bit field of the `0x4c`/`0x47`/`0x10`/
+  `0x87`/`0x81`/`0x15` frames: no stable `0x0f` (RR) and no temp-scaled value (`358`/`359`
+  = 0.1 °C, `3588` = 0.01 °C, `966`/`9658` = °F all absent). RR is most likely **app-derived**
+  (from PPG/HRV — respiratory sinus arrhythmia); skin temp is a real sensor reading, so it
+  is probably fetched by a **command this capture never issued** (candidate: the 🔴
+  secondary service `0x0900`, §1) or lives in a daily-summary record we haven't pulled.
+  A capture that opens the app's temperature screen / triggers a temp refresh is needed.
 
 **`[10:15]` = 5× per-30 s motion/activity counts** 🟢(role)/🟡(unit). Over a real night
 they decay from `~14 15 15 14` (≈20, awake/settling at 23:09) to the `01 01 01 01 01`

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -363,19 +363,33 @@ is the low byte of the final cursor). `[0:3]`=`50 00 00`, then 6-byte entries
 synced range, e.g. `50 00 00 | 15 12 0c22aae4 | 15 12 0c22acb5`. A 21-byte variant
 is undecoded 🔴.
 
-### 5.6 `0x02` sync cursor — TIMESTAMP 🟢 CONFIRMED
+### 5.6 `0x02` sync cursor — TIMESTAMP 🟢 CONFIRMED (issue #3 + #5 closed)
 Host write `02 00 <cursor:4 BE> <flag:1> 01 00` → `82 00 00 82`.
 **cursor = 4-byte BE seconds since epoch `1577793600` (2019-12-31 12:00:00 UTC)** —
 3 (time,value) pairs + 2 in-frame cross-checks agree to <0.34 s; 1/sec, monotonic;
 same epoch as the record counters. Build current: `floor(unix_utc) − 1577793600`,
 BE, into `02 00 <BE4> 00 01 00`; `FF FF FF FF` = "everything" while backlog exists.
-The 12 h offset vs 2020-01-01 is byte-confirmed but its **cause** (local-tz vs
-firmware epoch vs AM/PM) is unresolved from one timezone 🟡. `flag` byte[6]
-(`00`/`03`) meaning unknown 🟡.
+
+**No 12 h offset in decoded data 🟢 (issue #5 closed, `morning_temp_20260615`).**
+The epoch `1577793600` is 2019-12-31 **12:00:00** UTC (noon, not midnight): the 12 h
+"offset vs 2020-01-01" is simply the epoch constant value, NOT a decode error. Verified
+across **20 independent sync-open events** spanning 2026-06-13 21:52 UTC through
+2026-06-15 09:11 UTC: decoded cursor time matches capture wall-clock to < 0.5 s in
+every case (max observed delta 0.5 s, median 0.2 s). No timezone-dependent offset.
+`flag` byte[6] (`00`/`03`) meaning unknown 🟡.
 
 ### 5.7 `0x81` — status replies (← `0x01`)
 **`81 00 XX YY`** (← `01 00 00`): `[2]` is the only varying byte, full 8-bit range,
->100 → **not battery %**; likely a session token 🔴.
+>100 → **not battery %**; per-session nonce / ring-state token 🟡 (issue #4).
+
+**Byte[2] analysis, 20 BLE sessions, `morning_temp_20260615_btsnoop.log` 🟢:**
+Values span 31–249 (range=218; full 8-bit), definitively not battery % (values >100
+common: 176, 218, 216, 203, 227, 249). Non-monotonic within an hour: 7 consecutive
+sessions at 13:28–13:52 UTC return 31→120→227→63→249→188→157→128 — no slow battery-like
+drift. Two connections using recycled handle 0x002 (separated by >15 h) return
+different values (176 vs 148). Consistent with **per-session ring-state assignment** or
+a random nonce; source unknown 🔴. Settle with a long wear/discharge battery test.
+
 **`81 01 …`** (38 B, ← `01 01 <nonce>`): mostly constant; notable — `[27:32]`=
 `21 49 ac <XX> f4` (4/5 const, device-id-like) · `[34:36]`=16-bit monotonic counter
 ≈ 1/sec (30→1475→9045 over 3 sessions) 🟡. The `01 01 <3-B nonce>` arg is per-session
@@ -394,13 +408,21 @@ Each names the single capture that converts a 🟡/🔴 field into a decoded met
    a separate summary frame). Stages are app-computed, not on the wire. (Issue #7/#9.)
 3. ✅ **Counter→wall-clock — PINNED.** Counter is seconds (§5.6 epoch); the bulk-record
    step `+0x96` = **150 s**, so each `0x4c` record is a 2.5-min epoch and `0x47` records
-   span `0x0384`=900 s. Cross-checked: last session ends 6 min before the sync. (Issue #3.)
+   span `0x0384`=900 s. Cross-checked: last session ends 6 min before the sync.
+   `morning_temp_20260615` re-confirms: 28/29 `0x4c` steps=150 (1×151 rounding), 19/19
+   `0x47` steps=900, across 752 `0x4c` and 128 `0x47` records. (Issue #3 ✅ closed.)
 4. **`0x10`/`0x87` `[6:8]`/`[15]`:** sync after a known wear interval + app UI/battery
    screenshot → maps A/B to record counts and `[15]` to a real quantity.
-5. **`0x81` token vs battery:** repeat `01 00 00` within a session & across battery
-   levels → is `81 00 [2]` a token or battery; disambiguate `81 01 [34:36]`.
-6. **`0x02` epoch cause:** a capture incl. the clock-SET command, or a sync from a
-   phone set to UTC → resolves the 12 h offset.
+5. ✅ **`0x81 00` byte[2] — NOT battery; per-session nonce 🟡.** `morning_temp_20260615`
+   shows 20 sessions, byte[2] spans 31–249, non-monotonic, exceeds 100% repeatedly.
+   Definitively not battery %. Likely a per-session ring-state nonce (source unknown 🔴).
+   To settle: capture `01 00 00` responses across a full battery discharge cycle from 100%
+   to <20% — if byte[2] shows no correlation with battery level, the nonce hypothesis is
+   confirmed. (Issue #4 partially answered — battery ruled out; nonce still 🔴.)
+6. ✅ **`0x02` epoch / 12 h offset — RESOLVED.** The epoch is noon UTC on 2019-12-31;
+   the "12 h" is the epoch constant, not a decode error. 20 sync-open events confirm
+   decoded UTC matches capture wall-clock to < 0.5 s. No 12 h offset in decoded data.
+   (Issue #5 ✅ closed; see §5.6.)
 7. **Session nonce source:** correlate `01 01 <nonce>` against prior `0x81`/`0x10`
    fields. *(Not required — nonce is arbitrary; §4.)*
 8. **Skin temp + its transport:** temp is measured only at night yet is absent from a full

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -285,10 +285,18 @@ Baseline `01` = "still", not "unworn".
 `0x10` ← `d0 00 00` (also spontaneous ~30–60 s); `0x87` ← `07 00 00`. **Identical
 layout** (only `[0]` respid differs; `0x87` body == `0x10` body) → shared descriptor,
 XOR-valid. `[1]`=per-session marker (`4e`→`5c`; same value in `0x81 01`) 🟡 · `[2]`=
-state enum `01–04` (not a counter) 🟡 · `[6:8]`/`[8:10]`=16-bit A/B with validity
-flag byte (`00`+`fd` cold, `01`+value once data exists) 🟡 · `[15]`=declines over an
-evening but **not plain battery** 🟡 · `[17]`=`ff` idle; **non-`ff` precedes a bulk
-stream → "data follows"** 🟡.
+state enum `01–04` (not a counter) 🟡 · **`[4:6]`=STEP COUNT (16-bit BE)** 🟢 · `[6:8]`/
+`[8:10]`=16-bit A/B with validity flag (grow with activity → active-secs/calories? 🟡) ·
+`[15]`=declines over an evening but **not plain battery** 🟡 · `[17]`=`ff` idle;
+**non-`ff` precedes a bulk stream → "data follows"** 🟡.
+
+**`[4:6]` = the ring's onboard step count** 🟢 (live test 2026-06-14). After clearing
+the official app and forcing a from-scratch ring re-sync, the app showed **81 steps** and
+`[4:6]` in the descriptor frames read **exactly 81** (`00 51`); it is `0` overnight (no
+steps) and climbs through the day (6→24→35→79→80→81). NOTE this is the **ring's own
+count**, which differs from the app's normal display (cloud-aggregated daily total, e.g.
+917 earlier same day) — search for the *ring's* value, not the app's. Decoded by
+`OpenRingKit.DeviceStatus.steps`.
 
 ### 5.5 `0x50` — end-of-history cursor report (NO XOR trailer) 🟡
 Spontaneous after the last bulk page. Distinct class: **no XOR trailer** (last byte

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -288,6 +288,25 @@ Baseline `01` = "still", not "unworn".
 > 🟢 (app-aligned, §6.2). Open: `[6]`/`[7]` semantics, the activity-epoch `[15:22]` payload,
 > and skin temp + RR (not in this capture — see above).
 
+> **2026-06-15 first-morning sync, ground-truthed (`captures/morning_temp_20260615`).**
+> Captured the official app's first sync of the day via `adb bugreport`. App readout for the
+> 2026-06-14 night (ground truth): asleep **7:37**, in bed **9:33**, efficiency **80 %**,
+> awake **43 m**, REM **1:42**, light **4:45**, deep **1:10**, temp avg **96.40 °F**
+> (35.78 °C), baseline **96.73 °F** (35.96 °C), deviation **−0.32 °F**, RR **15.1 bpm**.
+> - **Temp + RR still absent from the wire**, now tested against the *exact* ground-truth
+>   values: searched every frame/handle for 96.40/96.73 °F and 35.78/35.96 °C in ×1/×10/×100
+>   (both scales) and RR 15.1 (`00 97`/`0f`) → **0 genuine matches**. A per-byte and BE-16
+>   scan of all 190 `0x4c` epochs found **no temp-like field** (`byte[1]=0x24` is just the
+>   counter high byte). So temp/RR are not in the passive activity/sleep/PPG drain. 🔴
+> - **New frames this capture:** opcode **`0x91`** (app→ring, `91 00 00`) ACKs a ring-pushed
+>   notification **`0x11`** (`11 00 0N 55`, N increments) — an event-counter handshake, no
+>   payload. `0x0805` carries only `01 00` control writes. Neither is temp.
+> - Ring owner confirms **temp does come over BLE** → it rides a command/flag the normal
+>   sync never sends (prime suspect: untried sync-open flag `02 00 <cursor> 01|02|04 01 00`),
+>   or a separate fetch outside the snoop ring-buffer window. **Resolved only by active
+>   probing** (in progress). HR/HRV/SpO2 decode re-confirmed (sleep window low-HR 48–58 bpm,
+>   SpO2 dip to 89 %). Sleep stages remain app-computed (no stage byte) — Phase-5 classifier.
+
 ### 5.4 `0x10` / `0x87` — fixed 19-byte descriptor
 `0x10` ← `d0 00 00` (also spontaneous ~30–60 s); `0x87` ← `07 00 00`. **Identical
 layout** (only `[0]` respid differs; `0x87` body == `0x10` body) → shared descriptor,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -178,6 +178,13 @@ ground-truth captures (§6).**
 in the HR-only capture). First sample is a warm-up sentinel (byte[2] ≈ 8); treat
 < ~30 as "not locked".
 
+**Poll cadence matters** 🟢 (btsnoop_hr.log): the ring emits one HR sample **~every
+2 s**, and the windowed average needs undisturbed time to climb off the warm-up `8`.
+The official app waits ~10 s after `06 01 00`, then polls `95 00 00` **request/response
+at ~2 s**. Polling faster (e.g. ~700 ms, 3×/sample) keeps **resetting** the HR window so
+byte[2] stays pinned at `8` — the cause of "stuck warming up". SpO2's byte[14] is robust
+to fast polling, so only HR exhibits this. Poll HR no faster than ~2 s.
+
 **Enter-live sequence** 🟢 (FR02.018 capture): after the connect-time history drain,
 the app sends **`d0 00 00` → `06 01 00` → `07 00 00`**, then polls `95 00 00` ~1/s. The
 `d0 00 00` is required — without it the ring stays in bulk mode and emits no `15 00` HR

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -476,9 +476,36 @@ the `0x10`/`0x87` descriptor `[1]`, §5.4 🟢 — already decoded.)
 
 **`81 01 …`** (38 B, ← `01 01 <nonce>`): mostly constant; notable — `[27:32]`=
 `21 49 ac <XX> f4` (4/5 const, device-id-like) · `[34:36]`=16-bit monotonic counter
-≈ 1/sec (30→1475→9045 over 3 sessions) 🟡. The `01 01 <3-B nonce>` arg is per-session
-and **arbitrary** (ring accepts any value — see §4); the constant `21 49 ac _ f4`
-block is a candidate nonce source 🔴.
+≈ 1/sec (30→1475→9045 over 3 sessions) 🟡.
+
+### 5.8 Per-connection AUTH (the activation gate) 🟢 + heartbeat + bonding — issue #54
+⚠️ **CORRECTION:** the `01 01 <3-byte nonce>` arg is **NOT arbitrary** — it is a deterministic
+**challenge→response auth**, and it is what "activates" the ring for streaming (🟢, confirmed
+2026-06-16 `login_activate_20260616`). Sequence every connect: host `01 00 00` → ring
+`81 00 <chal> <xor>`; host must answer `01 01 <f(chal)> 00`. `f` is a **256-entry keyed table
+over the 8-bit challenge** (NOT linear/XOR/LCG). 24 (chal→resp) pairs captured, zero collisions
+(`b0→31 82 67` recurs across sessions 12 h apart; the 2026-06-16 login used `e5→52 0b e1`). See
+`Command.knownAuthNonces`.
+
+**Why this is the "open the official app to activate" gate:** OpenRingConn hardcodes
+`01 01 31 82 67` (= `f(0xb0)`), correct only when the challenge is `0xb0`. When the ring is in a
+strict state it demands the right `f(chal)` for the issued challenge, so our wrong answer → no
+streaming; a logged-in official app answers correctly → the ring streams (and we ride along while
+it stays unlocked). **To be standalone, OpenRingConn must compute `f(chal)` — recover `f` from the
+official APK (`com.gdjztech.ringconn`); 24/256 entries known from captures is not enough.** This is
+LOGIN/auth-tied, **not** app-startup and **not** a re-bond (see bonding below).
+
+**Heartbeat 🟢:** ring→host `11 00 <ctr> <tok> <xor>` (~2.5 min idle; `ctr` resets to 01 per
+connection; `tok` = the session token also in `0x10[1]`; `[last]`=XOR). Host replies a constant
+`91 00 00` (does not echo). `0x10` telemetry streams on its own ~40/110 s timer regardless of the
+ACK. (OpenRingConn now ACKs it — `Command.heartbeatAck`.)
+
+**Bonding 🟢 — NO CLOUD KEY (resolves the Phase-1 make-or-break unknown):** the link is **LE Secure
+Connections "Just Works"** (ring IOcap=NoInputNoOutput), LTK generated **locally via ECDH** during
+a one-time pairing (seen once at 17:51:58; every reconnect since is re-encryption from the stored
+LTK — 25 EncryptionChange events, zero re-pairings, incl. across the 2026-06-16 login). So offline
+decoding is sound and HCI-snoop ATT is plaintext. CoreBluetooth auto-bonds; there is **no app-layer
+key exchange to replicate for the bond** — the replicable gate is the `f(chal)` auth above.
 
 ## 6. Ground-truth captures needed (prioritized)
 
@@ -507,8 +534,10 @@ Each names the single capture that converts a 🟡/🔴 field into a decoded met
    the "12 h" is the epoch constant, not a decode error. 20 sync-open events confirm
    decoded UTC matches capture wall-clock to < 0.5 s. No 12 h offset in decoded data.
    (Issue #5 ✅ closed; see §5.6.)
-7. **Session nonce source:** correlate `01 01 <nonce>` against prior `0x81`/`0x10`
-   fields. *(Not required — nonce is arbitrary; §4.)*
+7. **Auth function `f(challenge)` (issue #54 — the activation gate):** `01 01 <nonce>` is a
+   deterministic challenge→response, NOT arbitrary (§5.8). 24/256 entries known from captures;
+   recover the full `f` by decompiling the official APK (`com.gdjztech.ringconn`) — needed to make
+   OpenRingConn stream standalone (without the official app activating the ring).
 8. **Skin temp + its transport:** temp is measured only at night yet is absent from a full
    activity/sleep/PPG sync, from `0x0900`, and from a capture with the Temperature screen
    open (that screen reads cache, no BLE). **Mac active-probing is ruled out** — data

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -178,17 +178,36 @@ pull time (09:38) to <6 min — counter→wall-clock is right and lands on **dev
 time (no 12 h offset in this capture; bears on §5.6/§6.6). Reassemble + decode with
 `desktop/decode_bulk.py`.
 
-- **`[10:15]` = 5× per-30 s motion/activity counts** 🟢(role)/🟡(unit). Over a real
-  night they decay from `~14 15 15 14` (≈20, awake/settling at 23:09) to the `01 01 01
-  01 01` baseline (still/asleep by 23:37), and spike again at arousals/turns — i.e. the
-  per-epoch **stillness signal** Phase 5 `SleepDetection` needs (likely the IMU stream,
-  no separate `0x47` accel needed for staging). Baseline `01` = "still", not "unworn".
-- **`[15:22]` = 7-B per-epoch physiology** (HR / HRV / SpO2?) 🔴-values/🟡-role. Dense
-  every epoch during main sleep (23:37–01:34), then **sparse** (mostly the zero/idle
-  template with a non-zero spot-check every ~15 min) for the rest of the night — a
-  low-power sampling regime, not deep sleep. Zero ≠ asleep; zero = no measurement.
-- **`[8]` subtype**: `0x12` is the common epoch (idle alternates `12`/`13`); a
-  `0x5a–0x63` family recurs roughly every ~10–15 min as marker/summary epochs 🟡.
+**Two record layouts**, distinguished by `[8]`:
+- **Activity/awake epoch** `[8]=0x12`/`0x13`: physiology/activity in `[15:22]`, motion
+  in `[10:15]` elevated.
+- **Sleep-vitals epoch** `[8]=0x57–0x63` (87–99): per-epoch vitals in `[4:9]`, motion
+  `[10:15]` at `01` baseline, `[15:22]` ≈ zero.
+
+**Sleep-vitals fields — confirmed against the RingConn app's readout for the
+2026-06-13 night** (avg HR 68 / HRV 65 ms / SpO2 98 %, low 93 % ~02:30–03:00):
+- **`[4]` = heart rate (bpm)** 🟢. Sleep-window mean ~60, dips to 56–57 in deep-sleep
+  hours, rises to 66 at wake; evening (active) epochs read 83 — physiologically correct.
+  (Sleep mean < app's all-night avg 68 because the app average includes daytime.)
+- **`[5]` = HRV / RMSSD (ms)** 🟢. Mean 69, median 70 vs app 65; high beat-to-beat
+  spread (36–114) as expected for RMSSD.
+- **`[8]` = SpO2 (%)** 🟢. Mean 96, and the low cluster (89–93) lands at **02:32–03:07**,
+  matching the app's "lowest 93 % around 2:30–3 am" — the decisive temporal anchor.
+- `[6]` (1–10, ~9) and `[7]` (~120) unresolved 🟡 — candidate signal-quality / pulse
+  amplitude. `[9]`≈`0x0a` and `[22]` (low-nibble `4`, high-nibble varies) flags 🟡.
+- **Respiratory rate (15 bpm) and skin temp (35.88 °C) are NOT in the per-epoch record**
+  — no byte matches; they are derived/summary values (separate frame or app-computed) 🔴.
+
+**`[10:15]` = 5× per-30 s motion/activity counts** 🟢(role)/🟡(unit). Over a real night
+they decay from `~14 15 15 14` (≈20, awake/settling at 23:09) to the `01 01 01 01 01`
+baseline (still/asleep) and spike at arousals/turns — the per-epoch **stillness signal**
+Phase 5 `SleepDetection` needs (likely the IMU stream; no separate `0x47` accel needed).
+Baseline `01` = "still", not "unworn".
+
+> **Sleep stages (Awake/Light/Deep/REM) are not stored per-epoch** — no stage label byte
+> found. The ring streams raw HR/HRV/SpO2/motion and the **app computes** the hypnogram,
+> matching openwhoop's approach and our Phase 5 plan: compute stages in Swift from these
+> signals, don't expect them on the wire.
 
 > **Blocker to 🟢 on values:** assigning the 7 physiology bytes to HR/HRV/SpO2 needs the
 > RingConn app's timestamped per-epoch readout for the **same night** (§6.2 / issue #7).
@@ -235,11 +254,11 @@ block is a candidate nonce source 🔴.
 Each names the single capture that converts a 🟡/🔴 field into a decoded metric.
 1. **`0x47` → real PPG:** app's realtime/exported PPG trace recorded over the *same*
    window as a btsnoop sync → confirms bit-width, channel, counter time-unit.
-2. **`0x4c` → sleep/HR/HRV/SpO2 epochs:** ⏳ *capture obtained* — a real overnight sync
-   is in `captures/sleep_sync_btsnoop.log` (2026-06-13 night). Framing, 150 s epoch
-   cadence and the `[10:15]` motion channel are decoded (§5.3); **still needs** the app's
-   timestamped per-epoch HR/HRV/SpO2 + sleep-stage boundaries for that night to pin the
-   `[15:22]` payload bytes to units. (Issue #7.)
+2. ✅ **`0x4c` → sleep/HR/HRV/SpO2 epochs — DECODED.** `captures/sleep_sync_btsnoop.log`
+   (2026-06-13 night) aligned to the app's readout: sleep-vitals epoch `[4]`=HR,
+   `[5]`=HRV(ms), `[8]`=SpO2(%) confirmed (§5.3); `[10:15]`=motion. Remaining 🟡/🔴:
+   `[6]`/`[7]` semantics, and respiratory rate + skin temp (not in this record — likely
+   a separate summary frame). Stages are app-computed, not on the wire. (Issue #7/#9.)
 3. ✅ **Counter→wall-clock — PINNED.** Counter is seconds (§5.6 epoch); the bulk-record
    step `+0x96` = **150 s**, so each `0x4c` record is a 2.5-min epoch and `0x47` records
    span `0x0384`=900 s. Cross-checked: last session ends 6 min before the sync. (Issue #3.)

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -244,8 +244,14 @@ time (no 12 h offset in this capture; bears on §5.6/§6.6). Reassemble + decode
   spread (36–114) as expected for RMSSD.
 - **`[8]` = SpO2 (%)** 🟢. Mean 96, and the low cluster (89–93) lands at **02:32–03:07**,
   matching the app's "lowest 93 % around 2:30–3 am" — the decisive temporal anchor.
-- `[6]` (1–10, ~9) and `[7]` (~120) unresolved 🟡 — candidate signal-quality / pulse
-  amplitude. `[9]`≈`0x0a` and `[22]` (low-nibble `4`, high-nibble varies) flags 🟡.
+- **`[7]` = RESPIRATORY RATE × 8** 🟢 (ground-truthed 2026-06-15). On the asleep epochs,
+  `[7]/8` gives mean 15.2 vs the app's nightly **15.1**, and p5–p95 **14.6–16.0** vs the
+  app's reported low/high **14.5–16.1** — near-exact. RR IS per-epoch and single-night (no
+  model needed); earlier captures missed it only because the value (~120) was mistaken for
+  signal quality. Exact divisor ≈8.07; 8 is the natural 1/8-brpm fixed point. Decoded by
+  `BulkRecord.respiratoryRate`.
+- `[6]` (1–10, ~9) unresolved 🟡 — candidate signal quality. `[9]`≈`0x0a` and `[22]`
+  (low-nibble `4`, high-nibble varies) flags 🟡.
 - **Respiratory rate (15 bpm) and skin temp are NOT in ANY frame this sync captured** 🔴.
   Verified exhaustively: every byte and 16-bit field of the `0x4c`/`0x47`/`0x10`/`0x87`/
   `0x81`/`0x15` frames (no stable `0x0f` RR; no temp value at `358`/`359`=0.1 °C,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -166,10 +166,34 @@ oscillatory (pulsatile-like) when worn — not globally monotonic.
 Page: `[0]`=`0x4c` · `[1]`=`00` · **`[2]`=remaining-RECORD countdown** (−6/page) ·
 body = 6×**23-byte records** · `[last]`=XOR. 🟢
 Record (23 B): `[0]`=`0x0c` · `[1:4]`=BE counter **+0x96/rec** (cursor space) 🟢 ·
-`[8]`=subtype tag (idle alternates `12/13`) 🟢 · `[10:15]`=baseline `01 01 01 01 01` ·
-`[15:22]`=7-B payload (zero idle, dense when worn) 🟡 · `[22]`=trailer flags (idle
-`12→00`/`13→04`) 🟢. Idle/unworn template: `[4:7]=05 00 0c 00`, `[9]=0a`, `[10:14]=01×5`,
-`[15:21]=00×7` 🟢. Likely the per-epoch sleep/activity stream (role = inference).
+`[8]`=subtype tag 🟡 · `[9]`=small int (mostly `0a`) 🟡 · `[10:15]`=**5-channel motion**
+(see below) 🟢 · `[15:22]`=7-B per-epoch physiology payload 🟡 · `[22]`=trailer flags 🟡.
+Idle/unworn template: `[4:7]=05 00 0c 00`, `[9]=0a`, `[10:14]=01×5`, `[15:21]=00×7` 🟢.
+
+**+0x96 counter step = exactly 150 s** (the counter is seconds, §5.6) → **each record
+is a 150 s / 2.5-min epoch.** 🟢 Confirmed by `captures/sleep_sync_btsnoop.log`
+(FR02.018, full multi-day history sync, 470 records over 3 stored sessions). The last
+session decodes to **2026-06-13 23:09 → 06-14 09:32** and its end matches the bugreport
+pull time (09:38) to <6 min — counter→wall-clock is right and lands on **device-local**
+time (no 12 h offset in this capture; bears on §5.6/§6.6). Reassemble + decode with
+`desktop/decode_bulk.py`.
+
+- **`[10:15]` = 5× per-30 s motion/activity counts** 🟢(role)/🟡(unit). Over a real
+  night they decay from `~14 15 15 14` (≈20, awake/settling at 23:09) to the `01 01 01
+  01 01` baseline (still/asleep by 23:37), and spike again at arousals/turns — i.e. the
+  per-epoch **stillness signal** Phase 5 `SleepDetection` needs (likely the IMU stream,
+  no separate `0x47` accel needed for staging). Baseline `01` = "still", not "unworn".
+- **`[15:22]` = 7-B per-epoch physiology** (HR / HRV / SpO2?) 🔴-values/🟡-role. Dense
+  every epoch during main sleep (23:37–01:34), then **sparse** (mostly the zero/idle
+  template with a non-zero spot-check every ~15 min) for the rest of the night — a
+  low-power sampling regime, not deep sleep. Zero ≠ asleep; zero = no measurement.
+- **`[8]` subtype**: `0x12` is the common epoch (idle alternates `12`/`13`); a
+  `0x5a–0x63` family recurs roughly every ~10–15 min as marker/summary epochs 🟡.
+
+> **Blocker to 🟢 on values:** assigning the 7 physiology bytes to HR/HRV/SpO2 needs the
+> RingConn app's timestamped per-epoch readout for the **same night** (§6.2 / issue #7).
+> Structure, framing, epoch cadence and the motion channel are decoded; the payload
+> bytes are not yet pinned to units.
 
 ### 5.4 `0x10` / `0x87` — fixed 19-byte descriptor
 `0x10` ← `d0 00 00` (also spontaneous ~30–60 s); `0x87` ← `07 00 00`. **Identical
@@ -211,9 +235,14 @@ block is a candidate nonce source 🔴.
 Each names the single capture that converts a 🟡/🔴 field into a decoded metric.
 1. **`0x47` → real PPG:** app's realtime/exported PPG trace recorded over the *same*
    window as a btsnoop sync → confirms bit-width, channel, counter time-unit.
-2. **`0x4c` → sleep/HR/HRV/SpO2 epochs:** one fully app-logged night with timestamped
-   per-epoch values + session start/end → map the `+0x96` counter and payload bytes.
-3. **Counter→wall-clock:** two syncs a known gap apart (ring worn) → pins counter units.
+2. **`0x4c` → sleep/HR/HRV/SpO2 epochs:** ⏳ *capture obtained* — a real overnight sync
+   is in `captures/sleep_sync_btsnoop.log` (2026-06-13 night). Framing, 150 s epoch
+   cadence and the `[10:15]` motion channel are decoded (§5.3); **still needs** the app's
+   timestamped per-epoch HR/HRV/SpO2 + sleep-stage boundaries for that night to pin the
+   `[15:22]` payload bytes to units. (Issue #7.)
+3. ✅ **Counter→wall-clock — PINNED.** Counter is seconds (§5.6 epoch); the bulk-record
+   step `+0x96` = **150 s**, so each `0x4c` record is a 2.5-min epoch and `0x47` records
+   span `0x0384`=900 s. Cross-checked: last session ends 6 min before the sync. (Issue #3.)
 4. **`0x10`/`0x87` `[6:8]`/`[15]`:** sync after a known wear interval + app UI/battery
    screenshot → maps A/B to record counts and `[15]` to a real quantity.
 5. **`0x81` token vs battery:** repeat `01 00 00` within a session & across battery

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -307,6 +307,20 @@ Baseline `01` = "still", not "unworn".
 >   probing** (in progress). HR/HRV/SpO2 decode re-confirmed (sleep window low-HR 48–58 bpm,
 >   SpO2 dip to 89 %). Sleep stages remain app-computed (no stage byte) — Phase-5 classifier.
 
+> **2026-06-15 active probe from the Mac — BLOCKED at session-open (auth/nonce 🔴).**
+> Connected to the ring from the Mac (name-based discovery — macOS bleak can't match by MAC,
+> must scan by name prefix). Status works: `01 00 00`→`81`, `01 01 <x>`→`81 01`. But
+> **`02 00 FFFFFFFF <flag> 01 00` returns NO `82`** for any flag (`00/01/02/04/05/08`), and
+> `06 01 00`+`95 00 00` returns no `15` — the sync session never opens, no data flows. This
+> held even with a **previously-accepted** `01 01 31 82 67` (seen working at 21:52 and 10:33
+> the same day), so the `01 01` value **rotates/expires**; a stale one poisons the open. The
+> value never appears in any ring response (app-generated, not handed out) yet `31 82 67`
+> repeated across two sessions → likely a derived key, not random. **Conclusion:** Mac-side
+> metric probing (incl. the temp-flag hunt) is gated by the §4 session-open auth — must crack
+> the `01 01` derivation first, OR capture the official app's temp fetch (the app holds valid
+> auth). Temp is confirmed BLE-delivered but absent from the normal sync drain → its fetch is
+> a distinct, not-yet-triggered event.
+
 ### 5.4 `0x10` / `0x87` — fixed 19-byte descriptor
 `0x10` ← `d0 00 00` (also spontaneous ~30–60 s); `0x87` ← `07 00 00`. **Identical
 layout** (only `[0]` respid differs; `0x87` body == `0x10` body) → shared descriptor,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -206,14 +206,25 @@ time (no 12 h offset in this capture; bears on §5.6/§6.6). Reassemble + decode
   matching the app's "lowest 93 % around 2:30–3 am" — the decisive temporal anchor.
 - `[6]` (1–10, ~9) and `[7]` (~120) unresolved 🟡 — candidate signal-quality / pulse
   amplitude. `[9]`≈`0x0a` and `[22]` (low-nibble `4`, high-nibble varies) flags 🟡.
-- **Respiratory rate (15 bpm) and skin temp (35.88 °C) are NOT in ANY frame this
-  sync captured** 🔴 — checked every byte and 16-bit field of the `0x4c`/`0x47`/`0x10`/
-  `0x87`/`0x81`/`0x15` frames: no stable `0x0f` (RR) and no temp-scaled value (`358`/`359`
-  = 0.1 °C, `3588` = 0.01 °C, `966`/`9658` = °F all absent). RR is most likely **app-derived**
-  (from PPG/HRV — respiratory sinus arrhythmia); skin temp is a real sensor reading, so it
-  is probably fetched by a **command this capture never issued** (candidate: the 🔴
-  secondary service `0x0900`, §1) or lives in a daily-summary record we haven't pulled.
-  A capture that opens the app's temperature screen / triggers a temp refresh is needed.
+- **Respiratory rate (15 bpm) and skin temp are NOT in ANY frame this sync captured** 🔴.
+  Verified exhaustively: every byte and 16-bit field of the `0x4c`/`0x47`/`0x10`/`0x87`/
+  `0x81`/`0x15` frames (no stable `0x0f` RR; no temp value at `358`/`359`=0.1 °C,
+  `3588`=0.01 °C, `360`/`3597`, `966`/`9658`=°F, nor a small signed deviation), **and**
+  every BLE handle — all traffic was on `0x0804`/`0x0802`/`0x0805`, nothing on the
+  secondary service `0x0900`. Per-epoch `[6]` (1–10, quality?) and `[7]` (swings 64→120
+  over the night — too volatile for temp) are not it either.
+  - RR is most likely **app-derived** (PPG/HRV respiratory sinus arrhythmia), not on the wire.
+  - **Skin temp is measured only at night** (per the ring owner) yet was absent from this
+    overnight sync → it is fetched by a **separate command the app issues when its
+    Temperature screen is opened** (candidate transport: secondary service `0x0900`),
+    not part of the standard activity/sleep/PPG history drain.
+  - **Ground truth for when we capture it:** RingConn reports temp Oura-style as a signed
+    **deviation from a personal baseline** plus an absolute reading — observed `−0.16`
+    deviation and `96.75 °F` (35.97 °C); the 2026-06-13 night showed `96.58 °F` (35.88 °C).
+    Baseline ≈ 36.1 °C. Expect a small signed value (≈ `−16` if 0.01 °C, or `−0.16` scaled)
+    alongside an absolute near `3588`–`3597` (0.01 °C) or `9658`–`9675` (0.01 °F).
+  - **Capture needed:** snoop on → open the app's **Temperature / Trends screen** (which
+    should trigger the fetch) → sync / `adb bugreport`.
 
 **`[10:15]` = 5× per-30 s motion/activity counts** 🟢(role)/🟡(unit). Over a real night
 they decay from `~14 15 15 14` (≈20, awake/settling at 23:09) to the `01 01 01 01 01`
@@ -226,10 +237,9 @@ Baseline `01` = "still", not "unworn".
 > matching openwhoop's approach and our Phase 5 plan: compute stages in Swift from these
 > signals, don't expect them on the wire.
 
-> **Blocker to 🟢 on values:** assigning the 7 physiology bytes to HR/HRV/SpO2 needs the
-> RingConn app's timestamped per-epoch readout for the **same night** (§6.2 / issue #7).
-> Structure, framing, epoch cadence and the motion channel are decoded; the payload
-> bytes are not yet pinned to units.
+> **Status:** HR `[4]`, HRV `[5]`, SpO2 `[8]`, motion `[10:15]` and the 150 s cadence are
+> 🟢 (app-aligned, §6.2). Open: `[6]`/`[7]` semantics, the activity-epoch `[15:22]` payload,
+> and skin temp + RR (not in this capture — see above).
 
 ### 5.4 `0x10` / `0x87` — fixed 19-byte descriptor
 `0x10` ← `d0 00 00` (also spontaneous ~30–60 s); `0x87` ← `07 00 00`. **Identical
@@ -287,6 +297,11 @@ Each names the single capture that converts a 🟡/🔴 field into a decoded met
    phone set to UTC → resolves the 12 h offset.
 7. **Session nonce source:** correlate `01 01 <nonce>` against prior `0x81`/`0x10`
    fields. *(Not required — nonce is arbitrary; §4.)*
+8. **Skin temp + its transport:** temp is measured only at night yet is absent from a full
+   activity/sleep/PPG sync and from `0x0900` — fetched by a distinct command/screen. Snoop
+   on → open the app's **Temperature/Trends screen** → sync. Ground truth so far: `−0.16`
+   deviation / `96.75 °F`; expect an absolute near `3588`–`3597` (0.01 °C). Unblocks the
+   `bodyTemperature`/`appleSleepingWristTemperature` HealthKit write.
 
 ---
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -127,18 +127,69 @@ Bulk frames (`0x47`/`0x4c`) pack fixed-size records, each prefixed by delimiter
 | Page ACK | `c7 00 00` / `cc 00 00` | `47`/`4c` | continue bulk transfer | 🟢 |
 | Status query | `d0 00 00` | `10`/`50` | session/record status | 🟡 |
 
-**The `02` arg is a sync CURSOR, not a timestamp** (🟢, this was the key unlock).
-Real-time values are *rejected* (no `82`); only a cursor **≥ the ring's last-synced
-position** is accepted. `02 00 FF FF FF FF 00 01 00` (max) always works and means
-"sync everything". The capture's `0c 22 98 c3` was the app's then-current cursor;
-replaying it now fails because the ring has since advanced past it.
+**The `02` arg is a sync CURSOR, not a timestamp** (🟢, this was the key unlock). The cursor
+is *seconds since 2019* (§5.6). ⚠️ **`02 00 FF FF FF FF 00 01 00` does NOT mean "sync
+everything"** — `FF FF FF FF` is a far-FUTURE position that does not pull history (see the
+load-bearing caveat below).
+
+**How the official app pulls history** (🟢 *for the app's observed behaviour*,
+`ppg_align_20260616` capture, 23 sync-opens via `desktop/analyze_cursor.py`): **the app opens
+at cursor ≈ NOW on every sync** — *never* `FF FF FF FF` — and that open **triggers a drain of
+everything the ring hasn't handed off, up to the ring's current time.** The cursor acts as a
+"drain up to ≈now" trigger, **NOT a hard bound**:
+- Records routinely **overshoot** the open cursor — in 11/23 syncs the last returned record is
+  *above* the open (by up to ~39 min): the drain takes minutes and epochs created *during* it
+  keep streaming past the frozen cursor. So this is **not** "counter ≤ C"; the cursor only has
+  to look like a plausible recent time to trigger the drain (an absurd-future cursor does not).
+- Each sync resumes where the previous ended: open `0c22bbf7` → `0c22a16b..0c22bb60`; next open
+  `0c233d95` → `0c22bbf6..0c233cdf`. The FIRST open (`0c2298c3`) drained ~19 days in one shot
+  (`0c099dbf..0c2299cd`). The ring tracks its **own** resume pointer; the app persists none.
+- The 23 opens increase monotonically and are **never** equal to the previous `0x50 to` →
+  consistent with "open at ≈now," not "resume from the last reported cursor." (The Δ between
+  opens is read from the cursor values, not measured against packet wall-clock.)
+- The `0x50` end-of-history `to` cursor **trails the last delivered record** (e.g. `to=0c2299c8`
+  vs last record `0c2299cd`), so consecutive syncs re-deliver a small overlap — hence the
+  cross-sync **dedup** in `LocalStore`/`SyncCursor` and `extract_last_night.py`.
+- The app **drains even when entering live HR** (`btsnoop_hr`: live entry opens `0c2298c3`,
+  cursor≈now, draining a 19-day backlog *before* HR mode). It has **no** "skip-backlog" open —
+  our `FF FF FF FF` live path (below) is a deliberate, *unverified* divergence.
+
+⚠️ **Load-bearing and NOT ground-truthed (🟡): what `FF FF FF FF` actually does.** The official
+app never sends it in any capture, so this is inferred:
+- "`FF FF FF FF` → empty" comes only from our `livehr.py` replay — which *also* reused a stale
+  `01 01` nonce (§ session-open nuances), a confound, so "empty" might be the nonce, not the
+  cursor. (The iOS broken-vs-fixed paths use the **same** hardcoded nonce and differ *only* in
+  the cursor, so the nonce does not confound the iOS fix itself.)
+- Whether `FF FF FF FF` **advances the ring's resume pointer** is unknown, and it matters:
+  `autoMeasure` fires `syncAll` (`FF FF FF FF`) every ~10 min all day, so a pointer-advancing
+  `syncAll` would shred the backlog before the overnight `syncUpToNow` runs. The 3-week backlog
+  *surviving* in this capture is *weak* evidence it does NOT advance (an all-day pointer-advancing
+  `syncAll` would have kept the ring empty) — weak because we can't confirm the app was connected
+  throughout. **TODO (ring required): A/B test — `syncAll`, then immediately `syncUpToNow`, and
+  confirm the backlog still drains.** Safest alternative: drop `syncAll` from the live path too and
+  open at cursor≈now with a short drain cap (app-faithful; removes the dependency entirely).
+
+**Contention (🟢 behaviourally — overnight data reached the official app, not us; the
+single-shared-pointer *mechanism* is inferred, not two-client tested):** the ring holds only
+UN-synced data behind what is almost certainly ONE shared resume pointer; whoever
+opens at ≈now first (the official app OR us) drains the backlog and advances it, leaving the other
+with nothing. (This is why overnight sleep "vanished" — even after the cursor fix, a competing
+official-app sync can still win the one-time backlog.)
+
+**The fix in OpenRingConn:** (1) history/overnight opens use `Command.syncUpToNow()`
+(cursor = `floor(now) − epoch`), exactly the app's history behaviour — this part is solid (the
+capture proves cursor≈now drains, and lower-bound is ruled out, so it can't return empty). (2)
+The live/quick path still uses `Command.syncAll` (`FF FF FF FF`) to skip the drain for a fast HR
+lock — **pending the A/B test above**; until verified, treat this as the one residual risk. (3)
+Be the **sole** syncer — stop running the official app, which races us for the one-time backlog.
+**No cursor is persisted on our side; the ring self-tracks.**
 
 **Verified live-HR sequence (from the Mac, `desktop/livehr.py`):**
 ```
 01 00 00                  -> 81 ..        (wake/status)
 01 01 31 82 67 00         -> 81 01 ..     (config table)
-02 00 FF FF FF FF 00 01 00 -> 82 ..       (open sync, cursor=all)
-07 00 00 + c7/cc acks     -> 87,47,4c ..  (drain any history backlog)
+02 00 FF FF FF FF 00 01 00 -> 82 ..       (open sync; FFFFFFFF → empty/skip-backlog 🟡, §3 caveat)
+07 00 00 + c7/cc acks     -> 87,47,4c ..  (empty under FFFFFFFF 🟡; history uses cursor≈now)
 06 01 00                  -> 86 00 86     (enter live-HR mode)
 07 00 00                  -> 15 ..        (first live sample)
 95 00 00  (repeat)        -> 15 00 <hr> 0a b0 <xor>   (one HR sample per poll)
@@ -153,8 +204,9 @@ disconnect (wake via charger contact or motion). Metric-specific sync commands
 > - `01 01 <3 bytes>` carries a per-session **nonce** (`31 82 67`, then `f0 1e 88`,
 >   `9c 61 91` across sessions). Our replays reused a stale nonce, so the session
 >   never opened — this, not just the cursor, is why Mac live-HR replay stalled.
-> - `02 00 <cursor:4> …` cursor advances each sync (`0c 22 98 c3` → `0c 22 bb f7`).
->   `FFFFFFFF` works only while a backlog exists.
+> - `02 00 <cursor:4> …` cursor ≈ now is a "drain up to now" trigger (NOT a hard bound; §3), advancing each sync
+>   (`0c 22 98 c3` → `0c 22 bb f7`). `FFFFFFFF` (far-future) returns an empty stream
+>   (skip-backlog); pull history at cursor ≈ now (§3).
 > The HR DECODE is confirmed (above); reproducing the live stream on demand from the
 > Mac needs the nonce + cursor derived correctly (source of the nonce still 🔴 —
 > likely from an `81` response field). Not required for Phase 1.
@@ -213,6 +265,16 @@ continuous trace); 30 samples per 900 s record ≈ 1/channel/min, so this is a
 perfusion/amplitude trend, not pulse-resolution waveform 🟡. Reproduce with
 `desktop/decode_ppg.py`.
 
+**2026-06-16 cross-check (`ppg_align_20260616`, issue #8) — 10-bit holds, but still not
+fiducial.** Decoding the 176 `0x47` records 10-bit BE is flat/low-jitter (smoothness 0.04)
+while 12-bit BE is noise-like (1.12) → consistent with the 10-bit choice above. BUT these
+records are scattered history (176 over ~21 days, not a worn realtime window), so they do
+**not** supply the proof #8 demands: confirming bit-width + channel identity (red/IR) +
+counter time-unit still needs a **realtime PPG capture with finger on/off + a reference HR
+over the same window** — i.e. the physical ring. `desktop/decode_0x47.py` does the mechanical
+decode (both widths → CSV); alignment is the open step. Per the no-fabrication rule, treat
+channel identity as 🟡 (jitter-supported, not fiducial) until that capture lands.
+
 ### 5.3 `0x4c` — bulk activity/sleep page (ACK each with `cc 00 00`)
 Page: `[0]`=`0x4c` · `[1]`=`00` · **`[2]`=remaining-RECORD countdown** (−6/page) ·
 body = 6×**23-byte records** · `[last]`=XOR. 🟢
@@ -232,8 +294,11 @@ time (no 12 h offset in this capture; bears on §5.6/§6.6). Reassemble + decode
 **Two record layouts**, distinguished by `[8]`:
 - **Activity/awake epoch** `[8]=0x12`/`0x13`: physiology/activity in `[15:22]`, motion
   in `[10:15]` elevated.
-- **Sleep-vitals epoch** `[8]=0x57–0x63` (87–99): per-epoch vitals in `[4:9]`, motion
-  `[10:15]` at `01` baseline, `[15:22]` ≈ zero.
+- **Sleep-vitals epoch**: per-epoch vitals in `[4:9]`, motion `[10:15]` at `01` baseline,
+  `[15:22]` ≈ zero. `[8]` is the **SpO2 %** (typically `0x57–0x63` = 87–99, but lower on a real
+  desaturation). ⚠️ Layout is decided **structurally** (#39), NOT by this band: classify as
+  sleep-vitals = "not the idle template AND `[8]` ∉ {`0x12`,`0x13`}", so a sub-87 % desaturation
+  still keeps its HR/HRV/SpO2 (the old value-gate dropped the whole epoch — see `BulkSleep.swift`).
 
 **Sleep-vitals fields — confirmed against the RingConn app's readout for the
 2026-06-13 night** (avg HR 68 / HRV 65 ms / SpO2 98 %, low 93 % ~02:30–03:00):
@@ -376,7 +441,11 @@ Host write `02 00 <cursor:4 BE> <flag:1> 01 00` → `82 00 00 82`.
 **cursor = 4-byte BE seconds since epoch `1577793600` (2019-12-31 12:00:00 UTC)** —
 3 (time,value) pairs + 2 in-frame cross-checks agree to <0.34 s; 1/sec, monotonic;
 same epoch as the record counters. Build current: `floor(unix_utc) − 1577793600`,
-BE, into `02 00 <BE4> 00 01 00`; `FF FF FF FF` = "everything" while backlog exists.
+BE, into `02 00 <BE4> 00 01 00`. ⚠️ `FF FF FF FF` is **not** "everything" — it's a far-future
+cursor that does not pull history (the live-HR "skip history" open; 🟡, see §3 "Load-bearing").
+A plausible-recent cursor acts as a **"drain up to ≈now" trigger, not a hard bound** (§3): open
+at cursor **≈ now** and the ring streams everything un-delivered up to its current time (records
+can overshoot the cursor by minutes), then self-advances its resume pointer.
 
 **No 12 h offset in decoded data 🟢 (issue #5 closed, `morning_temp_20260615`).**
 The epoch `1577793600` is 2019-12-31 **12:00:00** UTC (noon, not midnight): the 12 h
@@ -388,15 +457,22 @@ every case (max observed delta 0.5 s, median 0.2 s). No timezone-dependent offse
 
 ### 5.7 `0x81` — status replies (← `0x01`)
 **`81 00 XX YY`** (← `01 00 00`): `[2]` is the only varying byte, full 8-bit range,
->100 → **not battery %**; per-session nonce / ring-state token 🟡 (issue #4).
+>100 → **not battery %** 🟢; a **per-session token / nonce** 🟡 (issue #4 — see confirmation below).
 
 **Byte[2] analysis, 20 BLE sessions, `morning_temp_20260615_btsnoop.log` 🟢:**
 Values span 31–249 (range=218; full 8-bit), definitively not battery % (values >100
 common: 176, 218, 216, 203, 227, 249). Non-monotonic within an hour: 7 consecutive
 sessions at 13:28–13:52 UTC return 31→120→227→63→249→188→157→128 — no slow battery-like
 drift. Two connections using recycled handle 0x002 (separated by >15 h) return
-different values (176 vs 148). Consistent with **per-session ring-state assignment** or
-a random nonce; source unknown 🔴. Settle with a long wear/discharge battery test.
+different values (176 vs 148). **Cross-capture confirmation (🟢, 2026-06-16, issue #4,
+`desktop/analyze_0x81.py`):** byte[2] is **one value per BLE connection** — `battery76` (ring
+steady at 76 %) returns `176, 218, 216, 129, 203, 163, 176, 150, …` across ~20 connections,
+**constant within each** connection, full 8-bit range, recurring (`176` on two). So it is
+**neither battery (would sit ≈constant near 76 %) nor a sequential counter**: a **per-session
+token / nonce** — assigned once per connect — likely the same session-auth nonce family as the
+`01 01` arg (the `81 01` block below + § session-open nuances in §3). **Issue #4 answer: not
+battery 🟢; per-session token role 🟡.** (Battery is
+the `0x10`/`0x87` descriptor `[1]`, §5.4 🟢 — already decoded.)
 
 **`81 01 …`** (38 B, ← `01 01 <nonce>`): mostly constant; notable — `[27:32]`=
 `21 49 ac <XX> f4` (4/5 const, device-id-like) · `[34:36]`=16-bit monotonic counter
@@ -437,8 +513,9 @@ Each names the single capture that converts a 🟡/🔴 field into a decoded met
    activity/sleep/PPG sync, from `0x0900`, and from a capture with the Temperature screen
    open (that screen reads cache, no BLE). **Mac active-probing is ruled out** — data
    commands need a bond (§0). Remaining lead: a **from-scratch phone resync** — `adb shell
-   am force-stop com.gdjztech.ringconn`, reopen the app so it re-pulls history from cursor
-   0, and btsnoop that; a full resync may issue the temp fetch the incremental syncs skip.
+   am force-stop com.gdjztech.ringconn`, reopen the app so it does a fresh sync (it still opens
+   at cursor ≈ now per §3 — NOT cursor 0 — but drains whatever backlog accrued while stopped),
+   and btsnoop that; a large fresh drain may surface the temp fetch the small incremental syncs skip.
    Ground truth: `−0.16` deviation / `96.75 °F` (and `96.58 °F`/35.88 °C for 2026-06-13);
    expect an absolute near `3588`–`3597` (0.01 °C). Unblocks the
    `bodyTemperature`/`appleSleepingWristTemperature` HealthKit write.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -165,7 +165,14 @@ ground-truth captures (§6).**
 ### 5.1 Heart rate (live) 🟢 CONFIRMED
 `0x95` poll → `0x15`: **`15 00 <hr> 0a b0 <xor>`**, byte[2] = HR bpm (61 bpm resting
 in the HR-only capture). First sample is a warm-up sentinel (byte[2] ≈ 8); treat
-< ~30 as "not locked". Longer `15 01 …` frames carry extra fields (SpO2? 🔴).
+< ~30 as "not locked".
+
+**Enter-live sequence** 🟢 (FR02.018 capture): after the connect-time history drain,
+the app sends **`d0 00 00` → `06 01 00` → `07 00 00`**, then polls `95 00 00` ~1/s. The
+`d0 00 00` is required — without it the ring stays in bulk mode and emits no `15 00` HR
+frames. **`06 01 00` = HR mode** (short `15 00 <hr>` frames); **`06 02 00` = SpO2 mode**
+→ long **`15 01 … <spo2> …`** frames where **byte[14] = SpO2 %** 🟡 (matches `0x60`/`0x61`
+= 96/97 in the live capture; byte[2] is `00`, so don't read HR from these).
 
 ### 5.2 `0x47` — bulk PPG / waveform page (ACK each with `c7 00 00`)
 Page: `[0]`=`0x47` · `[1]`=`00` · **`[2]`=remaining-RECORD countdown** (−5/full page,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -214,10 +214,17 @@ time (no 12 h offset in this capture; bears on §5.6/§6.6). Reassemble + decode
   secondary service `0x0900`. Per-epoch `[6]` (1–10, quality?) and `[7]` (swings 64→120
   over the night — too volatile for temp) are not it either.
   - RR is most likely **app-derived** (PPG/HRV respiratory sinus arrhythmia), not on the wire.
-  - **Skin temp is measured only at night** (per the ring owner) yet was absent from this
-    overnight sync → it is fetched by a **separate command the app issues when its
-    Temperature screen is opened** (candidate transport: secondary service `0x0900`),
-    not part of the standard activity/sleep/PPG history drain.
+  - **Skin temp is measured only at night** (per the ring owner) yet is absent from BOTH a
+    full morning sync (2026-06-13 night) AND a capture taken **while the app's Temperature
+    screen was open** — that screen showed cached data and issued **no BLE fetch** (only a
+    normal recent-activity re-sync followed). So temp never rides the activity/sleep/PPG
+    drain; it needs a **dedicated command the app sends on its own schedule** (e.g. first
+    sync of the day / background), which neither capture triggered.
+  - **Sync-open `0x02` flag byte** (byte[6]) observed as `00` and `03`; **both return the
+    same activity/sleep `0x4c`+`0x47` data** (flag=03 segments carried fewer `0x4c`, more
+    `0x10`/`0x87`). So flag is NOT a per-metric stream selector. Purpose still 🔴 — other
+    flag values (`01`/`02`/`04`…) are untried and a candidate temp/summary selector for
+    **active probing** (`replay 02 00 <cursor> 0X 01 00`).
   - **Ground truth for when we capture it:** RingConn reports temp Oura-style as a signed
     **deviation from a personal baseline** plus an absolute reading — observed `−0.16`
     deviation and `96.75 °F` (35.97 °C); the 2026-06-13 night showed `96.58 °F` (35.88 °C).

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -478,7 +478,9 @@ the `0x10`/`0x87` descriptor `[1]`, §5.4 🟢 — already decoded.)
 `21 49 ac <XX> f4` (4/5 const, device-id-like) · `[34:36]`=16-bit monotonic counter
 ≈ 1/sec (30→1475→9045 over 3 sessions) 🟡.
 
-### 5.8 Per-connection AUTH (the activation gate) 🟢 CRACKED + heartbeat + bonding — issue #54
+### 5.8 Per-connection AUTH (the activation gate) 🟢 CRACKED — issue #54
+> ✅ **Standalone confirmed on-device 2026-06-16:** with the official app logged out, OpenRingConn
+> activated the ring and streamed on its own. No official app needed. (+ heartbeat + bonding below.)
 The `01 01 <…>` arg is a deterministic **challenge→response auth** — what "activates" the ring for
 streaming. Sequence every connect: host `01 00 00` → ring `81 00 <chal> <xor>`; host must answer
 `01 01 <r0> <r1> <r2> 00`. **🟢 ALGORITHM (RE'd 2026-06-16 from the official app's Dart AOT

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -478,22 +478,30 @@ the `0x10`/`0x87` descriptor `[1]`, §5.4 🟢 — already decoded.)
 `21 49 ac <XX> f4` (4/5 const, device-id-like) · `[34:36]`=16-bit monotonic counter
 ≈ 1/sec (30→1475→9045 over 3 sessions) 🟡.
 
-### 5.8 Per-connection AUTH (the activation gate) 🟢 + heartbeat + bonding — issue #54
-⚠️ **CORRECTION:** the `01 01 <3-byte nonce>` arg is **NOT arbitrary** — it is a deterministic
-**challenge→response auth**, and it is what "activates" the ring for streaming (🟢, confirmed
-2026-06-16 `login_activate_20260616`). Sequence every connect: host `01 00 00` → ring
-`81 00 <chal> <xor>`; host must answer `01 01 <f(chal)> 00`. `f` is a **256-entry keyed table
-over the 8-bit challenge** (NOT linear/XOR/LCG). 24 (chal→resp) pairs captured, zero collisions
-(`b0→31 82 67` recurs across sessions 12 h apart; the 2026-06-16 login used `e5→52 0b e1`). See
-`Command.knownAuthNonces`.
+### 5.8 Per-connection AUTH (the activation gate) 🟢 CRACKED + heartbeat + bonding — issue #54
+The `01 01 <…>` arg is a deterministic **challenge→response auth** — what "activates" the ring for
+streaming. Sequence every connect: host `01 00 00` → ring `81 00 <chal> <xor>`; host must answer
+`01 01 <r0> <r1> <r2> 00`. **🟢 ALGORITHM (RE'd 2026-06-16 from the official app's Dart AOT
+`libapp.so`, capstone-disassembled; verified against 24 captured pairs + the SM3 KAT):**
 
-**Why this is the "open the official app to activate" gate:** OpenRingConn hardcodes
-`01 01 31 82 67` (= `f(0xb0)`), correct only when the challenge is `0xb0`. When the ring is in a
-strict state it demands the right `f(chal)` for the issued challenge, so our wrong answer → no
-streaming; a logged-in official app answers correctly → the ring streams (and we ride along while
-it stays unlocked). **To be standalone, OpenRingConn must compute `f(chal)` — recover `f` from the
-official APK (`com.gdjztech.ringconn`); 24/256 entries known from captures is not enough.** This is
-LOGIN/auth-tied, **not** app-startup and **not** a re-bond (see bonding below).
+```
+V        = mac[3] ^ mac[4] ^ mac[5]            # XOR of the ring's last 3 BLE-MAC bytes
+response = SM3( bytes([V, challenge]) )[29:32] # last 3 bytes of the 32-byte SM3 digest
+```
+
+`SM3` is the Chinese national 256-bit hash (GB/T 32905). The **only** key material is the ring's
+own MAC — **no cloud key, no app secret** — so it's computable offline for any RingConn. For this
+ring (`F8:79:99:F7:03:AD`): `V = F7^03^AD = 0x59`, e.g. `f(0xe5)=52 0b e1`, `f(0xb0)=31 82 67`. The
+old hardcoded `01 01 31 82 67` was simply `f(0xb0)`, which is why it only worked when the challenge
+happened to be `0xb0`. Impl: `RingAuth.authCommand(challenge:mac:)` (`OpenRingKit/RingAuth.swift`).
+
+**MAC on iOS:** CoreBluetooth hides the MAC, but the ring exposes it via the DIS **System ID**
+characteristic (`0x2a23`, §1) — read it once on connect (`RingAuth.macFromSystemID`).
+
+**This is the "open the official app to activate" gate, now closed:** a client that answers the
+challenge correctly activates the ring's stream itself; OpenRingConn now does this reactively on
+`81 00` (`RingSession` `case 0x81`), so it streams standalone with no official-app dependency. (It's
+per-connection auth — **not** app-startup and **not** a re-bond; see bonding below.)
 
 **Heartbeat 🟢:** ring→host `11 00 <ctr> <tok> <xor>` (~2.5 min idle; `ctr` resets to 01 per
 connection; `tok` = the session token also in `0x10[1]`; `[last]`=XOR). Host replies a constant

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -32,6 +32,17 @@ command**: `0x02` sync-open (even the known-good real cursor `0c2298c3` that ret
   `listen`/`replay` of data commands will see nothing. Active probing from the Mac is a
   dead end; capture the phone instead.
 
+**Resolved on iOS 🟢 (2026-06-14): bonding unlocks data, and it's shared across apps.**
+Our iPhone app first hit the same wall (live HR poll → only the `81 01` handshake, no
+`0x15` frames). The fix: **bond the iPhone to the ring once** — installing the official
+RingConn iOS app and signing in establishes the device↔ring LE bond. BLE bonds are
+**per device, not per app**, so OpenRingConn then inherits it: `02`/`07`/`95` go through
+and **live HR decoded 68 bpm** + history sync started. The ring supports multiple paired
+phones, so this doesn't disturb the Android pairing.
+> **Operational requirement:** any device running OpenRingConn must already be bonded to
+> the ring (pair via the official app once). This is the make-or-break unknown — answered:
+> offline decode works, *direct ring access* just needs a one-time bond.
+
 ## 1. Connection & GATT layout
 
 > ⚠️ Reported as not fully GATT-compatible. The capture confirms the app drives the

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -332,7 +332,9 @@ Baseline `01` = "still", not "unworn".
 ### 5.4 `0x10` / `0x87` — fixed 19-byte descriptor
 `0x10` ← `d0 00 00` (also spontaneous ~30–60 s); `0x87` ← `07 00 00`. **Identical
 layout** (only `[0]` respid differs; `0x87` body == `0x10` body) → shared descriptor,
-XOR-valid. `[1]`=per-session marker (`4e`→`5c`; same value in `0x81 01`) 🟡 · `[2]`=
+XOR-valid. **`[1]`=BATTERY %** 🟢 (ground-truthed 2026-06-15: `0x4c`=76 matched the app's
+76% exactly at capture time; the buffer showed a clean 92→86→85→84→78→77→76 discharge
+curve — it is NOT a per-session marker) · `[2]`=
 state enum `01–04` (not a counter) 🟡 · **`[4:6]`=STEP COUNT (16-bit BE)** 🟢 ·
 **`[6:8]`/`[8:10]`=SKIN TEMPERATURE, two channels, 0.1 °C BE** 🟢 (each prefixed `01`=
 valid; see below) · `[15]`=declines over an evening but **not plain battery** 🟡 ·

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -19,7 +19,18 @@ below to this FW until re-confirmed on another version.
 plaintext: readable identity strings, monotonic counters, and a checksum that
 validates (§3). No app-layer key exchange or challenge/response precedes data
 access. Offline decoding is viable → the iOS app is unblocked.
-(Link-layer LE encryption, if any, is transparent to CoreBluetooth — irrelevant.)
+
+**BUT data commands are gated behind an LE bond** 🟢 (live test, 2026-06-14). An
+*unbonded* central (macOS bleak) connects, subscribes, and gets replies to the `0x01`
+status handshake (`81 00 …`, `81 01 …`) — but the ring **silently drops every data
+command**: `0x02` sync-open (even the known-good real cursor `0c2298c3` that returns
+`82 00 00 82` on the bonded phone), `0x07` fetch, `0x95` poll — zero response. So:
+- The **bonded phone** (Android btsnoop) is the only way to pull real data; this is why
+  all metric RE here uses phone captures, and why the iPhone app works (iOS bonds).
+- The **desktop `openringconn` workbench can scan/enumerate/handshake but NOT pull data**
+  — CoreBluetooth/bleak can't initiate pairing (`pair()` → NotImplementedError on macOS).
+  `listen`/`replay` of data commands will see nothing. Active probing from the Mac is a
+  dead end; capture the phone instead.
 
 ## 1. Connection & GATT layout
 
@@ -66,8 +77,12 @@ or bulk transfer). Not used by the main protocol. Decode if needed later.
 **No app-layer handshake observed.** After enabling notifications (`0x0805 ← 01 00`)
 the app immediately issues data commands and the ring responds — no token, no
 challenge, no key derived from MAC/serial. History sync uses the same channel as
-live data with no extra auth. (Re-verify on a *fresh pair* capture to be certain a
-one-time bonding step isn't being skipped on an already-bonded phone.)
+live data with no extra *app-layer* auth.
+
+**The skipped step is the LE bond itself** 🟢 (§0, live test): on an already-bonded
+phone the app needs no further auth, but an unbonded central gets only the `0x01`
+handshake — data commands (`0x02`/`0x07`/`0x95`) are silently dropped until the link
+is bonded. So the "no auth" above is conditional on a bonded link.
 
 ## 3. Framing 🟢 (verified live on the Mac)
 
@@ -305,9 +320,13 @@ Each names the single capture that converts a 🟡/🔴 field into a decoded met
 7. **Session nonce source:** correlate `01 01 <nonce>` against prior `0x81`/`0x10`
    fields. *(Not required — nonce is arbitrary; §4.)*
 8. **Skin temp + its transport:** temp is measured only at night yet is absent from a full
-   activity/sleep/PPG sync and from `0x0900` — fetched by a distinct command/screen. Snoop
-   on → open the app's **Temperature/Trends screen** → sync. Ground truth so far: `−0.16`
-   deviation / `96.75 °F`; expect an absolute near `3588`–`3597` (0.01 °C). Unblocks the
+   activity/sleep/PPG sync, from `0x0900`, and from a capture with the Temperature screen
+   open (that screen reads cache, no BLE). **Mac active-probing is ruled out** — data
+   commands need a bond (§0). Remaining lead: a **from-scratch phone resync** — `adb shell
+   am force-stop com.gdjztech.ringconn`, reopen the app so it re-pulls history from cursor
+   0, and btsnoop that; a full resync may issue the temp fetch the incremental syncs skip.
+   Ground truth: `−0.16` deviation / `96.75 °F` (and `96.58 °F`/35.88 °C for 2026-06-13);
+   expect an absolute near `3588`–`3597` (0.01 °C). Unblocks the
    `bodyTemperature`/`appleSleepingWristTemperature` HealthKit write.
 
 ---

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -318,17 +318,35 @@ Baseline `01` = "still", not "unworn".
 > repeated across two sessions → likely a derived key, not random. **Conclusion:** Mac-side
 > metric probing (incl. the temp-flag hunt) is gated by the §4 session-open auth — must crack
 > the `01 01` derivation first, OR capture the official app's temp fetch (the app holds valid
-> auth). Temp is confirmed BLE-delivered but absent from the normal sync drain → its fetch is
-> a distinct, not-yet-triggered event.
+> auth). Temp is confirmed BLE-delivered but absent from the normal sync drain.
+> **RESOLVED 2026-06-15 (see §5.4):** temperature is in the `0x10`/`0x87` **descriptor**
+> `[6:8]`/`[8:10]` as 0.1 °C, streamed live while connected — not in the bulk sync. So it
+> needs neither the session-open auth nor active flag-probing; just read the descriptor.
 
 ### 5.4 `0x10` / `0x87` — fixed 19-byte descriptor
 `0x10` ← `d0 00 00` (also spontaneous ~30–60 s); `0x87` ← `07 00 00`. **Identical
 layout** (only `[0]` respid differs; `0x87` body == `0x10` body) → shared descriptor,
 XOR-valid. `[1]`=per-session marker (`4e`→`5c`; same value in `0x81 01`) 🟡 · `[2]`=
-state enum `01–04` (not a counter) 🟡 · **`[4:6]`=STEP COUNT (16-bit BE)** 🟢 · `[6:8]`/
-`[8:10]`=16-bit A/B with validity flag (grow with activity → active-secs/calories? 🟡) ·
-`[15]`=declines over an evening but **not plain battery** 🟡 · `[17]`=`ff` idle;
-**non-`ff` precedes a bulk stream → "data follows"** 🟡.
+state enum `01–04` (not a counter) 🟡 · **`[4:6]`=STEP COUNT (16-bit BE)** 🟢 ·
+**`[6:8]`/`[8:10]`=SKIN TEMPERATURE, two channels, 0.1 °C BE** 🟢 (each prefixed `01`=
+valid; see below) · `[15]`=declines over an evening but **not plain battery** 🟡 ·
+`[17]`=`ff` idle; **non-`ff` precedes a bulk stream → "data follows"** 🟡.
+
+**`[6:8]` / `[8:10]` = skin temperature in 0.1 °C** 🟢 (ground-truthed 2026-06-15,
+`captures/morning_temp_20260615`). Two near-equal 16-bit BE values (e.g. `01 64 01 65` =
+356/357 → **35.6/35.7 °C = 96.1/96.3 °F**); likely skin + reference/object channels. Proof:
+- **Donning curve** — ring put on at 14:04 read **28.7 °C** (cold) and climbed steadily
+  28.7→30→32→**34.5 °C** over ~25 min, cooled when removed, re-warmed on re-don. A thermistor
+  equilibrating on skin; step counts never decrease, so this is not activity. 🟢
+- **App-aligned** — morning value 35.6/35.7 °C sits right on the app's nightly **avg
+  96.40 °F (35.78 °C)** / baseline 96.73 °F; pair difference (~−0.1…−0.2 °C) ≈ the app's
+  deviation **−0.32 °F**. The app samples this **live over the night** (descriptor is sent
+  spontaneously ~30–60 s while connected) to compute avg/baseline/deviation — temp is **NOT**
+  in the `0x4c` sleep sync, which is why value-searches of the drain failed.
+- **Encoding note:** the wire carries the *raw reading* (355–357), not the displayed nightly
+  *average* (358) — earlier exact-358 searches missed it by 1–3 LSB.
+- **Implication:** readable **live, no sync session / nonce needed** — poll `d0 00 00`→`0x10`
+  (or listen for spontaneous descriptors) and parse `[6:8]`/`[8:10]`. Sidesteps the §4 auth wall.
 
 **`[4:6]` = the ring's onboard step count** 🟢 (live test 2026-06-14). After clearing
 the official app and forcing a from-scratch ring re-sync, the app showed **81 steps** and

--- a/docs/REVERSE_ENGINEERING.md
+++ b/docs/REVERSE_ENGINEERING.md
@@ -74,6 +74,32 @@ response → record in `PROTOCOL.md`.
 - **One variable at a time.** Take two HR readings 10 bpm apart and diff the
   payloads to locate the HR byte.
 
+## Track C — App-logic RE (Flutter / Dart AOT) — how the auth was cracked
+
+When the protocol isn't decodable from the wire alone (e.g. a keyed auth), reverse the official
+app's logic. The RingConn app is **Flutter**, so its logic lives in `lib/arm64-v8a/libapp.so`
+(Dart AOT snapshot) — **not** Java; jadx/apktool are useless. This is how the per-connection auth
+(`SM3([mac[3]^mac[4]^mac[5], challenge])[-3:]`, PROTOCOL §5.8 / issue #54) was recovered:
+
+1. **Pull the APK splits:** `adb shell pm path com.gdjztech.ringconn` → `adb pull` the base +
+   `split_config.arm64_v8a.apk` (the Dart code is in the **arm64 split**), or grab an XAPK/bundle.
+2. **Decompile the Dart AOT with blutter** (`github.com/worawit/blutter`; needs `brew install cmake
+   ninja capstone pkg-config` + a JDK). It auto-detects the Dart version, builds the matching VM,
+   and emits `asm/*.dart` (annotated ARM64), `pp.txt` (object pool), `objs.txt`, a Frida script.
+   ⚠️ **blutter can't parse a too-new Dart** — it SIGSEGV/SIGBUS'd on the current app's Dart 3.10.7.
+   **Workaround that worked:** RE an **older app version** (v3.2.1 = Dart 3.5.4) from APKMirror/
+   APKPure — wire protocols/algorithms are stable across app versions. Check first:
+   `strings libflutter.so | grep 'stable'`.
+3. **blutter sometimes omits a layer** (it dropped the BLE opcode-dispatch here). Fall back to
+   **capstone**: disassemble `libapp.so`, find the opcode-dispatch `cmp #0x81` cluster + the handler
+   it calls, read the arithmetic. (The Dart class names like `BleAuthRspMixin` survive as strings.)
+4. **VERIFY — never guess** (no-fabrication rule): reproduce the algorithm against ground-truth
+   (challenge,response) pairs harvested from btsnoop + a known-answer test for any standard primitive
+   (e.g. `SM3("abc")`). Don't claim a crack until **every** captured pair matches. Cheap pre-checks
+   first: `desktop/find_table.py` (lookup-table by spacing), `crack_f.py` (keyless/keyed hash/CRC
+   brute), `scan_smp.py` (SMP/bonding — confirm there's **no cloud key**, just a local ECDH LTK).
+5. **iOS gotcha:** CoreBluetooth hides the BLE MAC — read it from the DIS **System ID** char `0x2a23`.
+
 ## Safety
 
 `captures/` is gitignored — these logs contain your real health data and device

--- a/docs/REVERSE_ENGINEERING.md
+++ b/docs/REVERSE_ENGINEERING.md
@@ -40,6 +40,13 @@ and encrypted-vs-plaintext determination.
 
 ## Track B — Active probing (workbench)
 
+> ⚠️ **The Mac can only handshake, not pull data** (🟢 live test, PROTOCOL.md §0).
+> The ring gates `0x02`/`0x07`/`0x95` data commands behind an LE **bond**. An unbonded
+> CoreBluetooth/bleak central gets `0x01`→`0x81` replies but the ring silently drops
+> every data command, and bleak can't pair on macOS (`pair()` → NotImplementedError).
+> So `scan`/`enumerate`/`listen` work for the handshake, but `replay` of a sync/fetch
+> sees nothing. **For any real data, capture the bonded phone (Track A).**
+
 Once you can see the app's traffic, reproduce it yourself:
 
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,8 +26,10 @@ Validate the spec cheaply before committing to Swift.
 - [x] Port the validated **framing codec** to Swift — `ios/OpenRingKit` SwiftPM
       package (`Frame`, `Opcode`, `LiveHR`), tested against real FR02.018 capture
       frames. Builds/tests without Xcode via `swift run RingKitVerify`.
-- [ ] Port **per-metric parsers** (blocked: needs decoded metric formats — sleep/
-      SpO2/HRV/steps/temp captures are 🔴 in PROTOCOL.md §5).
+- [x] Port **sleep-vitals parser** — `OpenRingKit/BulkSleep.swift` decodes `0x4c`
+      history pages → HR/HRV/SpO2 per-epoch `QuantitySample`s (PROTOCOL.md §5.3 🟢,
+      app-confirmed). Tested against real 2026-06-13 sync frames. Steps/temp/RR parsers
+      still pending their formats (🟡/🔴).
 - [x] **Xcode app target** — `ios/project.yml` (XcodeGen) generates `OpenRingConn`
       (bundle `com.openringconn.app`, iOS 17, embeds OpenRingKit, HealthKit + BLE
       Info.plist keys + `bluetooth-central` background mode). **Compiles** for the
@@ -35,6 +37,8 @@ Validate the spec cheaply before committing to Swift.
 - [x] **CoreBluetooth glue** — `BLE/RingScanner.swift` (scan by confirmed name
       prefix, connect) + `RingSession.swift` (discover notify/write chars by UUID,
       enable notify, poll live HR via OpenRingKit.Frame, decode 0x15 frames).
+      `syncHistory()` drains `0x4c` pages → `BulkSleep` → HR/HRV/SpO2 samples,
+      finalized on `0x50` end-of-history; ContentView writes them to HealthKit.
 - [x] **HealthKitWriter** — auth + per-type write/units per HEALTHKIT_MAPPING.md.
 - [x] **Metric models + SyncCursor** — `Metrics.swift` + `SyncCursor.swift`, tested.
 - [x] **LocalStore (SwiftData)** — StoredSample/StoredCursor wrapping SyncCursor.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,9 +56,16 @@ Validate the spec cheaply before committing to Swift.
 > sync is not.
 
 ## Phase 4 — HealthKit write
-- [ ] Map each metric per `HEALTHKIT_MAPPING.md`; request authorizations.
-- [ ] Write live + historical samples with device timestamps; dedup on re-sync.
-- [ ] Backfill on first run, incremental thereafter.
+- [x] Map each metric per `HEALTHKIT_MAPPING.md`; request authorizations
+      (`HealthKitWriter` per-type units + auth; sleep as `sleepAnalysis` category).
+- [x] Write historical samples with device timestamps; **dedup on re-sync** —
+      sync → `LocalStore.ingest` (cursor-based `selectNew`) + `ingestSleep` (gated on
+      the `.sleep` cursor) → only NEW samples/segments reach HealthKit (ContentView).
+- [x] Backfill on first run, incremental thereafter — the per-metric cursor makes the
+      first sync write everything and later syncs write only newer records.
+> Dedup *logic* is unit-tested via `SyncCursor`; the `LocalStore` SwiftData wrapper is
+> build-verified only (no app-target test target yet). Live-HR samples aren't persisted
+> (only history sync routes through the store). Functional run needs device + ring.
 **Exit:** ring metrics appear in Apple Health, no cloud involved.
 
 ## Phase 5 — Analytics (port from openwhoop)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,9 +67,9 @@ Validate the spec cheaply before committing to Swift.
 > build-verified only (no app-target test target yet). Live-HR samples aren't persisted
 > (only history sync routes through the store). Functional run needs device + ring.
 > **The only blocker to actually writing Health is the HealthKit entitlement, which needs
-> a paid Apple Developer account.** Enable on a paid team with one command —
-> `HEALTHKIT_ENTITLEMENTS=OpenRingConn/OpenRingConn.entitlements xcodegen generate` — then
-> set your team (see HANDOFF). Free-team builds keep working (entitlement empty, auth no-ops).
+> a paid Apple Developer account.** On a paid team, uncomment the `entitlements:` block in
+> `ios/project.yml`, `xcodegen generate`, and pick your team (see HANDOFF). Do NOT set the
+> entitlement on a free team — it breaks device launch (pre-main libxpc crash).
 **Exit:** ring metrics appear in Apple Health, no cloud involved.
 
 ## Phase 5 — Analytics (port from openwhoop)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -66,6 +66,10 @@ Validate the spec cheaply before committing to Swift.
 > Dedup *logic* is unit-tested via `SyncCursor`; the `LocalStore` SwiftData wrapper is
 > build-verified only (no app-target test target yet). Live-HR samples aren't persisted
 > (only history sync routes through the store). Functional run needs device + ring.
+> **The only blocker to actually writing Health is the HealthKit entitlement, which needs
+> a paid Apple Developer account.** Enable on a paid team with one command —
+> `HEALTHKIT_ENTITLEMENTS=OpenRingConn/OpenRingConn.entitlements xcodegen generate` — then
+> set your team (see HANDOFF). Free-team builds keep working (entitlement empty, auth no-ops).
 **Exit:** ring metrics appear in Apple Health, no cloud involved.
 
 ## Phase 5 — Analytics (port from openwhoop)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,7 +44,8 @@ Validate the spec cheaply before committing to Swift.
 - [x] **LocalStore (SwiftData)** — StoredSample/StoredCursor wrapping SyncCursor.
 - [x] **XCTest suite** runs under Xcode: 23 tests, 0 failures.
 - [ ] Port **per-metric parsers** (blocked: metric formats 🔴 in PROTOCOL.md §5).
-- [ ] Run on a real device + ring (BLE needs hardware; simulator can't connect).
+- [x] Run on a real device + ring (BLE needs hardware; simulator can't connect) —
+      the app runs on an iPhone.
 **Exit:** iOS app pulls the same data the desktop client does.
 
 > **Blocked on hardware/decisions (hard stops):** (a) notify/write **characteristic

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,8 +79,14 @@ Validate the spec cheaply before committing to Swift.
       `0x4c [10:15]` motion channel (no gravity vector needed) into the same core;
       `BulkSleep.sleepSegments` → `inBed`/`asleepCore`/`awake` for HealthKit, surfaced in
       RingSession + ContentView. Validated on the 2026-06-13 night: detects in-bed
-      00:33→09:34 vs the app's ~00:32→09:30. Finer Deep/REM staging is a TODO (needs an
-      HR-based model — the ring sends no hypnogram).
+      00:33→09:34 vs the app's ~00:32→09:30.
+- [~] **Experimental Deep/REM staging** — `BulkSleep.stagedSegments` (HR-percentile
+      heuristic: Awake=motion, Deep=HR≤p20, REM=HR≥p70, else Light, ≥5-min runs).
+      Matches the night's stage TOTALS to ~13% (Deep 100 vs 90, REM 142 vs 115, Light
+      222 vs 242, Awake 8 vs 13 min) but **NOT the architecture** (put Deep late / REM
+      early — HR alone can't place cycles, and the deepest HR fell before sleep-onset).
+      Shown in-app as "experimental"; **only the coarse segments are written to
+      HealthKit**. A faithful hypnogram needs richer signal / per-epoch ground truth.
 - [ ] Wire **HRV/stress/strain** to real metrics (still gated: those assume per-beat
       RR intervals; the ring sends per-epoch HRV(ms)/HR, not RR — see note below).
 - [ ] Write derived metrics to HealthKit / app UI (Phase 4 dependency).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,9 +44,11 @@ Validate the spec cheaply before committing to Swift.
 - [x] **LocalStore (SwiftData)** — StoredSample/StoredCursor wrapping SyncCursor.
 - [x] **XCTest suite** runs under Xcode: 23 tests, 0 failures.
 - [ ] Port **per-metric parsers** (blocked: metric formats 🔴 in PROTOCOL.md §5).
-- [x] Run on a real device + ring (BLE needs hardware; simulator can't connect) —
-      the app runs on an iPhone.
-**Exit:** iOS app pulls the same data the desktop client does.
+- [x] Run on a real device + ring — **the app pulls live data from the ring** (live HR
+      decoded 68 bpm; history sync runs) once the iPhone is **bonded** to the ring (pair
+      via the official app once; BLE bonds are shared across apps — PROTOCOL.md §0).
+**Exit:** ✅ **MET** — iOS app pulls the same live HR / history the desktop decodes.
+Remaining for end-to-end into Apple Health: the paid-account HealthKit entitlement (Phase 4).
 
 > **Blocked on hardware/decisions (hard stops):** (a) notify/write **characteristic
 > UUIDs are still 🟡** — `openringconn scan` must bind them to the confirmed handles

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -66,13 +66,16 @@ Validate the spec cheaply before committing to Swift.
       and **sleep score** to Swift in `OpenRingKit/Analytics/`, with tests mirroring
       openwhoop's own Rust vectors (exact calibration anchors match: strain 21.0 at
       24h@maxHR, stress 10.0 at constant RR).
-- [x] Port **sleep-cycle detection** (activity.rs: gravity-vector stillness →
-      Sleep/Active periods, `findSleep`) to `Analytics/SleepDetection.swift`, with
-      tests mirroring openwhoop's. ⚠️ needs a per-reading **gravity vector** — the
-      ring's IMU stream is 🔴 (likely the 0x47/0x4c bulk frames), so it's algorithm-
-      ready but not yet wired to real data.
-- [ ] Wire analytics to real decoded metrics (blocked: RR-interval availability &
-      sample cadence are 🔴 in PROTOCOL.md §5 — needs a capture).
+- [x] Port **sleep-cycle detection** (activity.rs: stillness → Sleep/Active periods,
+      `findSleep`) to `Analytics/SleepDetection.swift`, with tests mirroring openwhoop's.
+- [x] **Wire sleep detection to real data** — `detectFromMotion` feeds the decoded
+      `0x4c [10:15]` motion channel (no gravity vector needed) into the same core;
+      `BulkSleep.sleepSegments` → `inBed`/`asleepCore`/`awake` for HealthKit, surfaced in
+      RingSession + ContentView. Validated on the 2026-06-13 night: detects in-bed
+      00:33→09:34 vs the app's ~00:32→09:30. Finer Deep/REM staging is a TODO (needs an
+      HR-based model — the ring sends no hypnogram).
+- [ ] Wire **HRV/stress/strain** to real metrics (still gated: those assume per-beat
+      RR intervals; the ring sends per-epoch HRV(ms)/HR, not RR — see note below).
 - [ ] Write derived metrics to HealthKit / app UI (Phase 4 dependency).
 
 > ⚠️ The ported analytics assume per-beat **RR intervals** and ~1 Hz HR (Whoop's

--- a/docs/RUNBOOK_OVERNIGHT_TEMP.md
+++ b/docs/RUNBOOK_OVERNIGHT_TEMP.md
@@ -1,0 +1,86 @@
+# Runbook — overnight capture for skin temperature (and sleep stages / HRV)
+
+Goal: capture the data we **can't get yet** — skin temperature, plus ground-truth
+sleep stages and HRV — by recording the official app's **first morning sync** over
+Android HCI snoop. See [`PROTOCOL.md`](PROTOCOL.md) §5 / issues #7, #9, #12.
+
+## Why it has to be done this way
+- **Skin temp is measured only overnight** and is **absent from the sleep/PPG frames
+  we've already decoded** (`0x4c`/`0x47`) and from the cached Temperature screen. The
+  official app must issue a temp-specific fetch command we haven't observed yet — so we
+  capture *the official app doing the morning sync*, not our own app.
+- **The ring only holds UN-synced data.** Once an app drains the night, it's gone from
+  the ring. So we must stop the app from trickle-syncing overnight, then capture the one
+  big first-sync in the morning.
+- Decoding needs **ground truth**: the app's own numbers for that night, matched against
+  the raw bytes in the log.
+
+Device facts (from memory `ring-device-access.md`):
+- Ring BLE MAC: `F8:79:99:F7:03:AD`
+- Official app package: `com.gdjztech.ringconn`
+- Android phone: Samsung SM-G781U1 (`RFCR81AZS4W`), HCI snoop already enabled (full).
+
+## Bond trade-off (read first)
+Logging into the official app on **Android steals the BLE bond from the iPhone**, so our
+iOS app stops working until you re-pair (open the official iOS app once). If you'd rather
+not disturb the iPhone, use the **PacketLogger-on-iPhone** alternative at the bottom.
+
+---
+
+## Tonight (before bed)
+1. Confirm snoop logging is on:
+   ```
+   adb shell dumpsys bluetooth_manager | grep -i snoop
+   ```
+   (expect enabled / full)
+2. Stop the app so it can't trickle-sync overnight — this keeps the whole night on the
+   ring for one clean morning sync:
+   ```
+   adb shell am force-stop com.gdjztech.ringconn
+   ```
+3. Wear the ring **snug, normal finger, OFF the charger** (it doesn't measure on the
+   charger). Sleep. The ring records temp onboard regardless of any app connection.
+
+## In the morning (first thing — don't open the app until ready)
+1. Open the official app; let it finish its one big first-sync of the whole night.
+2. Immediately grab the log:
+   ```
+   adb bugreport ~/Documents/Git/OpenRingConn/desktop/captures/overnight_temp.zip
+   ```
+3. Write down the app's numbers for that night (these are the ground truth):
+   - **Skin temperature** — the °F value **and** the deviation (e.g. `96.58°F, -0.16`).
+     *Most important.*
+   - Sleep: total sleep, time in bed, **deep / REM / light / awake** durations, and
+     sleep / wake times.
+   - Avg **HR**, **HRV** (ms), **SpO₂** (avg + lowest + when), **respiratory rate**.
+   - The date of the night.
+
+## Hand back to Claude
+Provide the zip path + the ground-truth numbers. Claude will:
+1. Extract `FS/data/log/bt/btsnoop_hci.log` from the zip.
+2. Decode + filter to the ring:
+   ```
+   python -m openringconn decode-log captures/btsnoop_hci.log --addr F8:79:99:F7:03:AD
+   ```
+3. Search for the temp value. Working hypothesis: encoded as **0.1 °C** (so 96.58 °F =
+   35.88 °C → look for `0x0166`/`0x0167`), but Claude matches against whatever number you
+   give. Also look for a **new command** the app sends that we haven't catalogued, and the
+   `0x06` sub-mode / dedicated fetch that precedes the temp frame.
+4. Same capture aligns sleep-stage and HRV bytes against ground truth (#7, #9).
+
+## Fallback (only if temp is missing from the log)
+If decode shows the app's sync cursor had already advanced past the temp record, the next
+morning escalate to a full from-scratch re-pull (wipes the cursor — same trick that
+cracked steps). Note: this logs you out and re-pairs.
+```
+adb shell pm clear com.gdjztech.ringconn
+```
+Then reopen, log in, let it re-sync everything, and capture as above. Tonight's
+force-stop step exists specifically to avoid needing this.
+
+## Alternative — capture from iPhone (preserves the bond)
+If you don't want to move the bond to Android: capture the **official iOS app** with
+Apple's **PacketLogger** (Additional Tools for Xcode) using a Bluetooth logging
+configuration profile on the iPhone, then export the `.pklg` and hand it over. More
+setup than Android btsnoop, but it doesn't steal the bond. Ask Claude for the
+step-by-step if you go this route.

--- a/ios/OpenRingConn/App.swift
+++ b/ios/OpenRingConn/App.swift
@@ -115,8 +115,34 @@ struct RollupBackup: Codable {
         var updatedAt: Date
         var healthWrittenSteps: Int
     }
+    /// User-ENTERED period logs (#78). Unlike sleep/steps these are NOT re-syncable from the
+    /// ring or recoverable from Apple Health (HK menstrualFlow isn't read back), so they're the
+    /// most irreplaceable rows and MUST survive a wipe. `healthWritten` + `hkSampleUUIDs` round-
+    /// trip so a restored entry isn't re-written to HealthKit and stays editable/deletable there.
+    struct Period: Codable {
+        var start: Date
+        var end: Date?
+        var flowLevelRaw: Int
+        var symptoms: [String]
+        var notes: String
+        var healthWritten: Bool
+        var hkSampleUUIDs: [String]
+        var updatedAt: Date
+    }
+    /// Auto-detected naps (#76). Re-derivable from synced sleep, but cheap to preserve and the
+    /// `healthWritten` flag round-trips so a restored nap isn't re-mirrored to Health.
+    struct Nap: Codable {
+        var start: Date
+        var end: Date
+        var asleepMin: Int
+        var isLongNap: Bool
+        var healthWritten: Bool
+        var updatedAt: Date
+    }
     var sleep: [Sleep]
     var daily: [Daily]
+    var periods: [Period]
+    var naps: [Nap]
 
     private static var backupURL: URL? {
         guard let dir = try? FileManager.default.url(
@@ -130,12 +156,15 @@ struct RollupBackup: Codable {
     /// them — and write a JSON snapshot. Returns the snapshot (nil if even this best-effort read
     /// fails). The file persists so a crash mid-wipe can't lose the rollups.
     static func exportBeforeWipe(config: ModelConfiguration) -> RollupBackup? {
-        let schema = Schema([StoredSleepSummary.self, StoredDaily.self])
+        let schema = Schema([StoredSleepSummary.self, StoredDaily.self,
+                             StoredPeriodEntry.self, StoredNap.self])
         let limited = ModelConfiguration(schema: schema, url: config.url)
         guard let container = try? ModelContainer(for: schema, configurations: limited) else { return nil }
         let ctx = ModelContext(container)
         let sleepRows = (try? ctx.fetch(FetchDescriptor<StoredSleepSummary>())) ?? []
         let dailyRows = (try? ctx.fetch(FetchDescriptor<StoredDaily>())) ?? []
+        let periodRows = (try? ctx.fetch(FetchDescriptor<StoredPeriodEntry>())) ?? []
+        let napRows = (try? ctx.fetch(FetchDescriptor<StoredNap>())) ?? []
         let backup = RollupBackup(
             sleep: sleepRows.map {
                 Sleep(night: $0.night, asleepMin: $0.asleepMin, deepMin: $0.deepMin,
@@ -146,6 +175,15 @@ struct RollupBackup: Codable {
             daily: dailyRows.map {
                 Daily(day: $0.day, steps: $0.steps, updatedAt: $0.updatedAt,
                       healthWrittenSteps: $0.healthWrittenSteps)
+            },
+            periods: periodRows.map {
+                Period(start: $0.start, end: $0.end, flowLevelRaw: $0.flowLevelRaw,
+                       symptoms: $0.symptoms, notes: $0.notes, healthWritten: $0.healthWritten,
+                       hkSampleUUIDs: $0.hkSampleUUIDs, updatedAt: $0.updatedAt)
+            },
+            naps: napRows.map {
+                Nap(start: $0.start, end: $0.end, asleepMin: $0.asleepMin,
+                    isLongNap: $0.isLongNap, healthWritten: $0.healthWritten, updatedAt: $0.updatedAt)
             })
         if let url = backupURL, let data = try? JSONEncoder().encode(backup) {
             try? data.write(to: url, options: .atomic)
@@ -167,6 +205,17 @@ struct RollupBackup: Codable {
         for d in daily {
             ctx.insert(StoredDaily(day: d.day, steps: d.steps, updatedAt: d.updatedAt,
                                    healthWrittenSteps: d.healthWrittenSteps))
+        }
+        for p in periods {
+            ctx.insert(StoredPeriodEntry(
+                start: p.start, end: p.end, flowLevelRaw: p.flowLevelRaw,
+                symptoms: p.symptoms, notes: p.notes, healthWritten: p.healthWritten,
+                hkSampleUUIDs: p.hkSampleUUIDs, updatedAt: p.updatedAt))
+        }
+        for n in naps {
+            ctx.insert(StoredNap(start: n.start, end: n.end, asleepMin: n.asleepMin,
+                                 isLongNap: n.isLongNap, healthWritten: n.healthWritten,
+                                 updatedAt: n.updatedAt))
         }
         if (try? ctx.save()) != nil, let url = Self.backupURL {
             try? FileManager.default.removeItem(at: url)

--- a/ios/OpenRingConn/App.swift
+++ b/ios/OpenRingConn/App.swift
@@ -4,11 +4,52 @@ import SwiftData
 @main
 struct OpenRingConnApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    private let container = OpenRingConnApp.makeContainer()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
-        .modelContainer(for: [StoredSample.self, StoredCursor.self])
+        .modelContainer(container)
+    }
+
+    /// Build the SwiftData container, recovering from an incompatible on-disk store.
+    ///
+    /// The default `.modelContainer(for:)` modifier traps if the container can't be
+    /// created — e.g. a schema change that lightweight migration can't handle — so the
+    /// app dies on the launch screen (black screen). Instead, if the first attempt
+    /// fails we wipe the local store and retry: it's only a cache of metrics the ring
+    /// re-syncs (and that are already in Apple Health), so nothing is permanently lost.
+    /// Prefer a real `SchemaMigrationPlan` for *expected* migrations; this is the
+    /// last-resort net so a model change can never hard-crash launch again.
+    static func makeContainer() -> ModelContainer {
+        let schema = Schema([StoredSample.self, StoredCursor.self])
+        let config = ModelConfiguration(schema: schema)
+
+        do {
+            return try ModelContainer(for: schema, configurations: config)
+        } catch {
+            #if DEBUG
+            print("SwiftData store unusable (\(error)); resetting local cache and retrying.")
+            #endif
+            removeStoreFiles(at: config.url)
+            do {
+                return try ModelContainer(for: schema, configurations: config)
+            } catch {
+                // A fresh store still failed — genuinely unrecoverable (e.g. no disk).
+                fatalError("Unrecoverable SwiftData store error: \(error)")
+            }
+        }
+    }
+
+    /// Delete the SQLite store plus its `-shm`/`-wal` sidecar files.
+    private static func removeStoreFiles(at storeURL: URL) {
+        let fm = FileManager.default
+        let base = storeURL.deletingPathExtension()
+        for url in [storeURL,
+                    base.appendingPathExtension("store-shm"),
+                    base.appendingPathExtension("store-wal")] {
+            try? fm.removeItem(at: url)
+        }
     }
 }

--- a/ios/OpenRingConn/App.swift
+++ b/ios/OpenRingConn/App.swift
@@ -23,7 +23,8 @@ struct OpenRingConnApp: App {
     /// Prefer a real `SchemaMigrationPlan` for *expected* migrations; this is the
     /// last-resort net so a model change can never hard-crash launch again.
     static func makeContainer() -> ModelContainer {
-        let schema = Schema([StoredSample.self, StoredCursor.self])
+        let schema = Schema([StoredSample.self, StoredCursor.self,
+                             StoredSleepSummary.self, StoredDaily.self])
         let config = ModelConfiguration(schema: schema)
 
         do {

--- a/ios/OpenRingConn/App.swift
+++ b/ios/OpenRingConn/App.swift
@@ -26,7 +26,8 @@ struct OpenRingConnApp: App {
     enum SchemaV1: VersionedSchema {
         static var versionIdentifier = Schema.Version(1, 0, 0)
         static var models: [any PersistentModel.Type] {
-            [StoredSample.self, StoredCursor.self, StoredSleepSummary.self, StoredDaily.self]
+            [StoredSample.self, StoredCursor.self, StoredSleepSummary.self, StoredDaily.self,
+             StoredNap.self]
         }
     }
 
@@ -51,7 +52,7 @@ struct OpenRingConnApp: App {
     /// are not backed up — they're already in Apple Health. (#40)
     static func makeContainer() -> ModelContainer {
         let schema = Schema([StoredSample.self, StoredCursor.self,
-                             StoredSleepSummary.self, StoredDaily.self])
+                             StoredSleepSummary.self, StoredDaily.self, StoredNap.self])
         let config = ModelConfiguration(schema: schema)
 
         do {

--- a/ios/OpenRingConn/App.swift
+++ b/ios/OpenRingConn/App.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @main
 struct OpenRingConnApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/ios/OpenRingConn/App.swift
+++ b/ios/OpenRingConn/App.swift
@@ -27,7 +27,7 @@ struct OpenRingConnApp: App {
         static var versionIdentifier = Schema.Version(1, 0, 0)
         static var models: [any PersistentModel.Type] {
             [StoredSample.self, StoredCursor.self, StoredSleepSummary.self, StoredDaily.self,
-             StoredNap.self]
+             StoredNap.self, StoredPeriodEntry.self]
         }
     }
 
@@ -52,7 +52,8 @@ struct OpenRingConnApp: App {
     /// are not backed up — they're already in Apple Health. (#40)
     static func makeContainer() -> ModelContainer {
         let schema = Schema([StoredSample.self, StoredCursor.self,
-                             StoredSleepSummary.self, StoredDaily.self, StoredNap.self])
+                             StoredSleepSummary.self, StoredDaily.self, StoredNap.self,
+                             StoredPeriodEntry.self])
         let config = ModelConfiguration(schema: schema)
 
         do {

--- a/ios/OpenRingConn/App.swift
+++ b/ios/OpenRingConn/App.swift
@@ -9,38 +9,79 @@ struct OpenRingConnApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                // Retention housekeeping: drop raw samples older than the window once per launch
+                // (the data already lives in Apple Health; rollups are kept). Runs off the launch
+                // path, never per write — see LocalStore.pruneExpiredSamples. (#32)
+                .task { OpenRingConnApp.pruneExpiredSamplesAtLaunch(container) }
         }
         .modelContainer(container)
     }
 
+    // MARK: Schema versioning (#40)
+    //
+    // A real (currently single-version) migration plan so an *expected* schema change is handled
+    // by lightweight/custom migration instead of falling through to the last-resort wipe below.
+    // Future schema changes append a `VersionedSchema` + a `MigrationStage` here rather than
+    // relying on the wipe — which destroys un-resyncable local history.
+    enum SchemaV1: VersionedSchema {
+        static var versionIdentifier = Schema.Version(1, 0, 0)
+        static var models: [any PersistentModel.Type] {
+            [StoredSample.self, StoredCursor.self, StoredSleepSummary.self, StoredDaily.self]
+        }
+    }
+
+    enum MigrationPlan: SchemaMigrationPlan {
+        static var schemas: [any VersionedSchema.Type] { [SchemaV1.self] }
+        static var stages: [MigrationStage] { [] }
+    }
+
+    /// UserDefaults flag the UI can read to tell the user their local cache was rebuilt (raw
+    /// sample history isn't re-syncable once the ring has been drained). Set only when the
+    /// last-resort wipe runs; the UI clears it after showing the notice. (#40)
+    static let historyResetDefaultsKey = "localHistoryWasReset"
+
     /// Build the SwiftData container, recovering from an incompatible on-disk store.
     ///
-    /// The default `.modelContainer(for:)` modifier traps if the container can't be
-    /// created — e.g. a schema change that lightweight migration can't handle — so the
-    /// app dies on the launch screen (black screen). Instead, if the first attempt
-    /// fails we wipe the local store and retry: it's only a cache of metrics the ring
-    /// re-syncs (and that are already in Apple Health), so nothing is permanently lost.
-    /// Prefer a real `SchemaMigrationPlan` for *expected* migrations; this is the
-    /// last-resort net so a model change can never hard-crash launch again.
+    /// The default `.modelContainer(for:)` modifier traps if the container can't be created —
+    /// e.g. a schema change neither `MigrationPlan` nor lightweight migration can handle — so the
+    /// app dies on the launch screen (black screen). Expected migrations go through the plan;
+    /// only if that STILL fails do we fall back to wiping. Before wiping we export the durable
+    /// rollups (sleep summaries + daily steps) to a JSON backup and restore them into the fresh
+    /// store, and raise `historyResetDefaultsKey` so the UI can tell the user. Raw epoch samples
+    /// are not backed up — they're already in Apple Health. (#40)
     static func makeContainer() -> ModelContainer {
         let schema = Schema([StoredSample.self, StoredCursor.self,
                              StoredSleepSummary.self, StoredDaily.self])
         let config = ModelConfiguration(schema: schema)
 
         do {
-            return try ModelContainer(for: schema, configurations: config)
+            return try ModelContainer(for: schema, migrationPlan: MigrationPlan.self,
+                                      configurations: config)
         } catch {
             #if DEBUG
-            print("SwiftData store unusable (\(error)); resetting local cache and retrying.")
+            print("SwiftData store unusable (\(error)); backing up rollups, resetting cache, retrying.")
             #endif
+            let backup = RollupBackup.exportBeforeWipe(config: config)
             removeStoreFiles(at: config.url)
+            let fresh: ModelContainer
             do {
-                return try ModelContainer(for: schema, configurations: config)
+                fresh = try ModelContainer(for: schema, migrationPlan: MigrationPlan.self,
+                                           configurations: config)
             } catch {
                 // A fresh store still failed — genuinely unrecoverable (e.g. no disk).
                 fatalError("Unrecoverable SwiftData store error: \(error)")
             }
+            backup?.restore(into: fresh)
+            UserDefaults.standard.set(true, forKey: historyResetDefaultsKey)
+            return fresh
         }
+    }
+
+    /// Prune expired raw samples once at launch. Best-effort — retention is housekeeping, so a
+    /// failure here must never block the UI.
+    @MainActor
+    static func pruneExpiredSamplesAtLaunch(_ container: ModelContainer) {
+        try? LocalStore(container.mainContext).pruneExpiredSamples()
     }
 
     /// Delete the SQLite store plus its `-shm`/`-wal` sidecar files.
@@ -51,6 +92,82 @@ struct OpenRingConnApp: App {
                     base.appendingPathExtension("store-shm"),
                     base.appendingPathExtension("store-wal")] {
             try? fm.removeItem(at: url)
+        }
+    }
+}
+
+/// Best-effort JSON backup of the durable rollup tables, used by `makeContainer` to carry sleep
+/// summaries + daily steps across a last-resort store wipe (#40). Raw `StoredSample` epochs are
+/// intentionally excluded — they already live in Apple Health and would bloat the backup.
+/// Everything here is best-effort: a failure degrades to "history reset", never a crash.
+struct RollupBackup: Codable {
+    struct Sleep: Codable {
+        var night: Date
+        var asleepMin, deepMin, lightMin, remMin, awakeMin: Int
+        var efficiency: Double
+        var inBedStart, inBedEnd, updatedAt: Date
+    }
+    struct Daily: Codable {
+        var day: Date
+        var steps: Int
+        var updatedAt: Date
+        var healthWrittenSteps: Int
+    }
+    var sleep: [Sleep]
+    var daily: [Daily]
+
+    private static var backupURL: URL? {
+        guard let dir = try? FileManager.default.url(
+            for: .applicationSupportDirectory, in: .userDomainMask,
+            appropriateFor: nil, create: true) else { return nil }
+        return dir.appendingPathComponent("rollup-backup.json")
+    }
+
+    /// Read the rollup tables from the (un-openable-as-current) store using a schema LIMITED to
+    /// just those tables — so a schema change to the sample/cursor tables can't block reading
+    /// them — and write a JSON snapshot. Returns the snapshot (nil if even this best-effort read
+    /// fails). The file persists so a crash mid-wipe can't lose the rollups.
+    static func exportBeforeWipe(config: ModelConfiguration) -> RollupBackup? {
+        let schema = Schema([StoredSleepSummary.self, StoredDaily.self])
+        let limited = ModelConfiguration(schema: schema, url: config.url)
+        guard let container = try? ModelContainer(for: schema, configurations: limited) else { return nil }
+        let ctx = ModelContext(container)
+        let sleepRows = (try? ctx.fetch(FetchDescriptor<StoredSleepSummary>())) ?? []
+        let dailyRows = (try? ctx.fetch(FetchDescriptor<StoredDaily>())) ?? []
+        let backup = RollupBackup(
+            sleep: sleepRows.map {
+                Sleep(night: $0.night, asleepMin: $0.asleepMin, deepMin: $0.deepMin,
+                      lightMin: $0.lightMin, remMin: $0.remMin, awakeMin: $0.awakeMin,
+                      efficiency: $0.efficiency, inBedStart: $0.inBedStart,
+                      inBedEnd: $0.inBedEnd, updatedAt: $0.updatedAt)
+            },
+            daily: dailyRows.map {
+                Daily(day: $0.day, steps: $0.steps, updatedAt: $0.updatedAt,
+                      healthWrittenSteps: $0.healthWrittenSteps)
+            })
+        if let url = backupURL, let data = try? JSONEncoder().encode(backup) {
+            try? data.write(to: url, options: .atomic)
+        }
+        return backup
+    }
+
+    /// Re-insert the backed-up rollups into the fresh store, then remove the JSON file. The
+    /// unique `night`/`day` keys keep this idempotent. Best-effort — a failure just means the
+    /// dashboard starts without past history.
+    func restore(into container: ModelContainer) {
+        let ctx = ModelContext(container)
+        for s in sleep {
+            ctx.insert(StoredSleepSummary(
+                night: s.night, asleepMin: s.asleepMin, deepMin: s.deepMin, lightMin: s.lightMin,
+                remMin: s.remMin, awakeMin: s.awakeMin, efficiency: s.efficiency,
+                inBedStart: s.inBedStart, inBedEnd: s.inBedEnd, updatedAt: s.updatedAt))
+        }
+        for d in daily {
+            ctx.insert(StoredDaily(day: d.day, steps: d.steps, updatedAt: d.updatedAt,
+                                   healthWrittenSteps: d.healthWrittenSteps))
+        }
+        if (try? ctx.save()) != nil, let url = Self.backupURL {
+            try? FileManager.default.removeItem(at: url)
         }
     }
 }

--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -41,7 +41,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                     store: LocalStore(container.mainContext),
                     health: HealthKitWriter()
                 )
-                let synced = try await service.syncVitals(timeout: 20)
+                // Use the service's adaptive budget (longer than the old 20 s so the live-HR
+                // poll isn't starved by the history drain, #45 A). The expirationHandler below
+                // still cancels cleanly if iOS grants a shorter window.
+                let synced = try await service.syncVitals()
                 guard !Task.isCancelled else { return }
                 scheduler.schedule()
                 task.setTaskCompleted(success: synced)

--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -1,0 +1,52 @@
+import BackgroundTasks
+import SwiftData
+import UIKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    private let scheduler = BackgroundRefreshScheduler()
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        scheduler.register { task in
+            guard let refreshTask = task as? BGAppRefreshTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            Self.handle(refreshTask)
+        }
+        return true
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        scheduler.schedule()
+    }
+
+    private static func handle(_ task: BGAppRefreshTask) {
+        let scheduler = BackgroundRefreshScheduler()
+        scheduler.schedule()
+
+        let operation = Task { @MainActor in
+            do {
+                let container = try ModelContainer(for: StoredSample.self, StoredCursor.self)
+                let service = RingBackgroundSyncService(
+                    store: LocalStore(container.mainContext),
+                    health: HealthKitWriter()
+                )
+                let synced = try await service.syncLiveHeartRate(timeout: 20)
+                guard !Task.isCancelled else { return }
+                scheduler.schedule()
+                task.setTaskCompleted(success: synced)
+            } catch {
+                guard !Task.isCancelled else { return }
+                scheduler.schedule()
+                task.setTaskCompleted(success: false)
+            }
+        }
+
+        task.expirationHandler = {
+            operation.cancel()
+            scheduler.schedule()
+            task.setTaskCompleted(success: false)
+        }
+    }
+}

--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -27,7 +27,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
         let operation = Task { @MainActor in
             do {
-                let container = try ModelContainer(for: StoredSample.self, StoredCursor.self)
+                let container = OpenRingConnApp.makeContainer()
                 let service = RingBackgroundSyncService(
                     store: LocalStore(container.mainContext),
                     health: HealthKitWriter()

--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -14,6 +14,15 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
             }
             Self.handle(refreshTask)
         }
+
+        // Re-instantiate the CBCentralManager (with its restore identifier) during launch so
+        // iOS can deliver state restoration — including when it relaunches us in the
+        // background because the ring came back in range. Touching `.shared` creates the
+        // central; `reconnectKnownPeripheral` then arms a pending connect-by-identifier to the
+        // last ring (no scan — background scans without a service filter are dropped). (#7)
+        MainActor.assumeIsolated {
+            RingScanner.shared.reconnectKnownPeripheral()
+        }
         return true
     }
 

--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -70,6 +70,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                 observability.recordSyncOutcome(kind: kind, success: synced,
                                                 detail: synced ? "captured/flushed data" : "no data this run")
                 await Self.evaluateAlerts()
+                // Body-vital alerts (#73/#85) from the freshly-synced store — battery/session are
+                // gone in the background, so this reads persisted samples only (session: nil).
+                await HealthNotificationCenter().evaluate(store: LocalStore(container.mainContext),
+                                                          session: nil)
                 scheduler.schedule()
                 scheduler.scheduleProcessing()
                 task.setTaskCompleted(success: synced)

--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -32,7 +32,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                     store: LocalStore(container.mainContext),
                     health: HealthKitWriter()
                 )
-                let synced = try await service.syncLiveHeartRate(timeout: 20)
+                let synced = try await service.syncVitals(timeout: 20)
                 guard !Task.isCancelled else { return }
                 scheduler.schedule()
                 task.setTaskCompleted(success: synced)

--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -1,12 +1,19 @@
 import BackgroundTasks
 import SwiftData
 import UIKit
+import UserNotifications
 
-final class AppDelegate: NSObject, UIApplicationDelegate {
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     private let scheduler = BackgroundRefreshScheduler()
 
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        // Show health alerts / reminders even when the app is in the FOREGROUND — which is the
+        // primary moment they're evaluated (scenePhase==.active and on sync completion). Without
+        // a delegate returning presentation options, iOS silently suppresses foreground-delivered
+        // local notifications, so the user would see nothing and the backoff would still record a
+        // fire — making them miss the alert entirely.
+        UNUserNotificationCenter.current().delegate = self
         scheduler.register { task in
             guard let refreshTask = task as? BGAppRefreshTask else {
                 task.setTaskCompleted(success: false)
@@ -95,6 +102,15 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
             scheduler.scheduleProcessing()
             task.setTaskCompleted(success: false)
         }
+    }
+
+    /// Present locally-posted notifications as a banner+sound+list entry while the app is in the
+    /// foreground (default iOS behavior is to suppress them). Health alerts and reminders are
+    /// evaluated mostly in the foreground, so this is what makes them actually visible.
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification) async
+        -> UNNotificationPresentationOptions {
+        [.banner, .sound, .list]
     }
 
     /// Fire debounced local notifications for silent-failure conditions after a background run.

--- a/ios/OpenRingConn/AppDelegate.swift
+++ b/ios/OpenRingConn/AppDelegate.swift
@@ -12,7 +12,18 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                 task.setTaskCompleted(success: false)
                 return
             }
-            Self.handle(refreshTask)
+            Self.handle(refreshTask, kind: .appRefresh,
+                        timeout: RingBackgroundSyncService.defaultTimeout)
+        }
+        // BGProcessingTask: the longer-window sibling that finally gives the optical-HR poll room
+        // to clear its ~60 s warm-up in the background (#45). Same sync path, larger time budget.
+        scheduler.registerProcessing { task in
+            guard let processingTask = task as? BGProcessingTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            Self.handle(processingTask, kind: .processing,
+                        timeout: RingBackgroundSyncService.processingTimeout)
         }
 
         // Re-instantiate the CBCentralManager (with its restore identifier) during launch so
@@ -28,11 +39,20 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
     func applicationDidEnterBackground(_ application: UIApplication) {
         scheduler.schedule()
+        scheduler.scheduleProcessing()
+        ObservabilityStore().recordScheduled()
     }
 
-    private static func handle(_ task: BGAppRefreshTask) {
+    /// Run one bounded background sync for either BGTask variant. `kind`/`timeout` differ (short
+    /// app-refresh vs. longer processing), but the body is shared: schedule the next runs, sync,
+    /// record the outcome to the observability log, and fire any debounced silent-failure alerts
+    /// (#44). Always re-submits BOTH requests so a granted run keeps the chain alive.
+    private static func handle(_ task: BGTask, kind: TaskRecord.Kind, timeout: TimeInterval) {
         let scheduler = BackgroundRefreshScheduler()
+        let observability = ObservabilityStore()
         scheduler.schedule()
+        scheduler.scheduleProcessing()
+        observability.recordScheduled()
 
         let operation = Task { @MainActor in
             do {
@@ -41,24 +61,44 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                     store: LocalStore(container.mainContext),
                     health: HealthKitWriter()
                 )
-                // Use the service's adaptive budget (longer than the old 20 s so the live-HR
-                // poll isn't starved by the history drain, #45 A). The expirationHandler below
-                // still cancels cleanly if iOS grants a shorter window.
-                let synced = try await service.syncVitals()
+                // Pass the per-task budget. The app-refresh path keeps the ~28 s budget so the
+                // live-HR poll isn't starved by the history drain (#45 A); the processing path
+                // gets the longer budget so the poll can actually lock. The expirationHandler
+                // below still cancels cleanly if iOS grants a shorter window.
+                let synced = try await service.syncVitals(timeout: timeout)
                 guard !Task.isCancelled else { return }
+                observability.recordSyncOutcome(kind: kind, success: synced,
+                                                detail: synced ? "captured/flushed data" : "no data this run")
+                await Self.evaluateAlerts()
                 scheduler.schedule()
+                scheduler.scheduleProcessing()
                 task.setTaskCompleted(success: synced)
             } catch {
                 guard !Task.isCancelled else { return }
+                observability.recordSyncOutcome(kind: kind, success: false,
+                                                detail: "error: \(error.localizedDescription)")
+                await Self.evaluateAlerts()
                 scheduler.schedule()
+                scheduler.scheduleProcessing()
                 task.setTaskCompleted(success: false)
             }
         }
 
         task.expirationHandler = {
             operation.cancel()
+            observability.recordSyncOutcome(kind: kind, success: false, detail: "iOS ended the task early")
             scheduler.schedule()
+            scheduler.scheduleProcessing()
             task.setTaskCompleted(success: false)
         }
+    }
+
+    /// Fire debounced local notifications for silent-failure conditions after a background run.
+    /// Battery is nil here (the background session is already torn down), so low-battery is
+    /// evaluated only in the foreground (ContentView) where a live reading exists — the staleness
+    /// and Health-auth-lost conditions are the ones that matter when iOS isn't waking us. (#44)
+    private static func evaluateAlerts() async {
+        let healthAuthorized = await MainActor.run { HealthKitWriter().isShareAuthorized }
+        await LocalAlertCenter().evaluate(batteryPercent: nil, healthAuthorized: healthAuthorized)
     }
 }

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -168,18 +168,30 @@ final class RingScanner: NSObject {
         reconnectKnownPeripheral()   // re-arm the standing pending connect (no scan)
     }
 
-    /// Bounded one-shot live-HR read for the background-refresh task: scan/connect,
-    /// start HR monitoring, and return the first reading (or nil on timeout). Always
-    /// disconnects on the way out so the link isn't held open in the background.
-    func readLiveHeartRate(timeout: TimeInterval) async -> Int? {
+    /// What a bounded background read captured. `startMonitoring(.hr)` first drains the
+    /// ring's history backlog to completion (overnight HR/HRV/SpO2 → the store, plus the
+    /// sleep segments + step/temp descriptor) BEFORE it can poll a live HR, so even when the
+    /// live HR never locks we still come away with last night's data. `gotData` is the
+    /// BGTask success flag — true if we captured anything worth persisting, not just an HR.
+    struct BackgroundCapture {
+        var heartRate: Int?
+        var sleepSegments: [SleepSegment] = []
+        var steps: Int?
+        var gotData: Bool { heartRate != nil || !sleepSegments.isEmpty || (steps ?? 0) > 0 }
+    }
+
+    /// Bounded one-shot background read: reconnect (no-scan by identifier, else a
+    /// service-filtered scan), drain + decode the ring's history, and snapshot it for the
+    /// caller to mirror into Apple Health. Always tears the link down (re-arming the standing
+    /// reconnect) on the way out so nothing is held open in the background.
+    func captureForBackground(timeout: TimeInterval) async -> BackgroundCapture {
         let deadline = Date().addingTimeInterval(timeout)
         var didStart = false
-        // Prefer a no-scan reconnect-by-identifier (works in the background); only fall back
-        // to the service-filtered scan if we've never connected to a ring before.
         if !reconnectKnownPeripheral() {
             start(services: Self.backgroundScanServices)
         }
 
+        var capture = BackgroundCapture()
         defer { endBackgroundReadRearming() }
 
         while !Task.isCancelled && Date() < deadline {
@@ -188,9 +200,11 @@ final class RingScanner: NSObject {
                     session.startMonitoring(mode: .hr)
                     didStart = true
                 }
-                if let liveHR = session.liveHR {
-                    return liveHR
-                }
+                // Snapshot the decoded history as it lands; the drain completes before the
+                // first live HR, so this captures sleep/steps even if HR never locks.
+                if !session.sleepSegments.isEmpty { capture.sleepSegments = session.sleepSegments }
+                if let s = session.steps { capture.steps = s }
+                if let liveHR = session.liveHR { capture.heartRate = liveHR; break }
             } else if case .idle = state {
                 if !reconnectKnownPeripheral() {
                     start(services: Self.backgroundScanServices)
@@ -198,7 +212,14 @@ final class RingScanner: NSObject {
             }
             try? await Task.sleep(for: .seconds(1))
         }
-        return nil
+        // Final snapshot before teardown, in case we exited on the deadline after the drain
+        // completed but before a live HR arrived.
+        if let session {
+            if capture.sleepSegments.isEmpty { capture.sleepSegments = session.sleepSegments }
+            if capture.steps == nil { capture.steps = session.steps }
+            if capture.heartRate == nil { capture.heartRate = session.liveHR }
+        }
+        return capture
     }
 }
 

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -49,6 +49,11 @@ final class RingScanner: NSObject {
         set { UserDefaults.standard.set(newValue, forKey: savedPeripheralKey) }
     }
 
+    /// True when a previously connected ring's identifier is saved, so a no-scan
+    /// reconnect-by-identifier is possible. The foreground auto-refresh uses this to
+    /// decide whether there's anything to reconnect to (vs. requiring a user Scan).
+    var hasSavedRing: Bool { Self.savedPeripheralID != nil }
+
     /// Set when a reconnect was requested before Bluetooth finished powering on; retried
     /// from `centralManagerDidUpdateState` once `.poweredOn` arrives.
     private var reconnectWhenPoweredOn = false

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -89,6 +89,9 @@ final class RingScanner: NSObject {
 
     func stop() {
         wantConnection = false
+        // Explicit user stop: forget the ring so we don't silently auto-reconnect on the next
+        // launch (reconnect-by-identifier only re-arms while an id is saved). (Reviewer MINOR.)
+        Self.savedPeripheralID = nil
         central.stopScan()
         if let target { central.cancelPeripheralConnection(target) }
         if case .scanning = state { state = .idle }
@@ -145,6 +148,21 @@ final class RingScanner: NSObject {
         state = .idle
     }
 
+    /// End-of-background-read teardown that RE-ARMS reconnection. The bounded read must not
+    /// leave the link held open, but a plain `disconnect()` also clears the standing pending
+    /// connect that lets iOS wake us (state restoration) next time the ring is in range —
+    /// disarming the very background path we want. So: drop the live link, then re-issue a
+    /// no-scan pending connect-by-identifier so reconnection stays armed across the next
+    /// suspension. (Reviewer MAJOR fix.)
+    private func endBackgroundReadRearming() {
+        session?.stopLiveMonitoring()
+        session = nil
+        if let target { central.cancelPeripheralConnection(target) }
+        target = nil
+        state = .idle
+        reconnectKnownPeripheral()   // re-arm the standing pending connect (no scan)
+    }
+
     /// Bounded one-shot live-HR read for the background-refresh task: scan/connect,
     /// start HR monitoring, and return the first reading (or nil on timeout). Always
     /// disconnects on the way out so the link isn't held open in the background.
@@ -157,7 +175,7 @@ final class RingScanner: NSObject {
             start(services: Self.backgroundScanServices)
         }
 
-        defer { disconnect() }
+        defer { endBackgroundReadRearming() }
 
         while !Task.isCancelled && Date() < deadline {
             if let session, session.ready {
@@ -184,7 +202,14 @@ extension RingScanner: CBCentralManagerDelegate {
         Task { @MainActor in
             switch central.state {
             case .poweredOn:
-                self.state = .idle
+                // Don't clobber a link state restoration already rebuilt: willRestoreState
+                // runs BEFORE this and may have set .connected/.connecting. Only fall back to
+                // .idle from a non-connected state (otherwise the UI would show "Scan & connect"
+                // over a live connection).
+                switch self.state {
+                case .connected, .connecting: break
+                default: self.state = .idle
+                }
                 // A reconnect was requested before Bluetooth was ready (cold/background
                 // launch) — complete it now that the radio is on.
                 if self.reconnectWhenPoweredOn { self.reconnectKnownPeripheral() }
@@ -219,7 +244,12 @@ extension RingScanner: CBCentralManagerDelegate {
             default:
                 // Re-issue the pending connect so we reconnect when the ring is in range.
                 self.state = .connecting(peripheral.name ?? "RingConn")
-                self.central.connect(peripheral)
+                if self.central.state == .poweredOn {
+                    self.central.connect(peripheral)
+                } else {
+                    // Radio not up yet on a cold restoration — retry once powered on.
+                    self.reconnectWhenPoweredOn = true
+                }
             }
         }
     }

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -20,6 +20,13 @@ final class RingScanner: NSObject {
         case poweredOff, unauthorized, scanning, connecting(String), connected(String), idle
     }
 
+    /// Shared instance. State restoration + background relaunch require a SINGLE
+    /// CBCentralManager that's re-created (with the same restore identifier) early in
+    /// every launch — including when iOS relaunches us in the background because the ring
+    /// came back in range. A per-view/per-task manager would either miss restoration or
+    /// collide on the restore identifier, so everything funnels through this one. (#7)
+    static let shared = RingScanner()
+
     private(set) var state: State = .idle
     private(set) var session: RingSession?
 
@@ -27,9 +34,35 @@ final class RingScanner: NSObject {
     private var target: CBPeripheral?
     private var localStore: LocalStore?
 
-    override init() {
+    /// Stable identifier that lets iOS associate the restored Bluetooth state with this
+    /// central across relaunches. Must be constant for the life of the app.
+    private static let restoreIdentifier = "com.openringconn.central.restore"
+
+    /// UserDefaults key holding the last connected peripheral's CoreBluetooth identifier
+    /// (a per-device UUID — NOT the MAC, which iOS never exposes). Lets us reconnect by
+    /// identifier with no scan after a cold launch / background relaunch.
+    private static let savedPeripheralKey = "com.openringconn.ring.peripheralID"
+
+    /// Last connected peripheral's `identifier.uuidString`, persisted across launches.
+    private static var savedPeripheralID: String? {
+        get { UserDefaults.standard.string(forKey: savedPeripheralKey) }
+        set { UserDefaults.standard.set(newValue, forKey: savedPeripheralKey) }
+    }
+
+    /// Set when a reconnect was requested before Bluetooth finished powering on; retried
+    /// from `centralManagerDidUpdateState` once `.poweredOn` arrives.
+    private var reconnectWhenPoweredOn = false
+
+    private override init() {
         super.init()
-        central = CBCentralManager(delegate: self, queue: .main)
+        // Opting into state restoration: iOS preserves this central's connections/pending
+        // connects while the app is suspended and relaunches the app (into the background)
+        // when a relevant BLE event fires — delivered via `willRestoreState`.
+        central = CBCentralManager(
+            delegate: self,
+            queue: .main,
+            options: [CBCentralManagerOptionRestoreIdentifierKey: Self.restoreIdentifier]
+        )
     }
 
     /// True once the user has connected; keeps us auto-reconnecting if the ring sleeps.
@@ -61,6 +94,38 @@ final class RingScanner: NSObject {
         if case .scanning = state { state = .idle }
     }
 
+    /// Reconnect to the last-known ring WITHOUT scanning. `retrievePeripherals` resurfaces a
+    /// peripheral we've connected to before by its CoreBluetooth identifier; `connect` then
+    /// issues a *pending* connect that has no timeout — it completes the moment the ring is in
+    /// range, even from the background. This is the reliable background path: iOS drops
+    /// no-service-filter background scans, but it honours a pending connect-by-identifier and
+    /// will relaunch us (via state restoration) to complete it.
+    ///
+    /// Returns `false` when there's no saved ring to reconnect to (caller falls back to a scan).
+    @discardableResult
+    func reconnectKnownPeripheral() -> Bool {
+        switch state {
+        case .connected, .connecting: return true   // already (re)connecting — nothing to do
+        default: break
+        }
+        guard central.state == .poweredOn else {
+            // Bluetooth not ready yet (common on a cold/background launch). Retry from
+            // centralManagerDidUpdateState once we reach `.poweredOn`.
+            reconnectWhenPoweredOn = true
+            return false
+        }
+        reconnectWhenPoweredOn = false
+        guard let idString = Self.savedPeripheralID,
+              let uuid = UUID(uuidString: idString),
+              let peripheral = central.retrievePeripherals(withIdentifiers: [uuid]).first
+        else { return false }
+        wantConnection = true
+        target = peripheral
+        state = .connecting(peripheral.name ?? "RingConn")
+        central.connect(peripheral)
+        return true
+    }
+
     func setLocalStore(_ localStore: LocalStore) {
         self.localStore = localStore
         session?.setLocalStore(localStore)
@@ -86,7 +151,11 @@ final class RingScanner: NSObject {
     func readLiveHeartRate(timeout: TimeInterval) async -> Int? {
         let deadline = Date().addingTimeInterval(timeout)
         var didStart = false
-        start(services: Self.backgroundScanServices)
+        // Prefer a no-scan reconnect-by-identifier (works in the background); only fall back
+        // to the service-filtered scan if we've never connected to a ring before.
+        if !reconnectKnownPeripheral() {
+            start(services: Self.backgroundScanServices)
+        }
 
         defer { disconnect() }
 
@@ -100,7 +169,9 @@ final class RingScanner: NSObject {
                     return liveHR
                 }
             } else if case .idle = state {
-                start(services: Self.backgroundScanServices)
+                if !reconnectKnownPeripheral() {
+                    start(services: Self.backgroundScanServices)
+                }
             }
             try? await Task.sleep(for: .seconds(1))
         }
@@ -112,12 +183,54 @@ extension RingScanner: CBCentralManagerDelegate {
     nonisolated func centralManagerDidUpdateState(_ central: CBCentralManager) {
         Task { @MainActor in
             switch central.state {
-            case .poweredOn: self.state = .idle
+            case .poweredOn:
+                self.state = .idle
+                // A reconnect was requested before Bluetooth was ready (cold/background
+                // launch) — complete it now that the radio is on.
+                if self.reconnectWhenPoweredOn { self.reconnectKnownPeripheral() }
             case .poweredOff: self.state = .poweredOff
             case .unauthorized: self.state = .unauthorized
             default: self.state = .idle
             }
         }
+    }
+
+    /// State restoration entry point. iOS calls this (before `centralManagerDidUpdateState`)
+    /// when it relaunches the app and hands back the central's preserved peripherals — those
+    /// we were connected to or had a pending connect for at suspension. We re-adopt the ring
+    /// as our target and re-attach the session so the link keeps working with no user action.
+    nonisolated func centralManager(_ central: CBCentralManager,
+                                    willRestoreState dict: [String: Any]) {
+        let restored = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] ?? []
+        Task { @MainActor in
+            guard let peripheral = self.restoredTarget(from: restored) else { return }
+            self.wantConnection = true
+            self.target = peripheral
+            switch peripheral.state {
+            case .connected:
+                // The link survived the relaunch — rebuild the session now; `didConnect`
+                // won't fire again. RingSession re-discovers services/characteristics.
+                Self.savedPeripheralID = peripheral.identifier.uuidString
+                self.state = .connected(peripheral.name ?? "RingConn")
+                self.session = RingSession(peripheral: peripheral, localStore: self.localStore)
+            case .connecting:
+                // Pending connect still in flight; `didConnect` will complete it.
+                self.state = .connecting(peripheral.name ?? "RingConn")
+            default:
+                // Re-issue the pending connect so we reconnect when the ring is in range.
+                self.state = .connecting(peripheral.name ?? "RingConn")
+                self.central.connect(peripheral)
+            }
+        }
+    }
+
+    /// Pick which restored peripheral to re-adopt: prefer the saved id, else the first.
+    private func restoredTarget(from peripherals: [CBPeripheral]) -> CBPeripheral? {
+        if let id = Self.savedPeripheralID,
+           let match = peripherals.first(where: { $0.identifier.uuidString == id }) {
+            return match
+        }
+        return peripherals.first
     }
 
     nonisolated func centralManager(_ central: CBCentralManager,
@@ -139,6 +252,10 @@ extension RingScanner: CBCentralManagerDelegate {
     nonisolated func centralManager(_ central: CBCentralManager,
                                     didConnect peripheral: CBPeripheral) {
         Task { @MainActor in
+            // Remember this ring so we can reconnect by identifier (no scan) after a
+            // cold launch or background relaunch.
+            self.target = peripheral
+            Self.savedPeripheralID = peripheral.identifier.uuidString
             self.state = .connected(peripheral.name ?? "RingConn")
             self.session = RingSession(peripheral: peripheral, localStore: self.localStore)
         }

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -35,13 +35,23 @@ final class RingScanner: NSObject {
     /// True once the user has connected; keeps us auto-reconnecting if the ring sleeps.
     private var wantConnection = false
 
-    func start() {
+    /// Service filter for background scans. iOS only delivers scan results to a
+    /// backgrounded app when `scanForPeripherals` filters by explicit service UUIDs;
+    /// a `nil` filter (used in the foreground) yields nothing in the background (#14).
+    /// Caveat: this still requires the ring to advertise its data service — if it
+    /// advertises name-only, background reconnection must instead use
+    /// `central.connect(knownPeripheral)` against a persisted identifier.
+    private static let backgroundScanServices = [CBUUID(string: OpenRingKit.Transport.dataServiceUUID)]
+
+    /// Begin scanning. Foreground callers pass no filter: the ring is matched by its
+    /// advertised name (`matchesRingName`) and is not known to advertise its data
+    /// service, so filtering there could miss it. The background path passes
+    /// `backgroundScanServices` because nil-filtered scans are dropped while backgrounded.
+    func start(services: [CBUUID]? = nil) {
         guard central.state == .poweredOn else { return }
         wantConnection = true
         state = .scanning
-        // Discover all services (the ring is reportedly not fully GATT-compatible,
-        // so we don't filter by service UUID — those roles are 🔴 in PROTOCOL.md).
-        central.scanForPeripherals(withServices: nil)
+        central.scanForPeripherals(withServices: services)
     }
 
     func stop() {
@@ -54,6 +64,47 @@ final class RingScanner: NSObject {
     func setLocalStore(_ localStore: LocalStore) {
         self.localStore = localStore
         session?.setLocalStore(localStore)
+    }
+
+    /// Tear down the live link and STOP auto-reconnecting. Clearing `wantConnection`
+    /// before cancelling is essential: otherwise `didDisconnectPeripheral` still wants a
+    /// connection and immediately reconnects, looping forever (#14 fix).
+    func disconnect() {
+        wantConnection = false
+        central.stopScan()
+        if let target {
+            central.cancelPeripheralConnection(target)
+        }
+        session = nil
+        target = nil
+        state = .idle
+    }
+
+    /// Bounded one-shot live-HR read for the background-refresh task: scan/connect,
+    /// start HR monitoring, and return the first reading (or nil on timeout). Always
+    /// disconnects on the way out so the link isn't held open in the background.
+    func readLiveHeartRate(timeout: TimeInterval) async -> Int? {
+        let deadline = Date().addingTimeInterval(timeout)
+        var didStart = false
+        start(services: Self.backgroundScanServices)
+
+        defer { disconnect() }
+
+        while !Task.isCancelled && Date() < deadline {
+            if let session, session.ready {
+                if !didStart {
+                    session.startMonitoring(mode: .hr)
+                    didStart = true
+                }
+                if let liveHR = session.liveHR {
+                    return liveHR
+                }
+            } else if case .idle = state {
+                start(services: Self.backgroundScanServices)
+            }
+            try? await Task.sleep(for: .seconds(1))
+        }
+        return nil
     }
 }
 

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -168,11 +168,12 @@ final class RingScanner: NSObject {
         reconnectKnownPeripheral()   // re-arm the standing pending connect (no scan)
     }
 
-    /// What a bounded background read captured. `startMonitoring(.hr)` first drains the
-    /// ring's history backlog to completion (overnight HR/HRV/SpO2 → the store, plus the
-    /// sleep segments + step/temp descriptor) BEFORE it can poll a live HR, so even when the
-    /// live HR never locks we still come away with last night's data. `gotData` is the
-    /// BGTask success flag — true if we captured anything worth persisting, not just an HR.
+    /// What a bounded background read captured. The background read uses the FULL (quiet-bounded)
+    /// drain — `startMonitoring(.hr, userInitiated: false, quickLiveRead: false)` — so the
+    /// overnight HR/HRV/SpO2 + sleep segments + step/temp descriptor land in the store before it
+    /// polls a live HR, and we still come away with last night's data even when the optical HR
+    /// never locks. `gotData` is the BGTask success flag — true if we captured anything worth
+    /// persisting, not just an HR.
     struct BackgroundCapture {
         var heartRate: Int?
         var sleepSegments: [SleepSegment] = []
@@ -197,7 +198,11 @@ final class RingScanner: NSObject {
         while !Task.isCancelled && Date() < deadline {
             if let session, session.ready {
                 if !didStart {
-                    session.startMonitoring(mode: .hr)
+                    // Full drain (capture overnight sleep) but NOT user-initiated — keep any
+                    // prior live HR until a fresh one locks. The extended background timeout
+                    // (below) is what finally gives the HR poll a real budget so it can lock
+                    // instead of being crammed behind the drain (#45 A).
+                    session.startMonitoring(mode: .hr, userInitiated: false, quickLiveRead: false)
                     didStart = true
                 }
                 // Snapshot the decoded history as it lands; the drain completes before the

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -138,12 +138,17 @@ final class RingScanner: NSObject {
     }
 
     /// Cancel any in-flight reconnect backoff and clear the calm state (#35). Used on a fresh
-    /// user scan, a user stop/disconnect, and once a link proves stable.
+    /// user scan, a user stop/disconnect, and once a link proves stable. Also clears the
+    /// deferred radio-off reconnect flag: a backoff timer that fired while the radio was off
+    /// sets `reconnectWhenPoweredOn`, and a subsequent user `disconnect()` must not leave that
+    /// armed — otherwise the next `.poweredOn` would re-issue a reconnect against disconnect()'s
+    /// "STOP auto-reconnecting" intent. (Reviewer MINOR.)
     private func resetReconnectBackoff() {
         reconnectTask?.cancel(); reconnectTask = nil
         connectStableTask?.cancel(); connectStableTask = nil
         reconnectAttempts = 0
         reconnectStalled = false
+        reconnectWhenPoweredOn = false
     }
 
     /// Reconnect to the last-known ring WITHOUT scanning. `retrievePeripherals` resurfaces a

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -58,6 +58,28 @@ final class RingScanner: NSObject {
     /// from `centralManagerDidUpdateState` once `.poweredOn` arrives.
     private var reconnectWhenPoweredOn = false
 
+    /// Consecutive failed auto-reconnect attempts since the last frame-delivering connect (#35).
+    /// Drives the backoff delay (`ReconnectBackoff`); reset to 0 once a reconnected link proves
+    /// real (`connectStableTask`). A ring on the charger that accepts then drops a connect keeps
+    /// this climbing, so the reconnect cadence stretches instead of hammering the radio.
+    private var reconnectAttempts = 0
+    /// The pending backoff timer: sleeps the computed delay, then re-issues a single standing
+    /// pending connect. Cancelled on connect / user stop so we never stack timers.
+    private var reconnectTask: Task<Void, Never>?
+    /// After a fresh connect, this waits a beat and only resets the backoff if the link SURVIVED
+    /// and delivered a real frame — the "successful data frame" reset signal (#35). Guards the
+    /// connect/reject loop a charging ring produces (resetting on `didConnect` alone would pin
+    /// the backoff at its shortest delay).
+    private var connectStableTask: Task<Void, Never>?
+    /// How long a new link must hold (and send a frame) before we trust it and reset the backoff.
+    private static let connectStablePeriod: TimeInterval = 6
+
+    /// True once enough reconnects have failed that the UI should show a calm "ring unreachable /
+    /// charging — will reconnect automatically" instead of a permanent "Connecting…" (#35). Based
+    /// on elapsed attempts, NOT a decoded charging byte (that descriptor bit is protocol-blocked,
+    /// #41) — we never claim to KNOW the ring is charging.
+    private(set) var reconnectStalled = false
+
     private override init() {
         super.init()
         // Opting into state restoration: iOS preserves this central's connections/pending
@@ -88,18 +110,40 @@ final class RingScanner: NSObject {
     func start(services: [CBUUID]? = nil) {
         guard central.state == .poweredOn else { return }
         wantConnection = true
+        resetReconnectBackoff()   // a fresh user scan starts clean — no lingering backoff/calm state
         state = .scanning
         central.scanForPeripherals(withServices: services)
     }
 
     func stop() {
         wantConnection = false
+        resetReconnectBackoff()   // user stop: cancel any pending backoff reconnect
         // Explicit user stop: forget the ring so we don't silently auto-reconnect on the next
         // launch (reconnect-by-identifier only re-arms while an id is saved). (Reviewer MINOR.)
         Self.savedPeripheralID = nil
         central.stopScan()
         if let target { central.cancelPeripheralConnection(target) }
         if case .scanning = state { state = .idle }
+    }
+
+    /// Tear down the active session (#42): persist its last live reading + captured pages
+    /// (`stopLiveMonitoring`), then cancel EVERY task it owns (`invalidate`), then release it.
+    /// Called everywhere `session` is replaced or dropped — before assigning a new session in
+    /// `didConnect`/`willRestoreState`, and on disconnect — so a stale session's keepalive/
+    /// auto-measure/sync loops can never keep writing to the peripheral behind a newer one.
+    private func teardownSession() {
+        session?.stopLiveMonitoring()
+        session?.invalidate()
+        session = nil
+    }
+
+    /// Cancel any in-flight reconnect backoff and clear the calm state (#35). Used on a fresh
+    /// user scan, a user stop/disconnect, and once a link proves stable.
+    private func resetReconnectBackoff() {
+        reconnectTask?.cancel(); reconnectTask = nil
+        connectStableTask?.cancel(); connectStableTask = nil
+        reconnectAttempts = 0
+        reconnectStalled = false
     }
 
     /// Reconnect to the last-known ring WITHOUT scanning. `retrievePeripherals` resurfaces a
@@ -144,11 +188,12 @@ final class RingScanner: NSObject {
     /// connection and immediately reconnects, looping forever (#14 fix).
     func disconnect() {
         wantConnection = false
+        resetReconnectBackoff()   // user stop: drop any pending backoff reconnect (#35)
         central.stopScan()
         if let target {
             central.cancelPeripheralConnection(target)
         }
-        session = nil
+        teardownSession()         // cancel all of the session's tasks, not just the live poll (#42)
         target = nil
         state = .idle
     }
@@ -160,8 +205,7 @@ final class RingScanner: NSObject {
     /// no-scan pending connect-by-identifier so reconnection stays armed across the next
     /// suspension. (Reviewer MAJOR fix.)
     private func endBackgroundReadRearming() {
-        session?.stopLiveMonitoring()
-        session = nil
+        teardownSession()   // stopLiveMonitoring + cancel keepalive/auto-measure/sync tasks (#42)
         if let target { central.cancelPeripheralConnection(target) }
         target = nil
         state = .idle
@@ -241,9 +285,19 @@ extension RingScanner: CBCentralManagerDelegate {
                 case .connected, .connecting: break
                 default: self.state = .idle
                 }
-                // A reconnect was requested before Bluetooth was ready (cold/background
-                // launch) — complete it now that the radio is on.
-                if self.reconnectWhenPoweredOn { self.reconnectKnownPeripheral() }
+                // A reconnect was requested before Bluetooth was ready (cold/background launch,
+                // or a backoff reconnect that armed while the radio was off) — complete it now.
+                // When we already hold the peripheral object, connect it directly: a backoff sets
+                // state to `.connecting`, which `reconnectKnownPeripheral` treats as "already
+                // connecting" and no-ops — connecting `target` ourselves avoids that stall. (#35)
+                if self.reconnectWhenPoweredOn {
+                    self.reconnectWhenPoweredOn = false
+                    if let target = self.target {
+                        self.central.connect(target)
+                    } else {
+                        self.reconnectKnownPeripheral()
+                    }
+                }
                 // A session restored before the radio was up may have fired its discovery
                 // into the void (chars never matched → never `ready`). Re-kick it now. The
                 // session also self-heals on the first frame it receives (#reconnect).
@@ -271,9 +325,14 @@ extension RingScanner: CBCentralManagerDelegate {
             switch peripheral.state {
             case .connected:
                 // The link survived the relaunch — rebuild the session now; `didConnect`
-                // won't fire again. RingSession re-discovers services/characteristics.
+                // won't fire again. RingSession re-matches characteristics (skipping a full
+                // service re-discovery when they're already present, #42).
                 Self.savedPeripheralID = peripheral.identifier.uuidString
                 self.state = .connected(peripheral.name ?? "RingConn")
+                // Tear down any session that already exists (e.g. a later `didConnect` racing this
+                // restore) before replacing it, so its tasks don't keep writing to the peripheral
+                // behind the new session (#42).
+                self.teardownSession()
                 self.session = RingSession(peripheral: peripheral, localStore: self.localStore)
             case .connecting:
                 // Pending connect still in flight; `didConnect` will complete it.
@@ -323,8 +382,32 @@ extension RingScanner: CBCentralManagerDelegate {
             // cold launch or background relaunch.
             self.target = peripheral
             Self.savedPeripheralID = peripheral.identifier.uuidString
+            // A connect landed — stop any pending backoff timer and clear the calm "unreachable"
+            // note. (We don't reset the attempt COUNT yet: a charging ring can connect then
+            // immediately drop, so the backoff only truly resets once the link proves stable.) #35
+            self.reconnectTask?.cancel(); self.reconnectTask = nil
+            self.reconnectStalled = false
             self.state = .connected(peripheral.name ?? "RingConn")
+            // Tear down any prior session before replacing it so its keepalive/auto-measure/sync
+            // tasks can't keep driving the same peripheral behind the new session (#42).
+            self.teardownSession()
             self.session = RingSession(peripheral: peripheral, localStore: self.localStore)
+            self.armConnectStabilityReset()
+        }
+    }
+
+    /// Arm the backoff reset (#35). Only once a reconnected link has SURVIVED a beat AND delivered
+    /// a real frame (`session.lastFrameAt`) do we trust it and zero the attempt count — so a
+    /// charging ring's connect/reject loop (which never delivers a frame) keeps the backoff
+    /// climbing instead of resetting on every brief connect.
+    private func armConnectStabilityReset() {
+        connectStableTask?.cancel()
+        connectStableTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Self.connectStablePeriod))
+            guard let self, !Task.isCancelled else { return }
+            if case .connected = self.state, self.session?.lastFrameAt != nil {
+                self.reconnectAttempts = 0
+            }
         }
     }
 
@@ -332,16 +415,44 @@ extension RingScanner: CBCentralManagerDelegate {
                                     didDisconnectPeripheral peripheral: CBPeripheral,
                                     error: Error?) {
         Task { @MainActor in
-            self.session?.stopLiveMonitoring()
-            self.session = nil
-            // Auto-reconnect: CoreBluetooth's connect has no timeout — it reconnects
-            // (using the persisted bond) the moment the ring wakes/comes back in range,
-            // so the user never has to re-pair or open the official app again.
+            self.connectStableTask?.cancel(); self.connectStableTask = nil
+            self.teardownSession()   // cancel ALL of the session's tasks, persisting last reading (#42)
+            // Auto-reconnect: CoreBluetooth's connect has no timeout — it reconnects (using the
+            // persisted bond) the moment the ring wakes/comes back in range, so the user never has
+            // to re-pair or open the official app again. But we no longer re-issue it IMMEDIATELY:
+            // a ring on the charger that drops the link in a loop would keep the radio armed for
+            // hours. Back off with a growing delay instead (#35).
             if self.wantConnection {
-                self.state = .connecting(peripheral.name ?? "RingConn")
-                self.central.connect(peripheral)
+                self.scheduleReconnect(peripheral)
             } else {
                 self.state = .idle
+            }
+        }
+    }
+}
+
+extension RingScanner {
+    /// Schedule a backoff reconnect after a disconnect (#35). Each consecutive failure stretches
+    /// the delay (1 s → 5 s → 30 s cap); a stable, frame-delivering connect resets it. We keep the
+    /// cheap standing pending connect — we just delay re-issuing it and do NOT actively re-scan
+    /// during the wait. After a few failures the UI switches to a calm "unreachable" note.
+    private func scheduleReconnect(_ peripheral: CBPeripheral) {
+        reconnectTask?.cancel()
+        reconnectAttempts += 1
+        let delay = ReconnectBackoff.delay(forAttempt: reconnectAttempts)
+        reconnectStalled = ReconnectBackoff.shouldSurfaceCalmState(attempts: reconnectAttempts)
+        target = peripheral
+        state = .connecting(peripheral.name ?? "RingConn")
+        reconnectTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard let self, !Task.isCancelled, self.wantConnection else { return }
+            // Don't fight a link that already came back during the wait.
+            if case .connected = self.state { return }
+            if self.central.state == .poweredOn {
+                self.central.connect(peripheral)   // single standing pending connect (no scan)
+            } else {
+                // Radio not up yet — let the poweredOn handler complete the reconnect-by-identifier.
+                self.reconnectWhenPoweredOn = true
             }
         }
     }

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -31,8 +31,12 @@ final class RingScanner: NSObject {
         central = CBCentralManager(delegate: self, queue: .main)
     }
 
+    /// True once the user has connected; keeps us auto-reconnecting if the ring sleeps.
+    private var wantConnection = false
+
     func start() {
         guard central.state == .poweredOn else { return }
+        wantConnection = true
         state = .scanning
         // Discover all services (the ring is reportedly not fully GATT-compatible,
         // so we don't filter by service UUID — those roles are 🔴 in PROTOCOL.md).
@@ -40,7 +44,9 @@ final class RingScanner: NSObject {
     }
 
     func stop() {
+        wantConnection = false
         central.stopScan()
+        if let target { central.cancelPeripheralConnection(target) }
         if case .scanning = state { state = .idle }
     }
 }
@@ -87,7 +93,15 @@ extension RingScanner: CBCentralManagerDelegate {
         Task { @MainActor in
             self.session?.stopLiveMonitoring()
             self.session = nil
-            self.state = .idle
+            // Auto-reconnect: CoreBluetooth's connect has no timeout — it reconnects
+            // (using the persisted bond) the moment the ring wakes/comes back in range,
+            // so the user never has to re-pair or open the official app again.
+            if self.wantConnection {
+                self.state = .connecting(peripheral.name ?? "RingConn")
+                self.central.connect(peripheral)
+            } else {
+                self.state = .idle
+            }
         }
     }
 }

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -25,6 +25,7 @@ final class RingScanner: NSObject {
 
     private var central: CBCentralManager!
     private var target: CBPeripheral?
+    private var localStore: LocalStore?
 
     override init() {
         super.init()
@@ -48,6 +49,11 @@ final class RingScanner: NSObject {
         central.stopScan()
         if let target { central.cancelPeripheralConnection(target) }
         if case .scanning = state { state = .idle }
+    }
+
+    func setLocalStore(_ localStore: LocalStore) {
+        self.localStore = localStore
+        session?.setLocalStore(localStore)
     }
 }
 
@@ -83,7 +89,7 @@ extension RingScanner: CBCentralManagerDelegate {
                                     didConnect peripheral: CBPeripheral) {
         Task { @MainActor in
             self.state = .connected(peripheral.name ?? "RingConn")
-            self.session = RingSession(peripheral: peripheral)
+            self.session = RingSession(peripheral: peripheral, localStore: self.localStore)
         }
     }
 

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -85,6 +85,7 @@ extension RingScanner: CBCentralManagerDelegate {
                                     didDisconnectPeripheral peripheral: CBPeripheral,
                                     error: Error?) {
         Task { @MainActor in
+            self.session?.stopLiveMonitoring()
             self.session = nil
             self.state = .idle
         }

--- a/ios/OpenRingConn/BLE/RingScanner.swift
+++ b/ios/OpenRingConn/BLE/RingScanner.swift
@@ -239,6 +239,12 @@ extension RingScanner: CBCentralManagerDelegate {
                 // A reconnect was requested before Bluetooth was ready (cold/background
                 // launch) — complete it now that the radio is on.
                 if self.reconnectWhenPoweredOn { self.reconnectKnownPeripheral() }
+                // A session restored before the radio was up may have fired its discovery
+                // into the void (chars never matched → never `ready`). Re-kick it now. The
+                // session also self-heals on the first frame it receives (#reconnect).
+                if let session = self.session, session.ready != true {
+                    session.rediscoverIfNeeded()
+                }
             case .poweredOff: self.state = .poweredOff
             case .unauthorized: self.state = .unauthorized
             default: self.state = .idle

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -23,6 +23,10 @@ final class RingSession: NSObject {
     /// reading is converging vs. stuck — these sensors report a windowed average that
     /// climbs over ~20–60 s of stillness, so a single number is misleading.
     private(set) var liveHRTrend: [Int] = []
+    /// Raw byte[2] of the most recent SHORT HR frame while still below the lock
+    /// threshold (sensor warming up / poor contact). Lets the UI prove frames are
+    /// arriving and climbing, vs. no HR frames at all.
+    private(set) var liveHRWarmup: Int?
     private(set) var steps: Int?          // ring onboard step count (0x10/0x87 [4:6], §5.4)
     private(set) var liveMode: LiveMode = .hr
     private(set) var monitoring = false
@@ -76,10 +80,13 @@ final class RingSession: NSObject {
         syncing = false
         monitoring = true
         liveHRTrend.removeAll()   // fresh convergence window
+        liveHRWarmup = nil
         let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
-        // Proven-accepted cursor (0xFFFFFFFF), then enter the selected live mode.
+        // Proven enter sequence (PROTOCOL.md §5.1): open session, drain a history record
+        // (the extra `fetch`), then d0 status query → mode byte → fetch. The history
+        // drain + d0 are what reliably leaves bulk mode so the live stream starts.
         let enterSeq: [[UInt8]] = [Command.status0, Command.status1, Command.syncAll,
-                                   Command.statusQuery, modeCmd, Command.fetch]
+                                   Command.fetch, Command.statusQuery, modeCmd, Command.fetch]
         monitorTask = Task { [weak self] in
             for cmd in enterSeq {
                 guard let self else { return }
@@ -122,10 +129,16 @@ final class RingSession: NSObject {
         guard liveMode != mode else { return }
         liveMode = mode
         liveHRTrend.removeAll()   // restarting the HR window
+        liveHRWarmup = nil
         guard monitoring else { return }
         let modeCmd = mode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
+        // Re-arm with the d0 status query before the mode byte (mirrors the proven enter
+        // sequence) — switching the mode byte alone doesn't reliably restart the short
+        // 15 00 HR stream when coming back from SpO2.
         Task { [weak self] in
             guard let self else { return }
+            self.write(Command.statusQuery)
+            try? await Task.sleep(for: .milliseconds(250))
             self.write(modeCmd)
             try? await Task.sleep(for: .milliseconds(250))
             self.write(Command.fetch)
@@ -179,9 +192,16 @@ final class RingSession: NSObject {
         stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
         syncing = false
         syncTask = nil
-        syncStatus = bulkRecords.isEmpty
-            ? "No data received — is the ring bonded/awake?"
-            : "Synced \(bulkRecords.count) epochs"
+        if !bulkRecords.isEmpty {
+            syncStatus = "Synced \(bulkRecords.count) epochs"
+        } else if steps != nil {
+            // Link is fine (status frames arrived) — the ring just had no un-synced
+            // sleep/vitals pages. It only holds history it hasn't handed off yet, so
+            // once the official app (or a prior sync) drains it, there's nothing left.
+            syncStatus = "No new sleep/vitals history on the ring (it only keeps un-synced data). Live status OK."
+        } else {
+            syncStatus = "No data received — is the ring bonded/awake?"
+        }
     }
 
     private func write(_ bytes: [UInt8]) {
@@ -250,10 +270,13 @@ extension RingSession: CBPeripheralDelegate {
             //   long  `15 01 … <spo2> …`  → byte[2]=0; SpO2 at byte[14] (🟡)
             // Only the short frame carries HR — don't let a long frame zero it out.
             if frame.opcode == Frame.responseID(Opcode.poll) {
-                if let hr = LiveHR.decodeLocked(bytes) {                         // short frame, warm-up filtered
+                if let hr = LiveHR.decodeLocked(bytes) {                         // short frame, locked on
                     self.liveHR = hr
+                    self.liveHRWarmup = nil
                     self.liveHRTrend.append(hr)
                     if self.liveHRTrend.count > 12 { self.liveHRTrend.removeFirst() }
+                } else if let raw = LiveHR.decode(bytes) {                       // short frame, still warming up
+                    self.liveHRWarmup = raw
                 }
                 if let spo2 = LiveHR.decodeSpO2(bytes) { self.liveSpO2 = spo2 }  // long frame, 🟡
             }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -140,6 +140,12 @@ final class RingSession: NSObject {
     private let dataServiceUUID = CBUUID(string: OpenRingKit.Transport.dataServiceUUID)
     private let notifyUUID = CBUUID(string: OpenRingKit.Transport.notifyCharUUID)
     private let writeUUID = CBUUID(string: OpenRingKit.Transport.writeCharUUID)
+    /// Device-Information System ID (0x2a23) — carries the ring's 6-byte MAC (§1). iOS hides the MAC
+    /// from CoreBluetooth, but the per-connection auth (#54) needs it, so we read it from here.
+    private let systemIDUUID = CBUUID(string: "2A23")
+    /// The ring's 6-byte BLE MAC, recovered from the System ID characteristic. Drives the auth
+    /// challenge-response (`RingAuth`); nil until read (then we fall back to the legacy fixed auth).
+    private var ringMAC: [UInt8]?
 
     init(peripheral: CBPeripheral, localStore: LocalStore? = nil) {
         self.peripheral = peripheral
@@ -218,7 +224,9 @@ final class RingSession: NSObject {
         let syncOpen = quickLiveRead ? Command.syncAll : Command.syncUpToNow()
         monitorTask = Task { [weak self] in
             // 1. Init + open the sync session at `syncOpen`.
-            for cmd in [Command.status0, Command.status1, syncOpen] {
+            // `status0` elicits the `81 00` auth challenge; the didUpdateValue handler answers it
+            // reactively with the SM3 auth (#54) before `syncOpen` opens the data session.
+            for cmd in [Command.status0, syncOpen] {
                 guard let self, !Task.isCancelled else { return }
                 self.write(cmd)
                 try? await Task.sleep(for: .milliseconds(250))
@@ -326,7 +334,7 @@ final class RingSession: NSObject {
             // (otherwise the very first reading races the reactive refresh and could leak).
             await self?.refreshNightWindowIfNeeded()
             // Prime a status session so the ring answers fetch with the descriptor.
-            for cmd in [Command.status0, Command.status1] {
+            for cmd in [Command.status0] {   // elicits the 81 00 challenge → reactive SM3 auth (#54)
                 guard let self, !Task.isCancelled else { return }
                 self.write(cmd)
                 try? await Task.sleep(for: .milliseconds(250))
@@ -627,7 +635,7 @@ final class RingSession: NSObject {
             // Open at cursor ≈ NOW: the ring streams its un-delivered backlog up to now and
             // advances its own resume pointer (§3). `syncAll`'s far-future cursor returned an
             // empty history — the bug that dropped overnight sleep/HRV/RR.
-            for cmd in [Command.status0, Command.status1, historyOpen, Command.fetch] {
+            for cmd in [Command.status0, historyOpen, Command.fetch] {   // 81 00 challenge → reactive SM3 auth (#54)
                 guard let self else { return }
                 self.write(cmd)
                 try? await Task.sleep(for: .milliseconds(300))
@@ -717,6 +725,8 @@ extension RingSession: CBPeripheralDelegate {
                     peripheral.setNotifyValue(true, for: ch)
                 } else if ch.uuid == self.writeUUID {
                     self.writeChar = ch
+                } else if ch.uuid == self.systemIDUUID, self.ringMAC == nil {
+                    peripheral.readValue(for: ch)   // → MAC for the auth challenge-response (#54)
                 }
             }
             self.ready = (self.notifyChar != nil && self.writeChar != nil)
@@ -734,6 +744,17 @@ extension RingSession: CBPeripheralDelegate {
         guard let data = characteristic.value else { return }
         let bytes = [UInt8](data)
         Task { @MainActor in
+            // System ID read (DIS 0x2a23) — recover the ring's MAC for the auth challenge-response
+            // (#54). Not a ring data frame, so handle + return before the frame logic below.
+            if characteristic.uuid == self.systemIDUUID {
+                if let mac = RingAuth.macFromSystemID(bytes) {
+                    self.ringMAC = mac
+                    ringLog.notice("ring MAC (System ID): \(mac.map { String(format: "%02x", $0) }.joined(separator: ":"), privacy: .public) → auth V=0x\(String(format: "%02x", RingAuth.macTailXor(mac)), privacy: .public)")
+                } else {
+                    ringLog.notice("System ID unparsed (\(bytes.count, privacy: .public)B): \(bytes.map { String(format: "%02x", $0) }.joined(separator: " "), privacy: .public)")
+                }
+                return
+            }
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
             self.lastFrameAt = Date()   // freshness anchor for staleness + last-reading timestamp (#36)
             // A DATA frame (anything but the cold `0x81` status reply, which even an un-activated ring
@@ -850,6 +871,18 @@ extension RingSession: CBPeripheralDelegate {
                 self.lastHeartbeatAt = Date()
                 ringLog.debug("← 0x11 heartbeat, ack 91 00 00")
                 self.write(Command.heartbeatAck)
+                return
+            case 0x81:
+                // Auth handshake (#54, §5.8). `81 00 <chal>` (← our `01 00 00`) is the ring's
+                // challenge — reply with `01 01 <SM3([V,chal])[-3:]> 00` so the ring activates its
+                // data stream. Needs the MAC (read from System ID); without it, fall back to the
+                // legacy fixed auth (`status1`), which is only correct when the challenge is 0xb0.
+                if bytes.count >= 3, bytes[1] == 0x00 {
+                    let chal = bytes[2]
+                    let auth = self.ringMAC.map { RingAuth.authCommand(challenge: chal, mac: $0) } ?? Command.status1
+                    ringLog.notice("← 0x81 challenge=0x\(String(format: "%02x", chal), privacy: .public), reply \(self.ringMAC == nil ? "legacy-fixed" : "SM3 auth", privacy: .public)")
+                    self.write(auth)
+                }
                 return
             default: break
             }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -2,6 +2,12 @@ import Foundation
 import CoreBluetooth
 import Observation
 import OpenRingKit
+import os
+
+/// Unified-logging channel for the BLE/sync path. Stream live from a connected device with:
+///   log stream --device --predicate 'subsystem == "com.dreamality.openringconn"'
+/// (Logger reaches the unified log; plain `print` on iOS does not.)
+let ringLog = Logger(subsystem: "com.dreamality.openringconn", category: "ring")
 
 // An active link to a connected ring: discovers the notify/write characteristics
 // by UUID, enables notifications, sends commands, and decodes responses through
@@ -277,6 +283,7 @@ final class RingSession: NSObject {
         syncQuietTicks = 0
         syncing = true
         syncStatus = nil
+        ringLog.notice("sync: START (cursor=all)")
         syncTask = Task { [weak self] in
             // Paced enter so CoreBluetooth doesn't drop writes.
             for cmd in [Command.status0, Command.status1, Command.syncAll, Command.fetch] {
@@ -284,12 +291,18 @@ final class RingSession: NSObject {
                 self.write(cmd)
                 try? await Task.sleep(for: .milliseconds(300))
             }
-            // Watchdog: finalize on 0x50, or when pages stop (4 s quiet), or a 45 s cap —
-            // so the sync can never hang if the end-marker or a write is lost.
+            // Watchdog: finalize on 0x50, or when pages stop (3 s quiet), or a 45 s cap —
+            // so the sync can never hang if the end-marker or a write is lost. The common
+            // case (ring sends 0x50) exits immediately; the quiet fallback only fires when
+            // the end-marker is lost, and pages stream sub-second apart during a real drain,
+            // so 3 s of silence reliably means "done" — a second shaved off every such sync.
             for tick in 0 ..< 45 {
                 try? await Task.sleep(for: .seconds(1))
                 guard let self else { return }
-                if self.syncDone || self.syncQuietTicks >= 4 { break }
+                if self.syncDone || self.syncQuietTicks >= 3 {
+                    ringLog.notice("sync: watchdog exit at \(tick)s (done=\(self.syncDone), quiet=\(self.syncQuietTicks), records=\(self.bulkRecords.count))")
+                    break
+                }
                 _ = tick
             }
             self?.finalizeSync()
@@ -305,6 +318,7 @@ final class RingSession: NSObject {
         persistSleepAndSteps()    // sleep summary + steps for offline display
         syncing = false
         syncTask = nil
+        ringLog.notice("sync: FINALIZE records=\(self.bulkRecords.count) samples=\(self.historySamples.count) sleepSegs=\(self.sleepSegments.count) steps=\(self.steps ?? -1)")
         if !bulkRecords.isEmpty {
             syncStatus = "Synced \(bulkRecords.count) epochs"
         } else if steps != nil {
@@ -318,8 +332,12 @@ final class RingSession: NSObject {
     }
 
     private func write(_ bytes: [UInt8]) {
-        guard let writeChar else { return }
+        guard let writeChar else {
+            ringLog.warning("write DROPPED (no writeChar yet): \(bytes.map { String(format: "%02x", $0) }.joined(separator: " "), privacy: .public)")
+            return
+        }
         // Write char advertises `write` (with response).
+        ringLog.debug("→ write \(bytes.map { String(format: "%02x", $0) }.joined(separator: " "), privacy: .public)")
         peripheral.writeValue(Data(bytes), for: writeChar, type: .withResponse)
     }
 }
@@ -344,6 +362,7 @@ extension RingSession: CBPeripheralDelegate {
                 }
             }
             self.ready = (self.notifyChar != nil && self.writeChar != nil)
+            ringLog.notice("ready=\(self.ready) (notify=\(self.notifyChar != nil), write=\(self.writeChar != nil))")
             if self.ready { self.startKeepalive() }   // begin continuous descriptor polling (primary tracker)
         }
     }
@@ -388,6 +407,7 @@ extension RingSession: CBPeripheralDelegate {
             case 0x47:
                 self.drainSawPage = true
                 if self.syncing { self.syncQuietTicks = 0 }
+                ringLog.debug("← 0x47 PPG page (\(bytes.count)B), ack")
                 self.write(Command.pageAck47)
                 self.handlePPGPage(data)   // Layer-A epoch decode, gated (#24)
                 return   // PPG page — BulkSleep decode TODO (issue #8)
@@ -397,6 +417,7 @@ extension RingSession: CBPeripheralDelegate {
                     self.bulkRecords += BulkSleep.records(fromPage: bytes)
                     self.syncQuietTicks = 0
                 }
+                ringLog.debug("← 0x4c sleep page (\(bytes.count)B) → records=\(self.bulkRecords.count), ack")
                 self.write(Command.pageAck4C)
                 self.handleActivityPage(data)   // Layer-A epoch decode, gated (#24)
                 return   // always ack to keep draining
@@ -405,6 +426,7 @@ extension RingSession: CBPeripheralDelegate {
                 // reaches Frame.parse. Mark done; the sync watchdog / live-enter drain finalizes.
                 self.drainDone = true
                 if self.syncing { self.syncDone = true }
+                ringLog.notice("← 0x50 END-OF-HISTORY (records=\(self.bulkRecords.count))")
                 self.handleEndOfHistory(data)   // finalize epoch session, gated persist (#24)
                 return
             default: break
@@ -425,6 +447,14 @@ extension RingSession: CBPeripheralDelegate {
                 }
                 if let spo2 = LiveHR.decodeSpO2(bytes) { self.liveSpO2 = spo2 }  // long frame, 🟡
             }
+        }
+    }
+
+    nonisolated func peripheral(_ peripheral: CBPeripheral,
+                                didWriteValueFor characteristic: CBCharacteristic,
+                                error: Error?) {
+        if let error {
+            ringLog.error("write FAILED: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -44,6 +44,7 @@ final class RingSession: NSObject {
     private(set) var ready = false
 
     private var monitorTask: Task<Void, Never>?
+    private var keepaliveTask: Task<Void, Never>?
 
     /// Sleep-vitals samples (HR/HRV/SpO2) decoded from the last history sync,
     /// finalized when the ring reports end-of-history (0x50). Feed to HealthKitWriter.
@@ -159,6 +160,34 @@ final class RingSession: NSObject {
 
     func setLocalStore(_ localStore: LocalStore) {
         self.localStore = localStore
+    }
+
+    /// Idle keepalive — what makes OpenRingConn a *primary* tracker rather than an
+    /// on-demand reader. The 0x10/0x87 descriptor (steps `[4:6]`, skin temp `[6:10]`,
+    /// battery `[1]`) is NOT unsolicited: in the official-app captures it arrives ~every
+    /// 40 s in response to a `07 00 00` (fetch) heartbeat. Without this, steps only
+    /// accumulate during a manual "Measure". With it, as long as we hold the link the ring
+    /// keeps reporting, so the live step delta-accumulation tracks the full day (the only
+    /// gap is time we're not connected — and with no official-app contention, that's it).
+    /// Skips ticks during live monitoring / sync, which generate descriptor traffic of
+    /// their own (and where an extra fetch can disturb the HR warm-up window).
+    func startKeepalive() {
+        guard keepaliveTask == nil else { return }
+        keepaliveTask = Task { [weak self] in
+            // Prime a status session so the ring answers fetch with the descriptor.
+            for cmd in [Command.status0, Command.status1] {
+                guard let self, !Task.isCancelled else { return }
+                self.write(cmd)
+                try? await Task.sleep(for: .milliseconds(250))
+            }
+            while !Task.isCancelled {
+                guard let self else { return }
+                if self.ready, !self.monitoring, !self.livePreparing, self.syncTask == nil {
+                    self.write(Command.fetch)   // 07 00 00 → fresh 0x10/0x87 descriptor
+                }
+                try? await Task.sleep(for: .seconds(30))
+            }
+        }
     }
 
     /// Persist decoded samples to the local store (the vitals dashboard reads from it, so
@@ -315,6 +344,7 @@ extension RingSession: CBPeripheralDelegate {
                 }
             }
             self.ready = (self.notifyChar != nil && self.writeChar != nil)
+            if self.ready { self.startKeepalive() }   // begin continuous descriptor polling (primary tracker)
         }
     }
 

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -98,8 +98,7 @@ final class RingSession: NSObject {
 
     private var bulkRecords: [BulkRecord] = []
     private var bulkFinalized = false    // captured pages already committed (sleep/vitals) — stop-time safety net skips re-commit
-    private var lastRawSteps: Int?       // last raw descriptor [4:6] counter (for delta accumulation)
-    private var dailyStepsTotal = 0      // accumulated daily step total (mirrors StoredDaily)
+    private var dailyStepsTotal = 0      // cached display total for the last sample day (mirrors StoredDaily)
     private var syncTask: Task<Void, Never>?
     private var syncDone = false        // 0x50 end-of-history seen
     private var syncQuietTicks = 0      // seconds since the last page arrived
@@ -441,6 +440,32 @@ final class RingSession: NSObject {
         // Steps are accumulated live in didUpdateValue (addDailySteps) — nothing to do here.
     }
 
+    // MARK: Step counter state (cross-session, #34)
+    //
+    // The ring's onboard step counter (descriptor [4:6]) is a since-handoff DELTA the official
+    // app resets; if that app isn't running it keeps climbing (it does NOT reset at midnight on
+    // its own). To compute a TRUE delta across a reconnect — instead of rebasing to the current
+    // counter and dropping every step taken while we were disconnected — we persist the last raw
+    // value AND the day it was seen in UserDefaults (not LocalStore: avoids a SwiftData migration
+    // and a per-day-row collision). The per-day TOTAL still lives in StoredDaily via addDailySteps.
+
+    private static let lastRawStepsKey = "steps.lastRawValue"      // Int: last raw [4:6] counter
+    private static let lastRawStepsDayKey = "steps.lastRawDay"     // Date: start-of-day it was observed
+
+    /// Last raw counter we recorded, or nil if we've never seen one (first run / cleared). Stored
+    /// as an object so a legitimate 0 reading is distinguishable from "unset".
+    private var persistedLastRawSteps: Int? {
+        UserDefaults.standard.object(forKey: Self.lastRawStepsKey) as? Int
+    }
+    /// Start-of-day the persisted raw counter was observed (for midnight-rollover detection).
+    private var persistedLastRawStepsDay: Date? {
+        UserDefaults.standard.object(forKey: Self.lastRawStepsDayKey) as? Date
+    }
+    private func persistStepRawState(raw: Int, day: Date) {
+        UserDefaults.standard.set(raw, forKey: Self.lastRawStepsKey)
+        UserDefaults.standard.set(day, forKey: Self.lastRawStepsDayKey)
+    }
+
     /// Start (or switch) live monitoring in a single mode. Guarantees only one metric
     /// reads at a time: switching to a mode puts the ring in `06 01`/`06 02`, so frames
     /// for the other metric stop arriving.
@@ -665,25 +690,40 @@ extension RingSession: CBPeripheralDelegate {
             // Frames arriving while the link isn't `ready` mean discovery didn't land on this
             // (restored) reconnect — re-run it so we can ack and the buttons enable. #reconnect
             if !self.ready { self.rediscoverIfNeeded() }
-            // The ring's onboard step counter (descriptor [4:6], §5.4) is a since-handoff DELTA that
-            // resets (the official app sums it in local memory). So accumulate observed deltas
-            // into a persistent daily total, reset-aware, rather than showing the raw counter
-            // (which reset to 0). NOTE: we only count steps while THIS app is connected, so the
-            // total lags the always-connected official app — but it never resets to 0.
+            // The ring's onboard step counter (descriptor [4:6], §5.4) is a since-handoff DELTA the
+            // official app resets; if that app isn't running it keeps climbing (it does NOT reset
+            // at midnight on its own). Fold each observed counter into a persistent per-day total,
+            // reset-aware, using the last raw value persisted ACROSS sessions — so a reconnect
+            // computes the TRUE delta since we last saw the ring instead of rebasing to the current
+            // counter and dropping every step taken while disconnected (#34). The pure, unit-tested
+            // StepAccumulator owns the reset/midnight math; this stays a thin caller.
             if let v = DeviceStatus.steps(bytes) {
-                if lastRawSteps == nil {
-                    // First reading this session — recover today's accumulated total from the
-                    // store and use this counter as the baseline (don't retro-count unseen steps).
-                    dailyStepsTotal = (try? localStore?.todaySteps()) ?? 0
-                } else if let last = lastRawSteps {
-                    let delta = v >= last ? v - last : v   // v < last => ring reset; v is the new count
-                    if delta > 0 {
-                        dailyStepsTotal += delta
-                        try? localStore?.addDailySteps(delta)
+                // Stamp by SAMPLE time (when the descriptor arrived), not ingest time, so a delta
+                // observed at 00:00:01 lands on the right day (#34). lastFrameAt was just set above.
+                let sampleDate = self.lastFrameAt ?? Date()
+                let sampleDay = Calendar.current.startOfDay(for: sampleDate)
+                let previousRaw = self.persistedLastRawSteps
+                let dayChanged = previousRaw != nil && self.persistedLastRawStepsDay != sampleDay
+                let update = StepAccumulator.update(previousRaw: previousRaw, newRaw: v, dayChanged: dayChanged)
+                if update.isReset {
+                    // Disambiguate a mid-day reset/handoff (unexpected — log loudly) from the
+                    // official app's normal midnight reset (expected) so we never silently miscount.
+                    if update.isAnomalousReset {
+                        ringLog.notice("steps: mid-day counter reset \(previousRaw ?? -1)→\(v) — counting \(v) as new (handoff/reboot/wrap)")
+                    } else {
+                        ringLog.debug("steps: counter reset across midnight \(previousRaw ?? -1)→\(v) — counting \(v) on new day (expected)")
                     }
                 }
-                lastRawSteps = v
+                if update.deltaToAdd > 0 {
+                    try? localStore?.addDailySteps(update.deltaToAdd, day: sampleDate)
+                }
+                // Re-read the sample day's total from the store as the live display value: a fresh
+                // row on midnight rollover reads its own total (no prior-day baseline bleed), and a
+                // baseline-only first reading recovers today's already-accumulated count.
+                dailyStepsTotal = (try? localStore?.todaySteps(day: sampleDate)) ?? dailyStepsTotal
                 self.steps = dailyStepsTotal
+                // Persist the raw counter + its day for the NEXT reading (cross-session, #34).
+                self.persistStepRawState(raw: v, day: sampleDay)
             }
             // Skin temperature rides the same 0x10/0x87 descriptor (§5.4). It streams live
             // (~30–60 s) and is NOT in the sleep sync, so capture + persist it here — but ONLY

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -157,8 +157,9 @@ final class RingSession: NSObject {
     }
 
     /// Begin live monitoring. The proven enter sequence (PROTOCOL.md §5.1 / livehr.py) is
-    /// unchanged: open the sync session (cursor 0xFFFFFFFF), let the ring's history backlog
-    /// drain, THEN `d0` → mode (`06 01`/`06 02`) → fetch, then poll `95 00 00`. Idempotent.
+    /// unchanged: open the sync session (cursor 0xFFFFFFFF for a quick read, cursor≈now for the
+    /// overnight capture — see `syncOpen` below), let the ring's history backlog drain, THEN `d0`
+    /// → mode (`06 01`/`06 02`) → fetch, then poll `95 00 00`. Idempotent.
     ///
     /// - `quickLiveRead`: the goal is a prompt live HR/SpO₂ (a user tap or the daytime auto/
     ///   background refresh), not the overnight sleep dump. The drain still runs and pages are
@@ -187,9 +188,13 @@ final class RingSession: NSObject {
         drainSawPage = false
         drainDone = false
         let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
+        // Quick live read skips the backlog (`syncAll` → empty → lock HR fast); the overnight
+        // background capture (quickLiveRead == false) opens at NOW so the night's backlog drains
+        // (§3). Computed on the MainActor before the Task.
+        let syncOpen = quickLiveRead ? Command.syncAll : Command.syncUpToNow()
         monitorTask = Task { [weak self] in
-            // 1. Init + open the sync session (cursor = everything; verified, §5.6).
-            for cmd in [Command.status0, Command.status1, Command.syncAll] {
+            // 1. Init + open the sync session at `syncOpen`.
+            for cmd in [Command.status0, Command.status1, syncOpen] {
                 guard let self, !Task.isCancelled else { return }
                 self.write(cmd)
                 try? await Task.sleep(for: .milliseconds(250))
@@ -560,7 +565,8 @@ final class RingSession: NSObject {
         persist(last)
     }
 
-    /// Pull stored history: open the sync session (cursor = everything) and fetch.
+    /// Pull stored history: open the sync session at cursor ≈ now (`syncUpToNow`, §3 — drains
+    /// the ring's un-delivered backlog; NOT `syncAll`/0xFFFFFFFF, which returns empty) and fetch.
     /// The ring streams 0x4c/0x47 pages, drained+decoded in didUpdateValue; results
     /// land in `historySamples` once 0x50 (end-of-history) arrives.
     func syncHistory() {
@@ -575,10 +581,13 @@ final class RingSession: NSObject {
         syncQuietTicks = 0
         syncing = true
         syncStatus = nil
-        ringLog.notice("sync: START (cursor=all)")
+        let historyOpen = Command.syncUpToNow()
+        ringLog.notice("sync: START open=\(historyOpen.map { String(format: "%02x", $0) }.joined(separator: " "), privacy: .public) (cursor≈now, §3)")
         syncTask = Task { [weak self] in
-            // Paced enter so CoreBluetooth doesn't drop writes.
-            for cmd in [Command.status0, Command.status1, Command.syncAll, Command.fetch] {
+            // Open at cursor ≈ NOW: the ring streams its un-delivered backlog up to now and
+            // advances its own resume pointer (§3). `syncAll`'s far-future cursor returned an
+            // empty history — the bug that dropped overnight sleep/HRV/RR.
+            for cmd in [Command.status0, Command.status1, historyOpen, Command.fetch] {
                 guard let self else { return }
                 self.write(cmd)
                 try? await Task.sleep(for: .milliseconds(300))
@@ -773,12 +782,17 @@ extension RingSession: CBPeripheralDelegate {
                 self.write(Command.pageAck4C)
                 self.handleActivityPage(data)   // Layer-A epoch decode, gated (#24)
                 return   // always ack to keep draining
+            case 0x82:
+                // Sync-open ACK. At NOTICE so an ACCEPTED open (0x82 arrives) is distinguishable
+                // from a refused one (silence — cursor out of range); debug writes don't persist.
+                ringLog.notice("← 0x82 sync-open ACK: \(self.lastFrame ?? "", privacy: .public)")
+                return
             case 0x50:
                 // End-of-history cursor report (§5.5) — NO XOR trailer, so it never
                 // reaches Frame.parse. Mark done; the sync watchdog / live-enter drain finalizes.
                 self.drainDone = true
                 if self.syncing { self.syncDone = true }
-                ringLog.notice("← 0x50 END-OF-HISTORY (records=\(self.bulkRecords.count))")
+                ringLog.notice("← 0x50 END-OF-HISTORY (records=\(self.bulkRecords.count)) raw=\(self.lastFrame ?? "", privacy: .public)")
                 self.handleEndOfHistory(data)   // finalize epoch session, gated persist (#24)
                 return
             default: break

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -673,9 +673,10 @@ final class RingSession: NSObject {
             syncStatus = "Synced \(bulkRecords.count) epochs"
         } else if steps != nil {
             // Link is fine (status frames arrived) — the ring just had no un-synced
-            // sleep/vitals pages. It only holds history it hasn't handed off yet, so
-            // once the official app (or a prior sync) drains it, there's nothing left.
-            syncStatus = "No new sleep/vitals history on the ring (it only keeps un-synced data). Live status OK."
+            // sleep/vitals pages. It only stores history until it has been handed off once;
+            // a prior sync (or the official app) has already drained it. Last night's HRV,
+            // Resting HR, RR, and Sleep are still visible in the vitals dashboard. (#58)
+            syncStatus = "Up to date — last night is likely already in the vitals dashboard. The ring clears history after each sync, so nothing new to fetch."
         } else {
             syncStatus = "No data received — is the ring bonded/awake?"
         }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -322,9 +322,17 @@ extension RingSession: CBPeripheralDelegate {
         Task { @MainActor in
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
             // Ring step count rides the 0x10/0x87 descriptor [4:6] (§5.4). Frames with 0
-            // are interleaved, so take the running max (today's cumulative count).
-            if let s = DeviceStatus.steps(bytes), s > 0 {
+            // are interleaved noise, so take the running max (today's cumulative count).
+            // Surface the count once ANY steps descriptor has arrived — `steps` stays nil
+            // = "no data yet" and becomes 0 (not nil) the moment the ring reports while
+            // connected, so the dashboard shows "0" instead of "—" (the running max keeps
+            // a real count from being clobbered back to 0 by interleaved 0-frames).
+            if let s = DeviceStatus.steps(bytes) {
                 self.steps = max(self.steps ?? 0, s)
+                // Persist the live count so "Steps (today)" survives disconnect (StoredDaily
+                // upsert keeps the per-day max; no-ops on 0). VitalsTableView.effectiveSteps
+                // falls back to today's StoredDaily when not connected.
+                if let steps = self.steps { try? self.localStore?.saveDailySteps(steps) }
             }
             // Skin temperature rides the same 0x10/0x87 descriptor (§5.4). It streams live
             // (~30–60 s) and is NOT in the sleep sync, so capture + persist it here.

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -79,6 +79,18 @@ final class RingSession: NSObject {
         }
     }
 
+    /// Start (or switch) live monitoring in a single mode. Guarantees only one metric
+    /// reads at a time: switching to a mode puts the ring in `06 01`/`06 02`, so frames
+    /// for the other metric stop arriving.
+    func startMonitoring(mode: LiveMode) {
+        if monitoring {
+            setLiveMode(mode)
+        } else {
+            liveMode = mode
+            startLiveMonitoring()
+        }
+    }
+
     /// Switch live measurement between HR (`06 01 00`) and SpO2 (`06 02 00`). The ring
     /// measures one at a time; the other metric keeps its last value. No-op until the
     /// next start if not currently monitoring.

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -19,6 +19,7 @@ final class RingSession: NSObject {
 
     private(set) var liveHR: Int?
     private(set) var liveSpO2: Int?       // 🟡 from long 0x15 frame byte[14]
+    private(set) var steps: Int?          // ring onboard step count (0x10/0x87 [4:6], §5.4)
     private(set) var liveMode: LiveMode = .hr
     private(set) var monitoring = false
     private(set) var lastFrame: String?
@@ -201,6 +202,11 @@ extension RingSession: CBPeripheralDelegate {
         let bytes = [UInt8](data)
         Task { @MainActor in
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
+            // Ring step count rides the 0x10/0x87 descriptor [4:6] (§5.4). Frames with 0
+            // are interleaved, so take the running max (today's cumulative count).
+            if let s = DeviceStatus.steps(bytes), s > 0 {
+                self.steps = max(self.steps ?? 0, s)
+            }
             // Bulk history pages: accumulate + ack to continue draining (47→c7, 4c→cc).
             switch bytes.first {
             case 0x47:

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -250,15 +250,32 @@ final class RingSession: NSObject {
     /// Device-Information System ID (0x2a23) — carries the ring's 6-byte MAC (§1). iOS hides the MAC
     /// from CoreBluetooth, but the per-connection auth (#54) needs it, so we read it from here.
     private let systemIDUUID = CBUUID(string: "2A23")
+    /// DIS Firmware Revision String (0x2A26) — human-readable FW version (e.g. "FR02.018"). (#79)
+    private let firmwareRevUUID = CBUUID(string: "2A26")
+    /// DIS Manufacturer Name String (0x2A29). (#79)
+    private let manufacturerUUID = CBUUID(string: "2A29")
+    /// DIS Hardware Revision String (0x2A27). (#79)
+    private let hardwareRevUUID = CBUUID(string: "2A27")
     /// The ring's 6-byte BLE MAC, recovered from the System ID characteristic. Drives the auth
     /// challenge-response (`RingAuth`); nil until read (then we fall back to the legacy fixed auth).
     private var ringMAC: [UInt8]?
+    /// DIS fields collected from the ring (firmware version, generation, manufacturer, etc.) (#79).
+    /// Populated incrementally as each DIS characteristic is read; `DeviceInfoView` observes this.
+    private(set) var firmwareInfo = FirmwareInfo()
+    /// Rolling battery % samples for the TTE estimate (#86). Capped at 20 entries (oldest→newest).
+    private var batteryHistory: [BatteryTTE.Sample] = []
+    private static let batteryHistoryCap = 20
+    /// Read accessor for the TTE sample window (#86).
+    var batteryTTESamples: [BatteryTTE.Sample] { batteryHistory }
 
     init(peripheral: CBPeripheral, localStore: LocalStore? = nil) {
         self.peripheral = peripheral
         self.localStore = localStore
         super.init()
         peripheral.delegate = self
+        // Seed the model name from the peripheral's advertised name; may be overridden later
+        // by a dedicated DIS Model Number characteristic if the ring exposes one. (#79)
+        firmwareInfo.modelName = peripheral.name ?? ""
         // Re-discovery guard (#42): on a restored / already-connected peripheral the data service
         // is usually already discovered, so re-scanning ALL services on every relaunch is wasted
         // work. If the data service is already present, go straight to (re-)matching its
@@ -1053,6 +1070,12 @@ extension RingSession: CBPeripheralDelegate {
                     self.writeChar = ch
                 } else if ch.uuid == self.systemIDUUID, self.ringMAC == nil {
                     peripheral.readValue(for: ch)   // → MAC for the auth challenge-response (#54)
+                } else if ch.uuid == self.firmwareRevUUID {
+                    peripheral.readValue(for: ch)   // → FW version string (#79)
+                } else if ch.uuid == self.manufacturerUUID {
+                    peripheral.readValue(for: ch)   // → Manufacturer Name (#79)
+                } else if ch.uuid == self.hardwareRevUUID {
+                    peripheral.readValue(for: ch)   // → Hardware Revision (#79)
                 }
             }
             self.ready = (self.notifyChar != nil && self.writeChar != nil)
@@ -1075,10 +1098,25 @@ extension RingSession: CBPeripheralDelegate {
             if characteristic.uuid == self.systemIDUUID {
                 if let mac = RingAuth.macFromSystemID(bytes) {
                     self.ringMAC = mac
-                    ringLog.notice("ring MAC (System ID): \(mac.map { String(format: "%02x", $0) }.joined(separator: ":"), privacy: .public) → auth V=0x\(String(format: "%02x", RingAuth.macTailXor(mac)), privacy: .public)")
+                    let macStr = mac.map { String(format: "%02x", $0) }.joined(separator: ":")
+                    ringLog.notice("ring MAC (System ID): \(macStr, privacy: .public) → auth V=0x\(String(format: "%02x", RingAuth.macTailXor(mac)), privacy: .public)")
+                    self.firmwareInfo.mac = macStr.uppercased()   // (#79) surfaced in DeviceInfoView
                 } else {
                     ringLog.notice("System ID unparsed (\(bytes.count, privacy: .public)B): \(bytes.map { String(format: "%02x", $0) }.joined(separator: " "), privacy: .public)")
                 }
+                return
+            }
+            // DIS string reads (firmware/manufacturer/hardware revision) — UTF-8 strings (#79).
+            if characteristic.uuid == self.firmwareRevUUID {
+                if let s = String(bytes: bytes, encoding: .utf8) { self.firmwareInfo.version = s }
+                return
+            }
+            if characteristic.uuid == self.manufacturerUUID {
+                if let s = String(bytes: bytes, encoding: .utf8) { self.firmwareInfo.manufacturer = s }
+                return
+            }
+            if characteristic.uuid == self.hardwareRevUUID {
+                if let s = String(bytes: bytes, encoding: .utf8) { self.firmwareInfo.hardwareRevision = s }
                 return
             }
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
@@ -1123,6 +1161,9 @@ extension RingSession: CBPeripheralDelegate {
                 }
                 if update.deltaToAdd > 0 {
                     try? localStore?.addDailySteps(update.deltaToAdd, day: sampleDate)
+                    // Record activity time for the sedentary reminder (#84).
+                    UserDefaults.standard.set(sampleDate.timeIntervalSince1970,
+                                              forKey: ReminderDefaults.lastActivityAt)
                 }
                 // Re-read the sample day's total from the store as the live display value: a fresh
                 // row on midnight rollover reads its own total (no prior-day baseline bleed), and a
@@ -1175,7 +1216,8 @@ extension RingSession: CBPeripheralDelegate {
                 }
             }
             // Ring battery % is descriptor byte[1] (§5.4 🟢, ground-truthed).
-            // Also stamps `batteryFetchedAt` (#57) and extends the charging-inference trend (#60).
+            // Also stamps `batteryFetchedAt` (#57) and extends the charging-inference trend (#60)
+            // and the TTE sample window (#86).
             if let b = DeviceStatus.battery(bytes) {
                 self.batteryPercent = b
                 self.batteryFetchedAt = Date()   // dedicated freshness anchor (#57)
@@ -1185,6 +1227,11 @@ extension RingSession: CBPeripheralDelegate {
                     if self.batteryTrend.count > Self.batteryTrendCapacity {
                         self.batteryTrend.removeFirst()
                     }
+                }
+                // TTE: rolling window of timestamped battery % readings (#86).
+                self.batteryHistory.append(BatteryTTE.Sample(percent: b, at: Date()))
+                if self.batteryHistory.count > Self.batteryHistoryCap {
+                    self.batteryHistory.removeFirst()
                 }
             }
             // Bulk history pages: accumulate + ack to continue draining (47→c7, 4c→cc).

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -22,8 +22,12 @@ final class RingSession: NSObject {
     /// Sleep-vitals samples (HR/HRV/SpO2) decoded from the last history sync,
     /// finalized when the ring reports end-of-history (0x50). Feed to HealthKitWriter.
     private(set) var historySamples: [QuantitySample] = []
-    /// Sleep-stage segments computed from the motion channel for the last sync.
+    /// Sleep-stage segments computed from the motion channel for the last sync
+    /// (coarse inBed/asleepCore/awake — the version written to HealthKit).
     private(set) var sleepSegments: [SleepSegment] = []
+    /// Experimental Light/Deep/REM/Awake staging (HR+motion heuristic, approximate —
+    /// matches stage totals but not architecture; for display, not HealthKit).
+    private(set) var stagedSegments: [SleepSegment] = []
     /// True while 0x4c pages are still arriving for the current sync.
     private(set) var syncing = false
 
@@ -61,6 +65,7 @@ final class RingSession: NSObject {
         bulkRecords.removeAll()
         historySamples.removeAll()
         sleepSegments.removeAll()
+        stagedSegments.removeAll()
         syncing = true
         for cmd in [Command.status0, Command.status1, Command.syncAll, Command.fetch] {
             write(cmd)
@@ -117,6 +122,7 @@ extension RingSession: CBPeripheralDelegate {
                 if self.syncing {
                     self.historySamples = BulkSleep.samples(from: self.bulkRecords)
                     self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords)
+                    self.stagedSegments = BulkSleep.stagedSegments(from: self.bulkRecords)
                     self.syncing = false
                 }
                 return

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -85,6 +85,11 @@ final class RingSession: NSObject {
     private(set) var userMeasureFailed = false
     /// Actionable guidance copy surfaced when `userMeasureFailed` is true.
     private(set) var userMeasureFailedMessage: String? = nil
+    /// Absolute deadline for the in-flight user measure's poll loop, or nil on the auto path
+    /// (which is bounded by `autoMeasureOnce`). Held on the session — NOT as a Task-local — so a
+    /// re-tap (`rearmUserMeasure`) can EXTEND it; otherwise a late re-arm inherits the original
+    /// budget and times out almost immediately (#65). Per-mode budget via `userMeasureBudget`.
+    private var userMeasureDeadline: Date?
 
     /// True when frames have stopped for long enough that the live readings (HR/SpO₂/battery/
     /// steps/temp) should read as STALE rather than current (#36). A silently-dropped link keeps
@@ -194,6 +199,7 @@ final class RingSession: NSObject {
         syncing = false
         autoMeasuring = false
         userMeasuring = false
+        userMeasureDeadline = nil
         // Stop CoreBluetooth callbacks routing to a torn-down session. Only clear the delegate if
         // it's still us — a newer session for the same peripheral reassigns it in its own `init`,
         // and we must not clobber that.
@@ -303,30 +309,38 @@ final class RingSession: NSObject {
             // shows actionable guidance rather than spinning forever. The auto-measure path
             // is already bounded by `autoMeasureOnce`'s own outer deadline — the poll loop
             // there can be unbounded (the task is cancelled externally when it fires). (#55)
-            let isUserMeasure = self?.userMeasuring ?? false
-            let pollDeadline: Date? = isUserMeasure
-                ? Date().addingTimeInterval((self?.liveMode == .spo2) ? 45 : 90)
-                : nil
+            // Arm the user-measure budget HERE (after the drain) so the per-mode timeout is
+            // measured from when polling actually starts. Held on the session so a re-tap can
+            // extend it (#65); the auto path leaves it nil (bounded by `autoMeasureOnce`). (#55)
+            self?.armUserMeasureDeadline()
             try? await Task.sleep(for: .seconds(2))   // let the ring settle before first poll
             while !Task.isCancelled {
                 guard let self else { return }
                 self.write(Command.poll)
-                // Check the user-measure budget on each iteration (auto path: pollDeadline is nil).
-                if let deadline = pollDeadline, Date() >= deadline {
+                // User-measure budget (auto path: userMeasureDeadline is nil). Re-read each
+                // iteration so a re-arm (rearmUserMeasure) extends it (#65).
+                if let deadline = self.userMeasureDeadline, Date() >= deadline {
                     let locked = self.liveMode == .hr ? self.liveHR != nil : self.liveSpO2 != nil
                     if !locked {
+                        // Timed out with NO lock — surface actionable guidance for the banner.
                         self.userMeasureFailed = true
                         self.userMeasureFailedMessage = "Couldn't get a reading — make sure the ring is worn snugly and not on the charger, then hold still."
                         let modeStr = self.liveMode == .hr ? "hr" : "spo2"
                         ringLog.notice("user measure: timeout, no lock (mode=\(modeStr, privacy: .public)) → userMeasureFailed (#55)")
                     }
+                    // Full teardown on ANY deadline exit — locked OR not (#65). Previously this
+                    // was conditional on `userMeasureFailed`, so a SUCCESSFUL measure that ran past
+                    // its budget broke the loop while leaving monitoring/userMeasuring set and a
+                    // COMPLETED monitorTask non-nil — freezing live HR, permanently blocking
+                    // auto-measure (`idleForAutoMeasure` needs !monitoring) and a fresh
+                    // startLiveMonitoring (`guard monitorTask == nil`), and never firing
+                    // `.onChange(monitoring)`→flushHealth. stopLiveMonitoring() clears all of it
+                    // and persists the last reading.
+                    self.stopLiveMonitoring()
                     break
                 }
                 try? await Task.sleep(for: .seconds(2))
             }
-            // Clean teardown after a user-measure timeout: stop monitoring, persist last value,
-            // and let ContentView's `.onChange(session?.monitoring)` flush to Health.
-            if let self, self.userMeasureFailed { self.stopLiveMonitoring() }
         }
     }
 
@@ -584,6 +598,20 @@ final class RingSession: NSObject {
         }
     }
 
+    /// Per-mode user-measure budget (seconds): HR needs longer stillness to converge than SpO₂.
+    private func userMeasureBudget(for mode: LiveMode) -> TimeInterval {
+        mode == .spo2 ? 45 : 90
+    }
+
+    /// (Re)arm the user-measure poll deadline for the current mode, or clear it on the auto path.
+    /// Called when the poll loop starts AND on a re-tap (`rearmUserMeasure`) so the budget is
+    /// always measured from the latest request, never the original (#65).
+    private func armUserMeasureDeadline() {
+        userMeasureDeadline = userMeasuring
+            ? Date().addingTimeInterval(userMeasureBudget(for: liveMode))
+            : nil
+    }
+
     /// Re-arm an already-running live read for a fresh user measurement (#45 B/C): drop the
     /// stale value + convergence window, then re-issue the proven `d0` → mode → fetch enter so
     /// the ring restarts the measurement. The existing poll loop keeps sending `95 00 00`, so no
@@ -595,6 +623,7 @@ final class RingSession: NSObject {
         liveHRWarmup = nil
         userMeasureFailed = false        // retry: dismiss the prior error naturally (#55)
         userMeasureFailedMessage = nil
+        armUserMeasureDeadline()         // fresh budget from THIS re-tap, not the original (#65)
         let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
         Task { [weak self] in
             guard let self else { return }
@@ -638,6 +667,7 @@ final class RingSession: NSObject {
         monitoring = false
         livePreparing = false
         userMeasuring = false   // user read done (or timed out — `userMeasureFailed` is kept for the banner) (#55)
+        userMeasureDeadline = nil   // no in-flight user-measure budget once the loop is torn down (#65)
         // Safety net for a background teardown that interrupted the live-enter drain before its
         // post-drain commit ran (#22 bg race): persist the captured pages so an overnight read
         // that never reached its finalize doesn't silently drop last night's sleep/vitals.

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -704,9 +704,77 @@ final class RingSession: NSObject {
             // remains the upsert key.
             let start = stagedSegments.map(\.start).min() ?? Date()
             let end = stagedSegments.map(\.end).max() ?? start
-            try? localStore.saveSleepSummary(summary, night: start, inBedStart: start, inBedEnd: end)
+            let extras = computeSleepExtras(summary: summary, start: start, end: end, store: localStore)
+            try? localStore.saveSleepSummary(summary, night: start, inBedStart: start, inBedEnd: end,
+                                             extras: extras)
         }
+        // Naps are detected over the whole drained window (independent of the overnight gate)
+        // so a daytime-only sync still records them, never folded into the main night (#76).
+        persistNaps(store: localStore)
         // Steps are accumulated live in didUpdateValue (addDailySteps) — nothing to do here.
+    }
+
+    /// Compute the Wave-1 sleep analytics for the night being persisted (#69/#70/#71): nightly
+    /// skin-temp mean + rolling-baseline offset, the 6-factor composite Sleep Score, overnight
+    /// stress from sleep-window RMSSD, per-stage average HR, and the movement timeline. All from
+    /// already-decoded data; values are estimates (labeled as such in the UI).
+    private func computeSleepExtras(summary: SleepStaging.Summary, start: Date, end: Date,
+                                    store: LocalStore) -> LocalStore.SleepNightExtras {
+        var extras = LocalStore.SleepNightExtras()
+        let window = DateInterval(start: start, end: max(end, start))
+
+        // Skin temp (#69): nightly mean from the persisted worn overnight readings.
+        let tempC = (try? store.samples(kind: .temperature, from: start, to: end))?.map(\.value)
+        let nightlyTemp = tempC.flatMap { SkinTempBaseline.nightlyMean($0) }
+        if let nightlyTemp { extras.skinTempC = nightlyTemp }
+
+        // Rolling baseline from PRIOR nights (exclude tonight's day), for the composite temp factor.
+        let tonightDay = Calendar.current.startOfDay(for: start)
+        let priorNights: [SkinTempBaseline.NightlyTemp] = ((try? store.recentSleepSummaries(limit: 40)) ?? [])
+            .filter { $0.skinTempC > 0 && Calendar.current.startOfDay(for: $0.night) != tonightDay }
+            .map { SkinTempBaseline.NightlyTemp(night: $0.night, celsius: $0.skinTempC) }
+        let baseline = SkinTempBaseline.baseline(priorNights: priorNights)
+        let tempOffset = (nightlyTemp != nil && baseline != nil) ? nightlyTemp! - baseline! : nil
+
+        // Per-stage HR + movement (#70).
+        let hrByStage = SleepDetailMetrics.averageHRByStage(records: bulkRecords, segments: stagedSegments)
+        extras.hrByStage = hrByStage
+        extras.movementLevels = SleepDetailMetrics.movementSummary(records: bulkRecords, in: window).levels
+
+        // Overnight stress (#71): median sleep-window RMSSD → band score.
+        let rmssd = bulkRecords.filter { window.contains($0.date()) }.compactMap { $0.hrvRMSSD }
+        if let stress = SleepStress.overnightScore(rmssd: rmssd) { extras.stressScore = stress }
+
+        // Resting/asleep HR for the composite HR factor (sleep mean → low-activity floor).
+        let nightHR = bulkRecords.compactMap { r -> HRSample? in
+            guard let hr = r.heartRate else { return nil }
+            let t = r.date()
+            return HRSample(bpm: hr, start: t, end: t)
+        }
+        let restingHR = RestingHR.value(hr: nightHR, sleep: stagedSegments)
+
+        // Composite 0–100 Sleep Score (#70).
+        let composite = SleepScore.composite(.init(
+            totalAsleep: summary.totalAsleep, timeAwake: summary.awake, efficiency: summary.efficiency,
+            deep: summary.deep, light: summary.light, rem: summary.rem,
+            restingHR: restingHR, tempOffsetC: tempOffset))
+        extras.sleepScore = composite.score
+        return extras
+    }
+
+    /// Detect daytime naps over the drained records and persist them (#76). Excludes the main
+    /// overnight block so naps never double-count against the night; the wear gate (#41) drops
+    /// off-wrist/charging stillness the same way the night does.
+    private func persistNaps(store: LocalStore) {
+        guard !bulkRecords.isEmpty else { return }
+        let main = BulkSleep.mainSleep(from: bulkRecords, temperatures: wearTemperatureSamples())
+        let naps = NapDetection.naps(from: bulkRecords, mainSleep: main,
+                                     temperatures: wearTemperatureSamples())
+        for nap in naps {
+            try? store.saveNap(start: nap.start, end: nap.end,
+                               asleepMin: Int((nap.asleep / 60).rounded()),
+                               isLongNap: nap.isLongNap)
+        }
     }
 
     // MARK: Step counter state (cross-session, #34)

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -698,8 +698,11 @@ extension RingSession: CBPeripheralDelegate {
             // counter and dropping every step taken while disconnected (#34). The pure, unit-tested
             // StepAccumulator owns the reset/midnight math; this stays a thin caller.
             if let v = DeviceStatus.steps(bytes) {
-                // Stamp by SAMPLE time (when the descriptor arrived), not ingest time, so a delta
-                // observed at 00:00:01 lands on the right day (#34). lastFrameAt was just set above.
+                // Stamp by SAMPLE time (when the descriptor arrived), not a hardcoded Date(), so a
+                // delta lands on the right StoredDaily row at a day boundary (#34). NOTE: on the LIVE
+                // path lastFrameAt was just set to now (line ~689), so sampleDate ≈ ingest time — this
+                // picks the correct day for the row/persist + display re-read, but it cannot back-date
+                // steps actually taken at 23:59 onto the prior day (no per-step timestamps on the wire).
                 let sampleDate = self.lastFrameAt ?? Date()
                 let sampleDay = Calendar.current.startOfDay(for: sampleDate)
                 let previousRaw = self.persistedLastRawSteps

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -66,6 +66,10 @@ final class RingSession: NSObject {
     /// Updates `liveHR`/`liveSpO2`. Idempotent.
     func startLiveMonitoring() {
         guard monitorTask == nil else { return }
+        // Live and history sync can't coexist (ring is one mode at a time). Cancel any
+        // in-flight sync so the ring is free to enter live mode.
+        syncTask?.cancel(); syncTask = nil
+        syncing = false
         monitoring = true
         let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
         // Proven-accepted cursor (0xFFFFFFFF), then enter the selected live mode.

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -73,6 +73,35 @@ final class RingSession: NSObject {
     /// UI can show a subtle "auto-updating" cue instead of reading as a user measurement.
     private(set) var autoMeasuring = false
 
+    // MARK: Wear gate / not-worn proxy (#56, #41)
+    //
+    // `appearsNotWorn` is true when the ring reads as OFF-WRIST / ON THE CHARGER, inferred from
+    // PROVEN proxies only — periodic auto-measures that never lock (🟢) plus, when available, a
+    // cold raw skin-temp reading (🟡, AutoMeasureGate). NO charging-flag byte is consulted (that
+    // descriptor field is undecoded — #61). It gates only the AUTOMATIC HR/SpO₂ refresh (which on
+    // the charger just times out and drains battery, #56) and a small UI hint; manual Measure /
+    // Sync are never blocked by it. Reset per connection (a new RingSession each connect).
+    private(set) var appearsNotWorn = false
+    /// Consecutive periodic auto-measure cycles that never locked a reading — the 🟢 not-worn
+    /// signal. Reset to 0 on a lock (or cleared by a warm skin-temp reading).
+    private var consecutiveAutoMeasureNoLock = 0
+    /// Most recent RAW skin temp (°C) from the 0x10/0x87 descriptor, updated on EVERY temp frame
+    /// regardless of the night-window / worn persistence gates below — the 🟡 wear proxy. nil
+    /// until the first valid reading.
+    private var lastRawSkinTempC: Double?
+    /// In-memory log of the night's RAW skin-temp readings (worn AND cold), independent of the
+    /// worn-only persistence gate — the ONLY source of the cold readings the sleep wear-gate
+    /// (#41) needs to reclassify a charging block out of sleep (the store keeps worn temps only).
+    /// Bounded rolling buffer; consumed by `wearTemperatureSamples()`.
+    private var nightTemperatureLog: [TemperatureSample] = []
+    private static let nightTemperatureLogCap = 2000
+    /// Cap on the not-worn auto-measure backoff: a ring left on the charger is re-probed at most
+    /// this rarely, but never abandoned — a lock (or warm temp) resumes the base cadence (#56).
+    private static let autoMeasureMaxBackoff: TimeInterval = 2 * 3600
+    /// Cheap re-check cadence while SKIPPING the probe on a confirmed-cold (not-worn) ring: short,
+    /// since it costs no live-enter, so re-wear (temp warming) resumes measurement promptly (#56).
+    private static let autoMeasureColdRecheck: TimeInterval = 180
+
     /// True when frames have stopped for long enough that the live readings (HR/SpO₂/battery/
     /// steps/temp) should read as STALE rather than current (#36). A silently-dropped link keeps
     /// its last values until CoreBluetooth eventually fires `didDisconnect`; this lets the UI
@@ -264,7 +293,8 @@ final class RingSession: NSObject {
             // discards delivered pages, so this is the only chance to keep them.
             if let self, !self.bulkRecords.isEmpty {
                 self.historySamples = BulkSleep.samples(from: self.bulkRecords)
-                self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords)
+                self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords,
+                                                             temperatures: self.wearTemperatureSamples())   // wear gate (#41)
                 self.stagedSegments = BulkSleep.stagedSegments(from: self.bulkRecords)
                 self.persist(self.historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
                 self.persistSleepAndSteps()          // sleep summary + steps for offline display
@@ -391,21 +421,29 @@ final class RingSession: NSObject {
             try? await Task.sleep(for: .seconds(Self.autoMeasureFirstDelay))
             while !Task.isCancelled {
                 guard let self else { return }
-                if Self.autoMeasureEnabled, self.idleForAutoMeasure {
+                if Self.autoMeasureEnabled, self.idleForAutoMeasure, !self.skipAutoMeasureProbe {
                     // Refresh BOTH every cycle — HR locks in seconds when still; SpO₂ rides
                     // the same live path. (Was SpO₂ every 3rd cycle, but relaunches reset that
                     // counter so it rarely fired.) Each is bounded, so a moving hand just times
-                    // out that read rather than blocking the loop.
-                    await self.autoMeasureOnce(mode: .hr, timeout: 90)   // HR can need ~60s of stillness
-                    if self.idleForAutoMeasure {
-                        await self.autoMeasureOnce(mode: .spo2, timeout: 45)
+                    // out that read rather than blocking the loop. The HR result feeds the
+                    // not-worn inference (#56); a user takeover (nil) is not counted.
+                    if let hrLocked = await self.autoMeasureOnce(mode: .hr, timeout: 90) {   // HR can need ~60s of stillness
+                        self.noteAutoMeasureCycle(locked: hrLocked)
                     }
-                    try? await Task.sleep(for: .seconds(Self.autoMeasureInterval))
+                    // Skip SpO₂ if the HR miss above just flipped us to not-worn-with-cold-temp —
+                    // no point spending another live-enter we expect to time out (#56).
+                    if self.idleForAutoMeasure, !self.skipAutoMeasureProbe {
+                        _ = await self.autoMeasureOnce(mode: .spo2, timeout: 45)
+                    }
+                    // Cadence backs off once the ring is inferred not-worn (#56); a lock above
+                    // already reset it to the base interval.
+                    try? await Task.sleep(for: .seconds(self.nextAutoMeasureInterval))
                 } else {
-                    // Disabled, or busy with a user measure / sync — re-check soon rather than
-                    // deferring a full interval (a one-off open-sync shouldn't push the first
-                    // HR out by 10 min).
-                    try? await Task.sleep(for: .seconds(30))
+                    // Disabled, busy with a user measure / sync, or inferred not-worn with a cold
+                    // skin temp (#56) — re-check soon rather than deferring a full interval. A
+                    // not-worn ring is re-checked cheaply (no live-enter) until its temp warms;
+                    // a one-off open-sync shouldn't push the first HR out by 10 min.
+                    try? await Task.sleep(for: .seconds(self.skipAutoMeasureProbe ? Self.autoMeasureColdRecheck : 30))
                 }
             }
         }
@@ -417,25 +455,72 @@ final class RingSession: NSObject {
         ready && !monitoring && !livePreparing && syncTask == nil
     }
 
+    /// Next sleep between auto-measure cycles: the base interval while worn, exponentially backed
+    /// off once the ring is inferred not-worn (#56). Pure policy lives in `AutoMeasureGate`.
+    private var nextAutoMeasureInterval: TimeInterval {
+        AutoMeasureGate.interval(base: Self.autoMeasureInterval,
+                                 cap: Self.autoMeasureMaxBackoff,
+                                 consecutiveNoLock: consecutiveAutoMeasureNoLock,
+                                 rawSkinTempC: lastRawSkinTempC)
+    }
+
+    /// Skip the live-enter probe entirely this cycle (#56): we've inferred not-worn AND the raw
+    /// skin temp still reads cold, so a probe would only time out and burn battery. Requires a
+    /// COLD reading (positive evidence) — a missing temp falls back to probing so a sensor gap
+    /// can't silently stop measuring. Re-wear is caught when the temp warms (the keepalive keeps
+    /// it fresh), which clears `appearsNotWorn`.
+    private var skipAutoMeasureProbe: Bool {
+        appearsNotWorn && (lastRawSkinTempC.map { $0 < ActivityPeriod.wornMinTemperatureC } ?? false)
+    }
+
+    /// Fold one finished auto-measure cycle into the not-worn inference (#56): a lock proves the
+    /// ring is worn (reset the miss count); a miss accrues toward the backoff. Recomputes the
+    /// published `appearsNotWorn`.
+    private func noteAutoMeasureCycle(locked: Bool) {
+        consecutiveAutoMeasureNoLock = locked ? 0 : consecutiveAutoMeasureNoLock + 1
+        refreshWornState()
+    }
+
+    /// Recompute the published not-worn flag from the current proxies (#56). Called after each
+    /// auto-measure cycle and whenever a fresh raw skin temp arrives. Guarded so `@Observable`
+    /// doesn't republish on every (unchanged) temp frame.
+    private func refreshWornState() {
+        let notWorn = AutoMeasureGate.appearsNotWorn(
+            consecutiveNoLock: consecutiveAutoMeasureNoLock,
+            rawSkinTempC: lastRawSkinTempC)
+        if notWorn != appearsNotWorn { appearsNotWorn = notWorn }
+    }
+
+    /// The night's skin-temp samples for the sleep wear-gate (#41): the in-memory log, the only
+    /// place cold/charging readings survive (the store keeps worn temps only). Empty ⇒ detection
+    /// falls back to motion alone (absence of data is not evidence of being unworn).
+    private func wearTemperatureSamples() -> [TemperatureSample] {
+        nightTemperatureLog
+    }
+
     /// One bounded auto-measurement: enter `mode`'s live read, wait for a converged value (or
     /// time out), then stop — which persists the reading and lets ContentView mirror it to
     /// Health. If the user takes over mid-read (monitoring an unexpected mode), we leave their
     /// session alone rather than cancelling it.
-    private func autoMeasureOnce(mode: LiveMode, timeout: TimeInterval) async {
-        guard idleForAutoMeasure else { return }
+    /// Returns whether the read LOCKED, or nil if the cycle was ABORTED by a user takeover — the
+    /// caller must not count an abort toward the not-worn inference (#56).
+    private func autoMeasureOnce(mode: LiveMode, timeout: TimeInterval) async -> Bool? {
+        guard idleForAutoMeasure else { return nil }
         autoMeasuring = true
         startMonitoring(mode: mode, userInitiated: false)   // auto refresh: prompt enter, keep last value until it locks
         let deadline = Date().addingTimeInterval(timeout)
+        var locked = false
         while !Task.isCancelled && Date() < deadline {
-            if mode == .hr, liveHR != nil { break }
-            if mode == .spo2, liveSpO2 != nil { break }
+            if mode == .hr, liveHR != nil { locked = true; break }
+            if mode == .spo2, liveSpO2 != nil { locked = true; break }
             // Bail if a user tap switched the mode out from under us — don't fight them.
-            if !monitoring || liveMode != mode { autoMeasuring = false; return }
+            if !monitoring || liveMode != mode { autoMeasuring = false; return nil }
             try? await Task.sleep(for: .seconds(1))
         }
         // Only tear down if WE still own the live read (user didn't take over).
         if autoMeasuring, monitoring, liveMode == mode { stopLiveMonitoring() }
         autoMeasuring = false
+        return locked
     }
 
     /// Resolve and cache the nightly sleep window used to gate skin-temp capture. Re-resolves
@@ -596,7 +681,8 @@ final class RingSession: NSObject {
         // No-op once the drain already committed (bulkFinalized) or nothing was captured.
         if !bulkRecords.isEmpty, !bulkFinalized {
             historySamples = BulkSleep.samples(from: bulkRecords)
-            sleepSegments = BulkSleep.sleepSegments(from: bulkRecords)
+            sleepSegments = BulkSleep.sleepSegments(from: bulkRecords,
+                                                    temperatures: wearTemperatureSamples())   // wear gate (#41)
             stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
             persist(historySamples)
             persistSleepAndSteps()
@@ -661,7 +747,8 @@ final class RingSession: NSObject {
     private func finalizeSync() {
         guard syncing else { return }
         historySamples = BulkSleep.samples(from: bulkRecords)
-        sleepSegments = BulkSleep.sleepSegments(from: bulkRecords)
+        sleepSegments = BulkSleep.sleepSegments(from: bulkRecords,
+                                                temperatures: wearTemperatureSamples())   // wear gate (#41)
         stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
         persist(historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
         persistSleepAndSteps()    // sleep summary + steps for offline display
@@ -812,6 +899,11 @@ extension RingSession: CBPeripheralDelegate {
             // (activity, ambient swings, intermittent skin contact) to be a usable trend, so we
             // drop them and surface no live value outside the window.
             if let t = DeviceStatus.skinTemperature(bytes) {
+                // Wear proxy (#56/#41): record the RAW reading BEFORE the night-window / worn
+                // gates below. A cold (off-wrist/charging) reading is exactly what the not-worn
+                // inference and the sleep wear-gate need, and neither survives those gates.
+                self.lastRawSkinTempC = t.celsius
+                self.refreshWornState()
                 // Window-miss guard: if we're outside the cached window (or it's nil), the cache
                 // may simply be stale/expired (night just started, or midnight rolled the window
                 // forward). Force a synchronous re-resolve BEFORE deciding to drop — this whole
@@ -825,8 +917,21 @@ extension RingSession: CBPeripheralDelegate {
                     Task { await self.refreshNightWindowIfNeeded() }   // background, don't block the frame
                 }
                 let inNightWindow = self.nightWindow?.contains(Date()) ?? false
-                self.liveTemperature = inNightWindow ? t.celsius : nil
+                let worn = t.celsius >= ActivityPeriod.wornMinTemperatureC
+                // Keep EVERY night reading (worn AND cold) in-memory for the sleep wear-gate's
+                // median test (#41) — the cold ones are what reclassify a charging block out of
+                // sleep. The store (below) keeps worn temps only, so this log is their sole home.
                 if inNightWindow {
+                    self.nightTemperatureLog.append(TemperatureSample(time: Date(), celsius: t.celsius))
+                    if self.nightTemperatureLog.count > Self.nightTemperatureLogCap {
+                        self.nightTemperatureLog.removeFirst(self.nightTemperatureLog.count - Self.nightTemperatureLogCap)
+                    }
+                }
+                // Persist / display ONLY a worn reading: a cold charging reading isn't a skin
+                // temperature, so it must not pollute the nightly average or reach Apple Health
+                // (#41). The cold reading still drives the wear proxies above.
+                self.liveTemperature = (inNightWindow && worn) ? t.celsius : nil
+                if inNightWindow, worn {
                     self.persist([QuantitySample(kind: .temperature, start: Date(), value: t.celsius)])
                 }
             }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -73,6 +73,19 @@ final class RingSession: NSObject {
     /// UI can show a subtle "auto-updating" cue instead of reading as a user measurement.
     private(set) var autoMeasuring = false
 
+    // MARK: User measure UX (#55)
+
+    /// True while the user has manually tapped "Measure" for a live HR or SpO₂ reading
+    /// (as opposed to the periodic `autoMeasuring`). Lets the poll loop enforce a per-mode
+    /// timeout and the UI distinguish Preparing → Measuring → failure states.
+    private(set) var userMeasuring = false
+    /// Set when a user-initiated measure times out without locking a reading. Cleared the
+    /// next time the user taps Measure so a retry dismisses the error naturally. Not cleared
+    /// on stop or disconnect — the banner persists until the user acts on it.
+    private(set) var userMeasureFailed = false
+    /// Actionable guidance copy surfaced when `userMeasureFailed` is true.
+    private(set) var userMeasureFailedMessage: String? = nil
+
     /// True when frames have stopped for long enough that the live readings (HR/SpO₂/battery/
     /// steps/temp) should read as STALE rather than current (#36). A silently-dropped link keeps
     /// its last values until CoreBluetooth eventually fires `didDisconnect`; this lets the UI
@@ -180,6 +193,7 @@ final class RingSession: NSObject {
         livePreparing = false
         syncing = false
         autoMeasuring = false
+        userMeasuring = false
         // Stop CoreBluetooth callbacks routing to a torn-down session. Only clear the delegate if
         // it's still us — a newer session for the same peripheral reassigns it in its own `init`,
         // and we must not clobber that.
@@ -284,12 +298,35 @@ final class RingSession: NSObject {
             //    then polls ~every 2 s, request/response. (SpO2's byte[14] survives fast
             //    polling, which is why only HR got stuck.) No `d0` here — it re-arms the
             //    mode switch and also kicks HR back to warm-up.
+            // User-measure deadline: a hand-started read gets a per-mode budget (HR 90 s,
+            // SpO₂ 45 s). On expiry without a lock, surface `userMeasureFailed` so the UI
+            // shows actionable guidance rather than spinning forever. The auto-measure path
+            // is already bounded by `autoMeasureOnce`'s own outer deadline — the poll loop
+            // there can be unbounded (the task is cancelled externally when it fires). (#55)
+            let isUserMeasure = self?.userMeasuring ?? false
+            let pollDeadline: Date? = isUserMeasure
+                ? Date().addingTimeInterval((self?.liveMode == .spo2) ? 45 : 90)
+                : nil
             try? await Task.sleep(for: .seconds(2))   // let the ring settle before first poll
             while !Task.isCancelled {
                 guard let self else { return }
                 self.write(Command.poll)
+                // Check the user-measure budget on each iteration (auto path: pollDeadline is nil).
+                if let deadline = pollDeadline, Date() >= deadline {
+                    let locked = self.liveMode == .hr ? self.liveHR != nil : self.liveSpO2 != nil
+                    if !locked {
+                        self.userMeasureFailed = true
+                        self.userMeasureFailedMessage = "Couldn't get a reading — make sure the ring is worn snugly and not on the charger, then hold still."
+                        let modeStr = self.liveMode == .hr ? "hr" : "spo2"
+                        ringLog.notice("user measure: timeout, no lock (mode=\(modeStr, privacy: .public)) → userMeasureFailed (#55)")
+                    }
+                    break
+                }
                 try? await Task.sleep(for: .seconds(2))
             }
+            // Clean teardown after a user-measure timeout: stop monitoring, persist last value,
+            // and let ContentView's `.onChange(session?.monitoring)` flush to Health.
+            if let self, self.userMeasureFailed { self.stopLiveMonitoring() }
         }
     }
 
@@ -537,6 +574,12 @@ final class RingSession: NSObject {
             }
         } else {
             liveMode = mode
+            // User-initiated: arm the timeout UX state so the poll loop can self-terminate (#55).
+            if userInitiated {
+                userMeasuring = true
+                userMeasureFailed = false
+                userMeasureFailedMessage = nil
+            }
             startLiveMonitoring(quickLiveRead: quickLiveRead, clearStaleValue: userInitiated)
         }
     }
@@ -550,6 +593,8 @@ final class RingSession: NSObject {
         liveHR = nil
         liveHRTrend.removeAll()
         liveHRWarmup = nil
+        userMeasureFailed = false        // retry: dismiss the prior error naturally (#55)
+        userMeasureFailedMessage = nil
         let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
         Task { [weak self] in
             guard let self else { return }
@@ -569,6 +614,8 @@ final class RingSession: NSObject {
         liveMode = mode
         liveHRTrend.removeAll()   // restarting the HR window
         liveHRWarmup = nil
+        userMeasureFailed = false   // mode switch = fresh start, dismiss any prior failure (#55)
+        userMeasureFailedMessage = nil
         guard monitoring else { return }
         let modeCmd = mode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
         // Re-arm with the d0 status query before the mode byte (mirrors the proven enter
@@ -590,6 +637,7 @@ final class RingSession: NSObject {
         monitorTask = nil
         monitoring = false
         livePreparing = false
+        userMeasuring = false   // user read done (or timed out — `userMeasureFailed` is kept for the banner) (#55)
         // Safety net for a background teardown that interrupted the live-enter drain before its
         // post-drain commit ran (#22 bg race): persist the captured pages so an overnight read
         // that never reached its finalize doesn't silently drop last night's sleep/vitals.

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -1128,6 +1128,11 @@ extension RingSession: CBPeripheralDelegate {
                 if !self.gotDataFrame { self.gotDataFrame = true }
                 if self.notStreaming { self.notStreaming = false }
                 self.streamWatchdogTask?.cancel(); self.streamWatchdogTask = nil
+                // Durable "last ring data received" timestamp for the wear reminder (#84): a real
+                // data frame proves the ring is worn/streaming. Persisted (unlike the in-memory
+                // `lastFrameAt`) so a cold foreground doesn't falsely fire "put your ring back on".
+                UserDefaults.standard.set(Date().timeIntervalSince1970,
+                                          forKey: ReminderDefaults.lastRingDataAt)
             }
             // Frames arriving while the link isn't `ready` mean discovery didn't land on this
             // (restored) reconnect — re-run it so we can ack and the buttons enable. #reconnect

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -30,6 +30,7 @@ final class RingSession: NSObject {
     /// arriving and climbing, vs. no HR frames at all.
     private(set) var liveHRWarmup: Int?
     private(set) var steps: Int?          // ring onboard step count (0x10/0x87 [4:6], §5.4)
+    private(set) var liveTemperature: Double?   // skin temp °C (0x10/0x87 [6:8]/[8:10], §5.4)
     private(set) var liveMode: LiveMode = .hr
     private(set) var monitoring = false
     /// True during the open→drain phase before the live stream starts. The ring won't
@@ -127,6 +128,7 @@ final class RingSession: NSObject {
                 self.historySamples = BulkSleep.samples(from: self.bulkRecords)
                 self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords)
                 self.stagedSegments = BulkSleep.stagedSegments(from: self.bulkRecords)
+                self.persist(self.historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
             }
             // 3. Leave bulk mode and enter the selected live mode.
             for cmd in [Command.statusQuery, modeCmd, Command.fetch] {
@@ -153,6 +155,13 @@ final class RingSession: NSObject {
 
     func setLocalStore(_ localStore: LocalStore) {
         self.localStore = localStore
+    }
+
+    /// Persist decoded samples to the local store (the vitals dashboard reads from it, so
+    /// data is always visible offline). The SyncCursor dedupes, so repeated calls are safe.
+    private func persist(_ samples: [QuantitySample]) {
+        guard let localStore, !samples.isEmpty else { return }
+        storedMetricSamples += (try? localStore.ingest(samples).count) ?? 0
     }
 
     /// Start (or switch) live monitoring in a single mode. Guarantees only one metric
@@ -196,6 +205,12 @@ final class RingSession: NSObject {
         monitorTask = nil
         monitoring = false
         livePreparing = false
+        // Persist the last live reading so the dashboard shows it after disconnect.
+        let now = Date()
+        var last: [QuantitySample] = []
+        if let hr = liveHR { last.append(QuantitySample(kind: .heartRate, start: now, value: Double(hr))) }
+        if let spo2 = liveSpO2 { last.append(QuantitySample(kind: .spo2, start: now, value: Double(spo2) / 100)) }
+        persist(last)
     }
 
     /// Pull stored history: open the sync session (cursor = everything) and fetch.
@@ -236,6 +251,7 @@ final class RingSession: NSObject {
         historySamples = BulkSleep.samples(from: bulkRecords)
         sleepSegments = BulkSleep.sleepSegments(from: bulkRecords)
         stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
+        persist(historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
         syncing = false
         syncTask = nil
         if !bulkRecords.isEmpty {
@@ -291,6 +307,12 @@ extension RingSession: CBPeripheralDelegate {
             // are interleaved, so take the running max (today's cumulative count).
             if let s = DeviceStatus.steps(bytes), s > 0 {
                 self.steps = max(self.steps ?? 0, s)
+            }
+            // Skin temperature rides the same 0x10/0x87 descriptor (§5.4). It streams live
+            // (~30–60 s) and is NOT in the sleep sync, so capture + persist it here.
+            if let t = DeviceStatus.skinTemperature(bytes) {
+                self.liveTemperature = t.celsius
+                self.persist([QuantitySample(kind: .temperature, start: Date(), value: t.celsius)])
             }
             // Bulk history pages: accumulate + ack to continue draining (47→c7, 4c→cc).
             switch bytes.first {

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -27,6 +27,12 @@ final class RingSession: NSObject {
 
     private(set) var liveHR: Int?
     private(set) var liveSpO2: Int?       // 🟡 from long 0x15 frame byte[14]
+    /// Wall-clock when `liveHR` / `liveSpO2` were last actually LOCKED (a fresh decoded reading) —
+    /// NOT when the last frame arrived. The idle keepalive bumps `lastFrameAt` to ≈now on every
+    /// descriptor frame, so stamping a persisted reading with `lastFrameAt` re-dated a lingering
+    /// (stale) HR/SpO₂ to ~now. Stamp with the true capture time instead (see `stopLiveMonitoring`).
+    private var liveHRAt: Date?
+    private var liveSpO2At: Date?
     /// Recent live-HR samples (oldest→newest, capped). Lets the UI show whether the
     /// reading is converging vs. stuck — these sensors report a windowed average that
     /// climbs over ~20–60 s of stillness, so a single number is misleading.
@@ -45,6 +51,10 @@ final class RingSession: NSObject {
     /// measured — not `Date()`, which would push a minutes-old reading into HealthKit "now".
     private(set) var lastFrameAt: Date?
     private(set) var monitoring = false
+    /// When the current live-monitoring cycle began (set in `startLiveMonitoring`). Lets the
+    /// stop-time persist keep ONLY readings actually measured during this cycle, so a value
+    /// lingering from an earlier cycle isn't re-persisted (and re-dated) at stop.
+    private var monitoringStartedAt: Date?
     /// True during the open→drain phase before the live stream starts. The ring won't
     /// emit live frames until its history backlog is fully drained, so we surface this
     /// so the UI shows "preparing" instead of a dead reading.
@@ -312,8 +322,9 @@ final class RingSession: NSObject {
         syncTask?.cancel(); syncTask = nil
         syncing = false
         monitoring = true
+        monitoringStartedAt = Date()
         livePreparing = true
-        if clearStaleValue { liveHR = nil }   // fresh user read — don't let a stale value look live (#45 C)
+        if clearStaleValue { liveHR = nil; liveHRAt = nil }   // fresh user read — don't let a stale value look live (#45 C)
         liveHRTrend.removeAll()   // fresh convergence window
         liveHRWarmup = nil
         bulkRecords.removeAll()   // any pages we drain below land here (don't lose them)
@@ -369,7 +380,7 @@ final class RingSession: NSObject {
                 self.historySamples = BulkSleep.samples(from: self.bulkRecords)
                 self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords,
                                                              temperatures: self.wearTemperatureSamples())   // wear gate (#41)
-                self.stagedSegments = BulkSleep.stagedSegments(from: self.bulkRecords)
+                self.stagedSegments = self.overnightStagedSegments(from: self.bulkRecords)   // overnight gate (review #1)
                 self.persist(self.historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
                 self.persistSleepAndSteps()          // sleep summary + steps for offline display
                 self.bulkFinalized = true            // committed — the stop-time safety net can skip it
@@ -666,6 +677,21 @@ final class RingSession: NSObject {
         storedMetricSamples += (try? localStore.ingest(samples).count) ?? 0
     }
 
+    /// Staged sleep segments for a sync, but ONLY when the detected block is OVERNIGHT sleep.
+    /// A normal daytime "Sync from ring" can drain worn, sedentary daytime epochs (a long meeting,
+    /// a movie, an afternoon nap > 1 h); `BulkSleep.stagedSegments` would classify the first still
+    /// block > 1 h as sleep, and since this feeds both the persistent Sleep card and the
+    /// `StoredSleepSummary` rollup (upserted by start-of-day), a daytime block could be shown as
+    /// "last night" and overwrite/supersede the real night — reintroducing the disappearing-sleep
+    /// bug through the sync door. Gating to an overnight window (by overlap, never clipping, so the
+    /// real night's totals are preserved) means a daytime block yields `[]`, and the card then
+    /// falls back to the stored real night. (Adversarial review #1.)
+    private func overnightStagedSegments(from records: [BulkRecord]) -> [SleepSegment] {
+        let segs = BulkSleep.stagedSegments(from: records)
+        guard let block = segs.first(where: { $0.stage == .inBed }) else { return segs }
+        return SleepWindow.isOvernightBlock(start: block.start, end: block.end) ? segs : []
+    }
+
     /// Persist the latest night's sleep summary + today's step count so the dashboard
     /// shows them OFFLINE after disconnect. Both UPSERT by day (no duplicates) and bypass
     /// the cumulative-counter `ingest` path entirely — the SyncCursor is untouched.
@@ -758,6 +784,7 @@ final class RingSession: NSObject {
     /// asking for a new reading wants.
     private func rearmUserMeasure() {
         liveHR = nil
+        liveHRAt = nil
         liveHRTrend.removeAll()
         liveHRWarmup = nil
         userMeasureFailed = false        // retry: dismiss the prior error naturally (#55)
@@ -815,19 +842,30 @@ final class RingSession: NSObject {
             historySamples = BulkSleep.samples(from: bulkRecords)
             sleepSegments = BulkSleep.sleepSegments(from: bulkRecords,
                                                     temperatures: wearTemperatureSamples())   // wear gate (#41)
-            stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
+            stagedSegments = overnightStagedSegments(from: bulkRecords)   // overnight gate (review #1)
             persist(historySamples)
             persistSleepAndSteps()
             bulkFinalized = true
         }
-        // Persist the last live reading so the dashboard shows it after disconnect. Stamp it with
-        // WHEN the ring last actually sent a frame, not `Date()` (#36): on a silently-dropped link
-        // the last value can be minutes old, and stamping "now" would push a wrong timestamp into
-        // HealthKit. Fall back to now only if we somehow never recorded a frame.
-        let stamp = lastFrameAt ?? Date()
+        // Persist the last live reading so the dashboard shows it after disconnect — stamped at
+        // WHEN THE VALUE WAS MEASURED (`liveHRAt`/`liveSpO2At`), not `lastFrameAt`. The idle
+        // keepalive bumps `lastFrameAt` to ≈now on every descriptor frame, so a lingering
+        // `liveHR`/`liveSpO2` (a prior lock — `liveSpO2` is never cleared) was re-stamped to ~now
+        // at every stop. That now-dated STALE value advanced the sync cursor past genuinely newer
+        // synced sleep epochs (which then deduped out of the store) AND out-ranked them in
+        // VitalsTableView.latestReading — so HR/SpO₂ showed the old measured value and never the
+        // newer synced one. Stamping at the true capture time, and only persisting a reading
+        // measured in THIS cycle (`>= monitoringStartedAt`), makes any re-persist land at its real
+        // (old) time: deduped harmlessly, never masking fresher sync data. (#36 still holds — a
+        // real lock's capture time is when it was measured, never a wrong "now".)
+        let cycleStart = monitoringStartedAt ?? .distantPast
         var last: [QuantitySample] = []
-        if let hr = liveHR { last.append(QuantitySample(kind: .heartRate, start: stamp, value: Double(hr))) }
-        if let spo2 = liveSpO2 { last.append(QuantitySample(kind: .spo2, start: stamp, value: Double(spo2) / 100)) }
+        if let hr = liveHR, let at = liveHRAt, at >= cycleStart {
+            last.append(QuantitySample(kind: .heartRate, start: at, value: Double(hr)))
+        }
+        if let spo2 = liveSpO2, let at = liveSpO2At, at >= cycleStart {
+            last.append(QuantitySample(kind: .spo2, start: at, value: Double(spo2) / 100))
+        }
         persist(last)
     }
 
@@ -881,7 +919,7 @@ final class RingSession: NSObject {
         historySamples = BulkSleep.samples(from: bulkRecords)
         sleepSegments = BulkSleep.sleepSegments(from: bulkRecords,
                                                 temperatures: wearTemperatureSamples())   // wear gate (#41)
-        stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
+        stagedSegments = overnightStagedSegments(from: bulkRecords)   // overnight gate (review #1)
         persist(historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
         persistSleepAndSteps()    // sleep summary + steps for offline display
         bulkFinalized = true      // committed — the stop-time safety net can skip these records
@@ -1143,6 +1181,7 @@ extension RingSession: CBPeripheralDelegate {
             if frame.opcode == Frame.responseID(Opcode.poll) {
                 if let hr = LiveHR.decodeLocked(bytes) {                         // short frame, locked on
                     self.liveHR = hr
+                    self.liveHRAt = Date()   // true capture time for the stop-time persist (not lastFrameAt)
                     self.liveHRWarmup = nil
                     self.liveHRTrend.append(hr)
                     if self.liveHRTrend.count > 12 { self.liveHRTrend.removeFirst() }
@@ -1155,6 +1194,7 @@ extension RingSession: CBPeripheralDelegate {
                 }
                 if let spo2 = LiveHR.decodeSpO2(bytes) {                         // long frame, 🟡
                     self.liveSpO2 = spo2
+                    self.liveSpO2At = Date()   // true capture time for the stop-time persist (not lastFrameAt)
                     ringLog.notice("live SpO2: \(spo2)%")
                 }
             }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -19,6 +19,10 @@ final class RingSession: NSObject {
 
     private(set) var liveHR: Int?
     private(set) var liveSpO2: Int?       // 🟡 from long 0x15 frame byte[14]
+    /// Recent live-HR samples (oldest→newest, capped). Lets the UI show whether the
+    /// reading is converging vs. stuck — these sensors report a windowed average that
+    /// climbs over ~20–60 s of stillness, so a single number is misleading.
+    private(set) var liveHRTrend: [Int] = []
     private(set) var steps: Int?          // ring onboard step count (0x10/0x87 [4:6], §5.4)
     private(set) var liveMode: LiveMode = .hr
     private(set) var monitoring = false
@@ -71,6 +75,7 @@ final class RingSession: NSObject {
         syncTask?.cancel(); syncTask = nil
         syncing = false
         monitoring = true
+        liveHRTrend.removeAll()   // fresh convergence window
         let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
         // Proven-accepted cursor (0xFFFFFFFF), then enter the selected live mode.
         let enterSeq: [[UInt8]] = [Command.status0, Command.status1, Command.syncAll,
@@ -81,9 +86,18 @@ final class RingSession: NSObject {
                 self.write(cmd)
                 try? await Task.sleep(for: .milliseconds(300))
             }
+            var tick = 0
             while !Task.isCancelled {
                 guard let self else { return }
                 self.write(Command.poll)
+                // Every ~8 s, re-pull the status descriptor (0x10/0x87) so the step
+                // count refreshes mid-session — otherwise steps only update if the ring
+                // happens to emit one spontaneously. Paced so the write isn't dropped.
+                if tick % 8 == 7 {
+                    try? await Task.sleep(for: .milliseconds(300))
+                    self.write(Command.statusQuery)
+                }
+                tick += 1
                 try? await Task.sleep(for: .seconds(1))
             }
         }
@@ -107,6 +121,7 @@ final class RingSession: NSObject {
     func setLiveMode(_ mode: LiveMode) {
         guard liveMode != mode else { return }
         liveMode = mode
+        liveHRTrend.removeAll()   // restarting the HR window
         guard monitoring else { return }
         let modeCmd = mode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
         Task { [weak self] in
@@ -235,7 +250,11 @@ extension RingSession: CBPeripheralDelegate {
             //   long  `15 01 … <spo2> …`  → byte[2]=0; SpO2 at byte[14] (🟡)
             // Only the short frame carries HR — don't let a long frame zero it out.
             if frame.opcode == Frame.responseID(Opcode.poll) {
-                if let hr = LiveHR.decodeLocked(bytes) { self.liveHR = hr }      // short frame, warm-up filtered
+                if let hr = LiveHR.decodeLocked(bytes) {                         // short frame, warm-up filtered
+                    self.liveHR = hr
+                    self.liveHRTrend.append(hr)
+                    if self.liveHRTrend.count > 12 { self.liveHRTrend.removeFirst() }
+                }
                 if let spo2 = LiveHR.decodeSpO2(bytes) { self.liveSpO2 = spo2 }  // long frame, 🟡
             }
         }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -30,6 +30,10 @@ final class RingSession: NSObject {
     private(set) var steps: Int?          // ring onboard step count (0x10/0x87 [4:6], §5.4)
     private(set) var liveMode: LiveMode = .hr
     private(set) var monitoring = false
+    /// True during the open→drain phase before the live stream starts. The ring won't
+    /// emit live frames until its history backlog is fully drained, so we surface this
+    /// so the UI shows "preparing" instead of a dead reading.
+    private(set) var livePreparing = false
     private(set) var lastFrame: String?
     private(set) var ready = false
 
@@ -53,6 +57,8 @@ final class RingSession: NSObject {
     private var syncTask: Task<Void, Never>?
     private var syncDone = false        // 0x50 end-of-history seen
     private var syncQuietTicks = 0      // seconds since the last page arrived
+    private var drainSawPage = false    // a 0x47/0x4c page arrived since last check (live-enter drain)
+    private var drainDone = false       // 0x50 end-of-history seen during live-enter drain
 
     private let peripheral: CBPeripheral
     private var notifyChar: CBCharacteristic?
@@ -68,10 +74,11 @@ final class RingSession: NSObject {
         peripheral.discoverServices(nil)
     }
 
-    /// Begin live monitoring: open the session at *now* (so there's no history backlog
-    /// to drain and flood the link), enter HR mode (`d0` → `06 01 00` → fetch), then poll
-    /// `95 00 00` ~1/s. Writes are paced ~300 ms apart so CoreBluetooth doesn't drop them.
-    /// Updates `liveHR`/`liveSpO2`. Idempotent.
+    /// Begin live monitoring. The ring will NOT emit live frames until its pending
+    /// history backlog is fully drained (PROTOCOL.md §5.1 / livehr.py): open the sync
+    /// session (cursor 0xFFFFFFFF), drain every 0x47/0x4c page to completion, THEN
+    /// `d0` → mode (`06 01`/`06 02`) → fetch, then poll `95 00 00`. Entering live mode
+    /// before the drain finishes leaves HR stuck at the warm-up sentinel (8). Idempotent.
     func startLiveMonitoring() {
         guard monitorTask == nil else { return }
         // Live and history sync can't coexist (ring is one mode at a time). Cancel any
@@ -79,28 +86,53 @@ final class RingSession: NSObject {
         syncTask?.cancel(); syncTask = nil
         syncing = false
         monitoring = true
+        livePreparing = true
         liveHRTrend.removeAll()   // fresh convergence window
         liveHRWarmup = nil
+        bulkRecords.removeAll()   // any pages we drain below land here (don't lose them)
+        drainSawPage = false
+        drainDone = false
         let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
-        // Proven enter sequence (PROTOCOL.md §5.1): open session, drain a history record
-        // (the extra `fetch`), then d0 status query → mode byte → fetch. The history
-        // drain + d0 are what reliably leaves bulk mode so the live stream starts.
-        let enterSeq: [[UInt8]] = [Command.status0, Command.status1, Command.syncAll,
-                                   Command.fetch, Command.statusQuery, modeCmd, Command.fetch]
         monitorTask = Task { [weak self] in
-            for cmd in enterSeq {
-                guard let self else { return }
+            // 1. Init + open the sync session (cursor = everything; verified, §5.6).
+            for cmd in [Command.status0, Command.status1, Command.syncAll] {
+                guard let self, !Task.isCancelled else { return }
                 self.write(cmd)
-                try? await Task.sleep(for: .milliseconds(300))
+                try? await Task.sleep(for: .milliseconds(250))
             }
-            // Pure polling only. Do NOT inject `d0` (status query) here to refresh steps:
-            // d0 re-arms the mode switch and kicks the HR session back to its warm-up
-            // sentinel (byte[2]=8), so the reading never climbs. Steps refresh from the
-            // ring's spontaneous 0x10/0x87 frames instead.
+            // 2. CRITICAL: drain the history backlog to completion before live mode.
+            //    Pages are acked in didUpdateValue; wait for the 0x50 end marker or
+            //    ~1.5 s of quiet (cap ~15 s for a large overnight backlog).
+            guard let s0 = self, !Task.isCancelled else { return }
+            s0.write(Command.fetch)
+            var quiet = 0
+            for _ in 0 ..< 30 {
+                try? await Task.sleep(for: .milliseconds(500))
+                guard let self, !Task.isCancelled else { return }
+                if self.drainDone { break }
+                if self.drainSawPage { self.drainSawPage = false; quiet = 0 }
+                else { quiet += 1; if quiet >= 3 { break } }
+            }
+            // Surface anything drained so overnight sleep/vitals aren't lost — the ring
+            // discards delivered pages, so this is the only chance to keep them.
+            if let self, !self.bulkRecords.isEmpty {
+                self.historySamples = BulkSleep.samples(from: self.bulkRecords)
+                self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords)
+                self.stagedSegments = BulkSleep.stagedSegments(from: self.bulkRecords)
+            }
+            // 3. Leave bulk mode and enter the selected live mode.
+            for cmd in [Command.statusQuery, modeCmd, Command.fetch] {
+                guard let self, !Task.isCancelled else { return }
+                self.write(cmd)
+                try? await Task.sleep(for: .milliseconds(250))
+            }
+            self?.livePreparing = false
+            // 4. Poll for live samples (~1.4/s). No `d0` here — it re-arms the mode
+            //    switch and kicks HR back to its warm-up sentinel.
             while !Task.isCancelled {
                 guard let self else { return }
                 self.write(Command.poll)
-                try? await Task.sleep(for: .seconds(1))
+                try? await Task.sleep(for: .milliseconds(700))
             }
         }
     }
@@ -145,6 +177,7 @@ final class RingSession: NSObject {
         monitorTask?.cancel()
         monitorTask = nil
         monitoring = false
+        livePreparing = false
     }
 
     /// Pull stored history: open the sync session (cursor = everything) and fetch.
@@ -244,17 +277,20 @@ extension RingSession: CBPeripheralDelegate {
             // Bulk history pages: accumulate + ack to continue draining (47→c7, 4c→cc).
             switch bytes.first {
             case 0x47:
+                self.drainSawPage = true
                 if self.syncing { self.syncQuietTicks = 0 }
                 self.write(Command.pageAck47); return   // PPG page — decode TODO (issue #8)
             case 0x4C:
-                if self.syncing {
+                self.drainSawPage = true
+                if self.syncing || self.livePreparing {   // keep records during a sync OR a live-enter drain
                     self.bulkRecords += BulkSleep.records(fromPage: bytes)
                     self.syncQuietTicks = 0
                 }
                 self.write(Command.pageAck4C); return   // always ack to keep draining
             case 0x50:
                 // End-of-history cursor report (§5.5) — NO XOR trailer, so it never
-                // reaches Frame.parse. Mark done; the sync watchdog finalizes.
+                // reaches Frame.parse. Mark done; the sync watchdog / live-enter drain finalizes.
+                self.drainDone = true
                 if self.syncing { self.syncDone = true }
                 return
             default: break

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -77,6 +77,7 @@ final class RingSession: NSObject {
     private(set) var syncStatus: String?
 
     private var bulkRecords: [BulkRecord] = []
+    private var bulkFinalized = false    // captured pages already committed (sleep/vitals) — stop-time safety net skips re-commit
     private var lastRawSteps: Int?       // last raw descriptor [4:6] counter (for delta accumulation)
     private var dailyStepsTotal = 0      // accumulated daily step total (mirrors StoredDaily)
     private var syncTask: Task<Void, Never>?
@@ -105,12 +106,22 @@ final class RingSession: NSObject {
         peripheral.discoverServices(nil)
     }
 
-    /// Begin live monitoring. The ring will NOT emit live frames until its pending
-    /// history backlog is fully drained (PROTOCOL.md §5.1 / livehr.py): open the sync
-    /// session (cursor 0xFFFFFFFF), drain every 0x47/0x4c page to completion, THEN
-    /// `d0` → mode (`06 01`/`06 02`) → fetch, then poll `95 00 00`. Entering live mode
-    /// before the drain finishes leaves HR stuck at the warm-up sentinel (8). Idempotent.
-    func startLiveMonitoring() {
+    /// Begin live monitoring. The proven enter sequence (PROTOCOL.md §5.1 / livehr.py) is
+    /// unchanged: open the sync session (cursor 0xFFFFFFFF), let the ring's history backlog
+    /// drain, THEN `d0` → mode (`06 01`/`06 02`) → fetch, then poll `95 00 00`. Idempotent.
+    ///
+    /// - `quickLiveRead`: the goal is a prompt live HR/SpO₂ (a user tap or the daytime auto/
+    ///   background refresh), not the overnight sleep dump. The drain still runs and pages are
+    ///   still captured, but we don't wait out a long backlog before entering live mode — the
+    ///   old 15 s worst-case wait starved the HR poll of its budget so it never locked in the
+    ///   background (#45). On a quiet ring the drain already exits on a beat of quiet, so this
+    ///   mostly just caps the pathological never-quiet case. The full (quiet-bounded) drain —
+    ///   used by the overnight background capture — still runs when this is false so sleep isn't
+    ///   lost.
+    /// - `clearStaleValue`: drop the last `liveHR` up front so an old reading can't masquerade
+    ///   as live while a fresh user measurement warms up (#45 C). Off for auto/background so a
+    ///   prior value stays on screen until the new one locks.
+    func startLiveMonitoring(quickLiveRead: Bool = false, clearStaleValue: Bool = false) {
         guard monitorTask == nil else { return }
         // Live and history sync can't coexist (ring is one mode at a time). Cancel any
         // in-flight sync so the ring is free to enter live mode.
@@ -118,9 +129,11 @@ final class RingSession: NSObject {
         syncing = false
         monitoring = true
         livePreparing = true
+        if clearStaleValue { liveHR = nil }   // fresh user read — don't let a stale value look live (#45 C)
         liveHRTrend.removeAll()   // fresh convergence window
         liveHRWarmup = nil
         bulkRecords.removeAll()   // any pages we drain below land here (don't lose them)
+        bulkFinalized = false
         drainSawPage = false
         drainDone = false
         let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
@@ -131,13 +144,18 @@ final class RingSession: NSObject {
                 self.write(cmd)
                 try? await Task.sleep(for: .milliseconds(250))
             }
-            // 2. CRITICAL: drain the history backlog to completion before live mode.
-            //    Pages are acked in didUpdateValue; wait for the 0x50 end marker or
-            //    ~1.5 s of quiet (cap ~15 s for a large overnight backlog).
+            // 2. Drain the history backlog before live mode. Pages are acked in
+            //    didUpdateValue; exit on the 0x50 end marker or a beat of quiet. A normal
+            //    overnight dump streams sub-second apart and then stops, so the quiet exit
+            //    fires right after the last page — the cap is only a backstop for a ring that
+            //    never goes quiet. For a quick live read that backstop is short (don't let a
+            //    pathological backlog eat the HR poll's budget, #45); the full-drain path keeps
+            //    the longer cap so a big overnight backlog is fully captured.
             guard let s0 = self, !Task.isCancelled else { return }
             s0.write(Command.fetch)
+            let drainMaxTicks = quickLiveRead ? 6 : 30   // ×500 ms ⇒ ~3 s quick / ~15 s full backstop
             var quiet = 0
-            for _ in 0 ..< 30 {
+            for _ in 0 ..< drainMaxTicks {
                 try? await Task.sleep(for: .milliseconds(500))
                 guard let self, !Task.isCancelled else { return }
                 if self.drainDone { break }
@@ -152,6 +170,7 @@ final class RingSession: NSObject {
                 self.stagedSegments = BulkSleep.stagedSegments(from: self.bulkRecords)
                 self.persist(self.historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
                 self.persistSleepAndSteps()          // sleep summary + steps for offline display
+                self.bulkFinalized = true            // committed — the stop-time safety net can skip it
             }
             // 3. Leave bulk mode and enter the selected live mode.
             for cmd in [Command.statusQuery, modeCmd, Command.fetch] {
@@ -189,6 +208,11 @@ final class RingSession: NSObject {
     /// gap is time we're not connected — and with no official-app contention, that's it).
     /// Skips ticks during live monitoring / sync, which generate descriptor traffic of
     /// their own (and where an extra fetch can disturb the HR warm-up window).
+    ///
+    /// The cadence is ADAPTIVE (#31): a fixed 30 s poll around the clock measurably drained
+    /// both batteries for a step counter that barely moves. Steps/battery drift slowly, and
+    /// skin temp only matters overnight (already window-gated), so we poll slowly by day and
+    /// tighten only inside the nightly window — `KeepaliveCadence` owns the policy.
     func startKeepalive() {
         guard keepaliveTask == nil else { return }
         keepaliveTask = Task { [weak self] in
@@ -203,12 +227,30 @@ final class RingSession: NSObject {
             }
             while !Task.isCancelled {
                 guard let self else { return }
+                // Re-resolve the night window (self-throttled to ≤ every 30 min) so the cadence
+                // tightens/relaxes as the window rolls over, not just at connect.
+                await self.refreshNightWindowIfNeeded()
                 if self.ready, !self.monitoring, !self.livePreparing, self.syncTask == nil {
                     self.write(Command.fetch)   // 07 00 00 → fresh 0x10/0x87 descriptor
                 }
-                try? await Task.sleep(for: .seconds(30))
+                try? await Task.sleep(for: .seconds(self.keepaliveInterval))
             }
         }
+    }
+
+    /// UserDefaults key for the battery-saver toggle — stretches the idle keepalive cadence (#31).
+    /// Default OFF (max fidelity); a stored `true` opts into the slower daytime/night cadences.
+    static let batterySaverEnabledKey = "keepalive.batterySaver"
+
+    /// Adaptive idle-keepalive interval (seconds): slow by day, tighter inside the nightly temp
+    /// window or while a live read holds the link, stretched further in battery saver (#31).
+    /// Policy lives in the pure, unit-tested `KeepaliveCadence`.
+    private var keepaliveInterval: TimeInterval {
+        KeepaliveCadence.interval(
+            isNight: nightWindow?.contains(Date()) ?? false,
+            activeMeasurement: monitoring || livePreparing,
+            batterySaver: UserDefaults.standard.bool(forKey: Self.batterySaverEnabledKey)
+        )
     }
 
     /// UserDefaults key for the periodic auto-measure toggle (default ON — the user opted in).
@@ -268,7 +310,7 @@ final class RingSession: NSObject {
     private func autoMeasureOnce(mode: LiveMode, timeout: TimeInterval) async {
         guard idleForAutoMeasure else { return }
         autoMeasuring = true
-        startMonitoring(mode: mode)             // sets monitoring=true; drains, enters, polls
+        startMonitoring(mode: mode, userInitiated: false)   // auto refresh: prompt enter, keep last value until it locks
         let deadline = Date().addingTimeInterval(timeout)
         while !Task.isCancelled && Date() < deadline {
             if mode == .hr, liveHR != nil { break }
@@ -340,12 +382,42 @@ final class RingSession: NSObject {
     /// Start (or switch) live monitoring in a single mode. Guarantees only one metric
     /// reads at a time: switching to a mode puts the ring in `06 01`/`06 02`, so frames
     /// for the other metric stop arriving.
-    func startMonitoring(mode: LiveMode) {
+    ///
+    /// - `userInitiated`: a real Measure tap. When already live in the SAME mode it re-arms a
+    ///   fresh poll (#45 B) — without this, tapping Measure on a stalled stream was a silent
+    ///   no-op. The periodic auto-measure passes `false` so it never disturbs a converging read.
+    /// - `quickLiveRead`: prompt live-read entry (the default for foreground/auto). The overnight
+    ///   background capture passes `false` for the full sleep drain (see `startLiveMonitoring`).
+    func startMonitoring(mode: LiveMode, userInitiated: Bool = true, quickLiveRead: Bool = true) {
         if monitoring {
-            setLiveMode(mode)
+            if liveMode == mode {
+                if userInitiated { rearmUserMeasure() }   // re-poll on demand; auto leaves it alone
+            } else {
+                setLiveMode(mode)
+            }
         } else {
             liveMode = mode
-            startLiveMonitoring()
+            startLiveMonitoring(quickLiveRead: quickLiveRead, clearStaleValue: userInitiated)
+        }
+    }
+
+    /// Re-arm an already-running live read for a fresh user measurement (#45 B/C): drop the
+    /// stale value + convergence window, then re-issue the proven `d0` → mode → fetch enter so
+    /// the ring restarts the measurement. The existing poll loop keeps sending `95 00 00`, so no
+    /// second loop is spawned. This intentionally kicks HR back to warm-up — exactly what a user
+    /// asking for a new reading wants.
+    private func rearmUserMeasure() {
+        liveHR = nil
+        liveHRTrend.removeAll()
+        liveHRWarmup = nil
+        let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
+        Task { [weak self] in
+            guard let self else { return }
+            self.write(Command.statusQuery)
+            try? await Task.sleep(for: .milliseconds(250))
+            self.write(modeCmd)
+            try? await Task.sleep(for: .milliseconds(250))
+            self.write(Command.fetch)
         }
     }
 
@@ -378,6 +450,18 @@ final class RingSession: NSObject {
         monitorTask = nil
         monitoring = false
         livePreparing = false
+        // Safety net for a background teardown that interrupted the live-enter drain before its
+        // post-drain commit ran (#22 bg race): persist the captured pages so an overnight read
+        // that never reached its finalize doesn't silently drop last night's sleep/vitals.
+        // No-op once the drain already committed (bulkFinalized) or nothing was captured.
+        if !bulkRecords.isEmpty, !bulkFinalized {
+            historySamples = BulkSleep.samples(from: bulkRecords)
+            sleepSegments = BulkSleep.sleepSegments(from: bulkRecords)
+            stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
+            persist(historySamples)
+            persistSleepAndSteps()
+            bulkFinalized = true
+        }
         // Persist the last live reading so the dashboard shows it after disconnect.
         let now = Date()
         var last: [QuantitySample] = []
@@ -393,6 +477,7 @@ final class RingSession: NSObject {
         guard syncTask == nil else { return }   // already syncing
         stopLiveMonitoring()                     // live polling would fight the drain
         bulkRecords.removeAll()
+        bulkFinalized = false                    // fresh capture — uncommitted until finalizeSync
         historySamples.removeAll()
         sleepSegments.removeAll()
         stagedSegments.removeAll()
@@ -433,6 +518,7 @@ final class RingSession: NSObject {
         stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
         persist(historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
         persistSleepAndSteps()    // sleep summary + steps for offline display
+        bulkFinalized = true      // committed — the stop-time safety net can skip these records
         syncing = false
         syncTask = nil
         ringLog.notice("sync: FINALIZE records=\(self.bulkRecords.count) samples=\(self.historySamples.count) sleepSegs=\(self.sleepSegments.count) steps=\(self.steps ?? -1)")

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -129,6 +129,7 @@ final class RingSession: NSObject {
                 self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords)
                 self.stagedSegments = BulkSleep.stagedSegments(from: self.bulkRecords)
                 self.persist(self.historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
+                self.persistSleepAndSteps()          // sleep summary + steps for offline display
             }
             // 3. Leave bulk mode and enter the selected live mode.
             for cmd in [Command.statusQuery, modeCmd, Command.fetch] {
@@ -162,6 +163,20 @@ final class RingSession: NSObject {
     private func persist(_ samples: [QuantitySample]) {
         guard let localStore, !samples.isEmpty else { return }
         storedMetricSamples += (try? localStore.ingest(samples).count) ?? 0
+    }
+
+    /// Persist the latest night's sleep summary + today's step count so the dashboard
+    /// shows them OFFLINE after disconnect. Both UPSERT by day (no duplicates) and bypass
+    /// the cumulative-counter `ingest` path entirely — the SyncCursor is untouched.
+    private func persistSleepAndSteps() {
+        guard let localStore else { return }
+        if !stagedSegments.isEmpty {
+            let summary = SleepStaging.summary(stagedSegments)
+            // `night` = start of the sleep window (segments carry the dates; Summary doesn't).
+            let night = stagedSegments.map(\.start).min() ?? Date()
+            try? localStore.saveSleepSummary(summary, night: night)
+        }
+        if let steps { try? localStore.saveDailySteps(steps) }
     }
 
     /// Start (or switch) live monitoring in a single mode. Guarantees only one metric
@@ -211,6 +226,8 @@ final class RingSession: NSObject {
         if let hr = liveHR { last.append(QuantitySample(kind: .heartRate, start: now, value: Double(hr))) }
         if let spo2 = liveSpO2 { last.append(QuantitySample(kind: .spo2, start: now, value: Double(spo2) / 100)) }
         persist(last)
+        // Steps stream live over 0x10/0x87 — persist the latest so it survives disconnect.
+        if let steps { try? localStore?.saveDailySteps(steps) }
     }
 
     /// Pull stored history: open the sync session (cursor = everything) and fetch.
@@ -252,6 +269,7 @@ final class RingSession: NSObject {
         sleepSegments = BulkSleep.sleepSegments(from: bulkRecords)
         stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
         persist(historySamples)   // auto-persist HR/HRV/SpO2 for the dashboard
+        persistSleepAndSteps()    // sleep summary + steps for offline display
         syncing = false
         syncTask = nil
         if !bulkRecords.isEmpty {

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -53,6 +53,22 @@ final class RingSession: NSObject {
     private(set) var decodedEpochRecords = 0
     private(set) var storedMetricSamples = 0
     private(set) var ready = false
+    /// True once the notify subscription is CONFIRMED (`didUpdateNotificationStateFor` success) —
+    /// distinct from `ready`, which only means the notify/write characteristics were DISCOVERED.
+    /// An unsubscribed notify char silently drops every inbound frame.
+    private(set) var notifySubscribed = false
+    /// True when the link is up + subscribed but the ring delivers only `0x81` status replies and
+    /// NO data frames (`0x10`/`0x82`/`0x15`/`0x47`/`0x4c`/`0x11`) — the signature of a ring that
+    /// hasn't been activated/bonded by the official app (it accepts writes but answers nothing, so
+    /// Measure/Sync would just time out). Cleared the instant a data frame arrives. We INFER this
+    /// (don't claim to KNOW it's unactivated), per the `reconnectStalled` precedent.
+    private(set) var notStreaming = false
+    /// Whether any non-`0x81` (data/activity) frame has arrived since connect. Drives `notStreaming`
+    /// — the cold status reads always elicit `0x81`, so "frames arrived" alone can't tell us the
+    /// data path is alive; a DATA frame can.
+    private var gotDataFrame = false
+    /// Wall-clock of the last `0x11` heartbeat (optional liveness signal).
+    private(set) var lastHeartbeatAt: Date?
     /// True while the periodic auto-measure (not a user tap) is driving a live read, so the
     /// UI can show a subtle "auto-updating" cue instead of reading as a user measurement.
     private(set) var autoMeasuring = false
@@ -75,6 +91,13 @@ final class RingSession: NSObject {
     private var monitorTask: Task<Void, Never>?
     private var keepaliveTask: Task<Void, Never>?
     private var autoMeasureTask: Task<Void, Never>?
+    /// Fires once after the notify subscription is confirmed: if no DATA frame has arrived within
+    /// `firstFrameTimeout`, flips `notStreaming` (ring not activated/bonded). #54.
+    private var streamWatchdogTask: Task<Void, Never>?
+    /// Seconds after a confirmed subscription to wait for the ring's first DATA frame. The keepalive
+    /// starts writing status/fetch immediately on `ready`, so an activated ring answers well within
+    /// this; only an un-activated ring stays silent past it.
+    private static let firstFrameTimeout: TimeInterval = 10
 
     /// Cached nightly sleep window — skin-temp capture is gated to this span (see the
     /// descriptor handler). Daytime readings are too noisy/unpredictable (activity,
@@ -145,6 +168,7 @@ final class RingSession: NSObject {
         monitorTask?.cancel(); monitorTask = nil
         keepaliveTask?.cancel(); keepaliveTask = nil
         autoMeasureTask?.cancel(); autoMeasureTask = nil
+        streamWatchdogTask?.cancel(); streamWatchdogTask = nil
         syncTask?.cancel(); syncTask = nil
         monitoring = false
         livePreparing = false
@@ -263,6 +287,22 @@ final class RingSession: NSObject {
 
     func setLocalStore(_ localStore: LocalStore) {
         self.localStore = localStore
+    }
+
+    /// After the notify subscription is confirmed, wait `firstFrameTimeout` for the ring's first
+    /// DATA frame. If none arrives (only the cold `0x81` status replies), the ring is almost
+    /// certainly not activated/bonded — surface `notStreaming` so the UI can say "open the official
+    /// app once to activate" instead of letting Measure/Sync silently time out (#54).
+    private func startStreamWatchdog() {
+        streamWatchdogTask?.cancel()
+        streamWatchdogTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Self.firstFrameTimeout))
+            guard let self, !Task.isCancelled else { return }
+            if self.notifySubscribed, !self.gotDataFrame {
+                self.notStreaming = true
+                ringLog.notice("activation: subscribed but no data frame in \(Self.firstFrameTimeout, privacy: .public)s — ring likely not activated/bonded (#54)")
+            }
+        }
     }
 
     /// Idle keepalive — what makes OpenRingConn a *primary* tracker rather than an
@@ -696,6 +736,14 @@ extension RingSession: CBPeripheralDelegate {
         Task { @MainActor in
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
             self.lastFrameAt = Date()   // freshness anchor for staleness + last-reading timestamp (#36)
+            // A DATA frame (anything but the cold `0x81` status reply, which even an un-activated ring
+            // answers) proves the ring's data path is live: clear `notStreaming` + satisfy the
+            // activation watchdog (#54). Guarded so `@Observable` doesn't republish on every frame.
+            if let op = bytes.first, op != 0x81 {
+                if !self.gotDataFrame { self.gotDataFrame = true }
+                if self.notStreaming { self.notStreaming = false }
+                self.streamWatchdogTask?.cancel(); self.streamWatchdogTask = nil
+            }
             // Frames arriving while the link isn't `ready` mean discovery didn't land on this
             // (restored) reconnect — re-run it so we can ack and the buttons enable. #reconnect
             if !self.ready { self.rediscoverIfNeeded() }
@@ -795,6 +843,14 @@ extension RingSession: CBPeripheralDelegate {
                 ringLog.notice("← 0x50 END-OF-HISTORY (records=\(self.bulkRecords.count)) raw=\(self.lastFrame ?? "", privacy: .public)")
                 self.handleEndOfHistory(data)   // finalize epoch session, gated persist (#24)
                 return
+            case 0x11:
+                // Ring heartbeat (unsolicited keepalive, ~2.5 min idle). The official app answers
+                // every `0x11` with a constant `91 00 00`; mirror that so an activated ring has no
+                // reason to throttle our stream (#54 / §5.8). Don't echo the counter/token.
+                self.lastHeartbeatAt = Date()
+                ringLog.debug("← 0x11 heartbeat, ack 91 00 00")
+                self.write(Command.heartbeatAck)
+                return
             default: break
             }
             guard let frame = Frame.parse(bytes) else { return }   // XOR-validate responses
@@ -828,6 +884,28 @@ extension RingSession: CBPeripheralDelegate {
                                 error: Error?) {
         if let error {
             ringLog.error("write FAILED: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Notify-subscription result (#54). `ready` only means the characteristic was DISCOVERED; this
+    /// is the first point we know whether notifications will actually flow. On failure (e.g. the
+    /// data char needs an encrypted/bonded link the ring won't grant when un-activated) we surface
+    /// `notStreaming` immediately instead of writing commands into the void; on success we arm the
+    /// first-DATA-frame watchdog.
+    nonisolated func peripheral(_ peripheral: CBPeripheral,
+                                didUpdateNotificationStateFor characteristic: CBCharacteristic,
+                                error: Error?) {
+        Task { @MainActor in
+            guard characteristic.uuid == self.notifyUUID else { return }
+            if let error {
+                ringLog.error("notify subscribe FAILED: \(error.localizedDescription, privacy: .public)")
+                self.notifySubscribed = false
+                self.notStreaming = true
+                return
+            }
+            self.notifySubscribed = characteristic.isNotifying
+            ringLog.notice("notify subscribed=\(characteristic.isNotifying)")
+            if characteristic.isNotifying { self.startStreamWatchdog() }
         }
     }
 

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -60,6 +60,8 @@ final class RingSession: NSObject {
     private(set) var syncStatus: String?
 
     private var bulkRecords: [BulkRecord] = []
+    private var lastRawSteps: Int?       // last raw descriptor [4:6] counter (for delta accumulation)
+    private var dailyStepsTotal = 0      // accumulated daily step total (mirrors StoredDaily)
     private var syncTask: Task<Void, Never>?
     private var syncDone = false        // 0x50 end-of-history seen
     private var syncQuietTicks = 0      // seconds since the last page arrived
@@ -180,7 +182,7 @@ final class RingSession: NSObject {
             let end = stagedSegments.map(\.end).max() ?? start
             try? localStore.saveSleepSummary(summary, night: start, inBedStart: start, inBedEnd: end)
         }
-        if let steps { try? localStore.saveDailySteps(steps) }
+        // Steps are accumulated live in didUpdateValue (addDailySteps) — nothing to do here.
     }
 
     /// Start (or switch) live monitoring in a single mode. Guarantees only one metric
@@ -230,8 +232,6 @@ final class RingSession: NSObject {
         if let hr = liveHR { last.append(QuantitySample(kind: .heartRate, start: now, value: Double(hr))) }
         if let spo2 = liveSpO2 { last.append(QuantitySample(kind: .spo2, start: now, value: Double(spo2) / 100)) }
         persist(last)
-        // Steps stream live over 0x10/0x87 — persist the latest so it survives disconnect.
-        if let steps { try? localStore?.saveDailySteps(steps) }
     }
 
     /// Pull stored history: open the sync session (cursor = everything) and fetch.
@@ -325,18 +325,25 @@ extension RingSession: CBPeripheralDelegate {
         let bytes = [UInt8](data)
         Task { @MainActor in
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
-            // Ring step count rides the 0x10/0x87 descriptor [4:6] (§5.4). Frames with 0
-            // are interleaved noise, so take the running max (today's cumulative count).
-            // Surface the count once ANY steps descriptor has arrived — `steps` stays nil
-            // = "no data yet" and becomes 0 (not nil) the moment the ring reports while
-            // connected, so the dashboard shows "0" instead of "—" (the running max keeps
-            // a real count from being clobbered back to 0 by interleaved 0-frames).
-            if let s = DeviceStatus.steps(bytes) {
-                self.steps = max(self.steps ?? 0, s)
-                // Persist the live count so "Steps (today)" survives disconnect (StoredDaily
-                // upsert keeps the per-day max; no-ops on 0). VitalsTableView.effectiveSteps
-                // falls back to today's StoredDaily when not connected.
-                if let steps = self.steps { try? self.localStore?.saveDailySteps(steps) }
+            // The ring's onboard step counter (descriptor [4:6], §5.4) is a since-handoff DELTA that
+            // resets (the official app sums it in local memory). So accumulate observed deltas
+            // into a persistent daily total, reset-aware, rather than showing the raw counter
+            // (which reset to 0). NOTE: we only count steps while THIS app is connected, so the
+            // total lags the always-connected official app — but it never resets to 0.
+            if let v = DeviceStatus.steps(bytes) {
+                if lastRawSteps == nil {
+                    // First reading this session — recover today's accumulated total from the
+                    // store and use this counter as the baseline (don't retro-count unseen steps).
+                    dailyStepsTotal = (try? localStore?.todaySteps()) ?? 0
+                } else if let last = lastRawSteps {
+                    let delta = v >= last ? v - last : v   // v < last => ring reset; v is the new count
+                    if delta > 0 {
+                        dailyStepsTotal += delta
+                        try? localStore?.addDailySteps(delta)
+                    }
+                }
+                lastRawSteps = v
+                self.steps = dailyStepsTotal
             }
             // Skin temperature rides the same 0x10/0x87 descriptor (§5.4). It streams live
             // (~30–60 s) and is NOT in the sleep sync, so capture + persist it here.

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -58,8 +58,9 @@ final class RingSession: NSObject {
     func startLiveMonitoring() {
         guard monitorTask == nil else { return }
         monitoring = true
-        let openNow = Command.syncSince(unixSeconds: Int(Date().timeIntervalSince1970))
-        let enterSeq: [[UInt8]] = [Command.status0, Command.status1, openNow,
+        // Use the proven-accepted cursor (0xFFFFFFFF). The "open at now" variant may be
+        // rejected by the ring. If even this gets no 0x82, it's the bond/auth wall.
+        let enterSeq: [[UInt8]] = [Command.status0, Command.status1, Command.syncAll,
                                    Command.statusQuery, Command.liveHRMode, Command.fetch]
         monitorTask = Task { [weak self] in
             for cmd in enterSeq {

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -39,6 +39,11 @@ final class RingSession: NSObject {
     private(set) var liveTemperature: Double?   // skin temp °C (0x10/0x87 [6:8]/[8:10], §5.4)
     private(set) var batteryPercent: Int?       // ring battery % (0x10/0x87 [1], §5.4 🟢)
     private(set) var liveMode: LiveMode = .hr
+    /// Wall-clock time of the most recent frame actually received from the ring (#36). Lets the
+    /// UI detect a silently-dropped link (values stop updating before CoreBluetooth fires
+    /// `didDisconnect`) and stamps the persisted last live reading with when it was REALLY
+    /// measured — not `Date()`, which would push a minutes-old reading into HealthKit "now".
+    private(set) var lastFrameAt: Date?
     private(set) var monitoring = false
     /// True during the open→drain phase before the live stream starts. The ring won't
     /// emit live frames until its history backlog is fully drained, so we surface this
@@ -51,6 +56,21 @@ final class RingSession: NSObject {
     /// True while the periodic auto-measure (not a user tap) is driving a live read, so the
     /// UI can show a subtle "auto-updating" cue instead of reading as a user measurement.
     private(set) var autoMeasuring = false
+
+    /// True when frames have stopped for long enough that the live readings (HR/SpO₂/battery/
+    /// steps/temp) should read as STALE rather than current (#36). A silently-dropped link keeps
+    /// its last values until CoreBluetooth eventually fires `didDisconnect`; this lets the UI
+    /// show "Xm ago" instead of a minutes-old value masquerading as live. Thresholds are mode-
+    /// aware: while monitoring, frames stream ~every 2 s, so a 30 s gap means the stream stalled;
+    /// while idle the only frames are the slow keepalive descriptor (up to ~5 min apart in
+    /// battery saver), so allow a much longer gap before crying stale.
+    var liveReadingsStale: Bool {
+        guard let at = lastFrameAt else { return false }   // no frame yet — nothing to call stale
+        let gap = Date().timeIntervalSince(at)
+        return gap > (monitoring ? Self.liveStaleAfter : Self.idleStaleAfter)
+    }
+    private static let liveStaleAfter: TimeInterval = 30
+    private static let idleStaleAfter: TimeInterval = 360
 
     private var monitorTask: Task<Void, Never>?
     private var keepaliveTask: Task<Void, Never>?
@@ -95,6 +115,7 @@ final class RingSession: NSObject {
     private var syncSession = EpochSyncSession()
     private let epochDecodingEnabled = false
 
+    private let dataServiceUUID = CBUUID(string: OpenRingKit.Transport.dataServiceUUID)
     private let notifyUUID = CBUUID(string: OpenRingKit.Transport.notifyCharUUID)
     private let writeUUID = CBUUID(string: OpenRingKit.Transport.writeCharUUID)
 
@@ -103,7 +124,37 @@ final class RingSession: NSObject {
         self.localStore = localStore
         super.init()
         peripheral.delegate = self
-        peripheral.discoverServices(nil)
+        // Re-discovery guard (#42): on a restored / already-connected peripheral the data service
+        // is usually already discovered, so re-scanning ALL services on every relaunch is wasted
+        // work. If the data service is already present, go straight to (re-)matching its
+        // characteristics — that still re-fires `didDiscoverCharacteristicsFor`, so `ready` lands.
+        // Only fall back to a full `discoverServices` when we've never seen the service.
+        if let dataService = peripheral.services?.first(where: { $0.uuid == dataServiceUUID }) {
+            peripheral.discoverCharacteristics(nil, for: dataService)
+        } else {
+            peripheral.discoverServices(nil)
+        }
+    }
+
+    /// Hard teardown (#42): cancel EVERY task this session owns so a session that's being
+    /// replaced (a second `didConnect`/`willRestoreState`) or torn down on disconnect can't keep
+    /// writing to the SHARED peripheral behind a newer session — which would race the delegate
+    /// routing and leak the keepalive/auto-measure/sync loops. Callers persist the last live
+    /// reading via `stopLiveMonitoring()` BEFORE this where that matters; `invalidate()` itself is
+    /// a pure cancel + detach. Idempotent.
+    func invalidate() {
+        monitorTask?.cancel(); monitorTask = nil
+        keepaliveTask?.cancel(); keepaliveTask = nil
+        autoMeasureTask?.cancel(); autoMeasureTask = nil
+        syncTask?.cancel(); syncTask = nil
+        monitoring = false
+        livePreparing = false
+        syncing = false
+        autoMeasuring = false
+        // Stop CoreBluetooth callbacks routing to a torn-down session. Only clear the delegate if
+        // it's still us — a newer session for the same peripheral reassigns it in its own `init`,
+        // and we must not clobber that.
+        if peripheral.delegate === self { peripheral.delegate = nil }
     }
 
     /// Begin live monitoring. The proven enter sequence (PROTOCOL.md §5.1 / livehr.py) is
@@ -473,11 +524,14 @@ final class RingSession: NSObject {
             persistSleepAndSteps()
             bulkFinalized = true
         }
-        // Persist the last live reading so the dashboard shows it after disconnect.
-        let now = Date()
+        // Persist the last live reading so the dashboard shows it after disconnect. Stamp it with
+        // WHEN the ring last actually sent a frame, not `Date()` (#36): on a silently-dropped link
+        // the last value can be minutes old, and stamping "now" would push a wrong timestamp into
+        // HealthKit. Fall back to now only if we somehow never recorded a frame.
+        let stamp = lastFrameAt ?? Date()
         var last: [QuantitySample] = []
-        if let hr = liveHR { last.append(QuantitySample(kind: .heartRate, start: now, value: Double(hr))) }
-        if let spo2 = liveSpO2 { last.append(QuantitySample(kind: .spo2, start: now, value: Double(spo2) / 100)) }
+        if let hr = liveHR { last.append(QuantitySample(kind: .heartRate, start: stamp, value: Double(hr))) }
+        if let spo2 = liveSpO2 { last.append(QuantitySample(kind: .spo2, start: stamp, value: Double(spo2) / 100)) }
         persist(last)
     }
 
@@ -607,6 +661,7 @@ extension RingSession: CBPeripheralDelegate {
         let bytes = [UInt8](data)
         Task { @MainActor in
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
+            self.lastFrameAt = Date()   // freshness anchor for staleness + last-reading timestamp (#36)
             // Frames arriving while the link isn't `ready` mean discovery didn't land on this
             // (restored) reconnect — re-run it so we can ack and the buttons enable. #reconnect
             if !self.ready { self.rediscoverIfNeeded() }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -15,8 +15,11 @@ import OpenRingKit
 @MainActor
 final class RingSession: NSObject {
 
+    enum LiveMode { case hr, spo2 }
+
     private(set) var liveHR: Int?
     private(set) var liveSpO2: Int?       // 🟡 from long 0x15 frame byte[14]
+    private(set) var liveMode: LiveMode = .hr
     private(set) var monitoring = false
     private(set) var lastFrame: String?
     private(set) var ready = false
@@ -58,10 +61,10 @@ final class RingSession: NSObject {
     func startLiveMonitoring() {
         guard monitorTask == nil else { return }
         monitoring = true
-        // Use the proven-accepted cursor (0xFFFFFFFF). The "open at now" variant may be
-        // rejected by the ring. If even this gets no 0x82, it's the bond/auth wall.
+        let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
+        // Proven-accepted cursor (0xFFFFFFFF), then enter the selected live mode.
         let enterSeq: [[UInt8]] = [Command.status0, Command.status1, Command.syncAll,
-                                   Command.statusQuery, Command.liveHRMode, Command.fetch]
+                                   Command.statusQuery, modeCmd, Command.fetch]
         monitorTask = Task { [weak self] in
             for cmd in enterSeq {
                 guard let self else { return }
@@ -73,6 +76,22 @@ final class RingSession: NSObject {
                 self.write(Command.poll)
                 try? await Task.sleep(for: .seconds(1))
             }
+        }
+    }
+
+    /// Switch live measurement between HR (`06 01 00`) and SpO2 (`06 02 00`). The ring
+    /// measures one at a time; the other metric keeps its last value. No-op until the
+    /// next start if not currently monitoring.
+    func setLiveMode(_ mode: LiveMode) {
+        guard liveMode != mode else { return }
+        liveMode = mode
+        guard monitoring else { return }
+        let modeCmd = mode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
+        Task { [weak self] in
+            guard let self else { return }
+            self.write(modeCmd)
+            try? await Task.sleep(for: .milliseconds(250))
+            self.write(Command.fetch)
         }
     }
 

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -22,6 +22,8 @@ final class RingSession: NSObject {
     /// Sleep-vitals samples (HR/HRV/SpO2) decoded from the last history sync,
     /// finalized when the ring reports end-of-history (0x50). Feed to HealthKitWriter.
     private(set) var historySamples: [QuantitySample] = []
+    /// Sleep-stage segments computed from the motion channel for the last sync.
+    private(set) var sleepSegments: [SleepSegment] = []
     /// True while 0x4c pages are still arriving for the current sync.
     private(set) var syncing = false
 
@@ -58,6 +60,7 @@ final class RingSession: NSObject {
     func syncHistory() {
         bulkRecords.removeAll()
         historySamples.removeAll()
+        sleepSegments.removeAll()
         syncing = true
         for cmd in [Command.status0, Command.status1, Command.syncAll, Command.fetch] {
             write(cmd)
@@ -113,6 +116,7 @@ extension RingSession: CBPeripheralDelegate {
                 // never reaches Frame.parse. Finalize the sync here.
                 if self.syncing {
                     self.historySamples = BulkSleep.samples(from: self.bulkRecords)
+                    self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords)
                     self.syncing = false
                 }
                 return

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -48,9 +48,13 @@ final class RingSession: NSObject {
     private(set) var decodedEpochRecords = 0
     private(set) var storedMetricSamples = 0
     private(set) var ready = false
+    /// True while the periodic auto-measure (not a user tap) is driving a live read, so the
+    /// UI can show a subtle "auto-updating" cue instead of reading as a user measurement.
+    private(set) var autoMeasuring = false
 
     private var monitorTask: Task<Void, Never>?
     private var keepaliveTask: Task<Void, Never>?
+    private var autoMeasureTask: Task<Void, Never>?
 
     /// Sleep-vitals samples (HR/HRV/SpO2) decoded from the last history sync,
     /// finalized when the ring reports end-of-history (0x50). Feed to HealthKitWriter.
@@ -78,6 +82,8 @@ final class RingSession: NSObject {
     private let peripheral: CBPeripheral
     private var notifyChar: CBCharacteristic?
     private var writeChar: CBCharacteristic?
+    /// Throttle for the half-open-link recovery (`rediscoverIfNeeded`).
+    private var lastDiscoveryKick: Date?
     private var localStore: LocalStore?
     private var syncSession = EpochSyncSession()
     private let epochDecodingEnabled = false
@@ -194,6 +200,77 @@ final class RingSession: NSObject {
                 try? await Task.sleep(for: .seconds(30))
             }
         }
+    }
+
+    /// UserDefaults key for the periodic auto-measure toggle (default ON — the user opted in).
+    static let autoMeasureEnabledKey = "autoMeasure.enabled"
+    /// How often to auto-measure HR while connected+idle. SpO₂ runs every 3rd cycle (~3×).
+    private static let autoMeasureInterval: TimeInterval = 600   // 10 min
+    /// Delay before the FIRST auto-measure after connecting — short, so opening the app
+    /// refreshes HR within ~a minute rather than waiting a full interval.
+    private static let autoMeasureFirstDelay: TimeInterval = 45
+    private static var autoMeasureEnabled: Bool {
+        // Default true when unset (the user chose "periodic"); a stored false disables it.
+        UserDefaults.standard.object(forKey: autoMeasureEnabledKey) as? Bool ?? true
+    }
+
+    /// Periodic auto-measure — what makes HR/SpO₂ refresh on their own, like the official app
+    /// (the ring measures them ONLY on demand; the idle keepalive carries just temp/steps/
+    /// battery). While connected and idle it briefly enters HR live mode, waits for a converged
+    /// reading, persists it (which the app then mirrors to Health), and returns to idle; SpO₂
+    /// every 3rd cycle. Skips entirely while the user is measuring or a sync is running, and
+    /// respects the `autoMeasure.enabled` toggle. Battery cost is real — hence the toggle.
+    func startAutoMeasure() {
+        guard autoMeasureTask == nil else { return }
+        autoMeasureTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Self.autoMeasureFirstDelay))
+            while !Task.isCancelled {
+                guard let self else { return }
+                if Self.autoMeasureEnabled, self.idleForAutoMeasure {
+                    // Refresh BOTH every cycle — HR locks in seconds when still; SpO₂ rides
+                    // the same live path. (Was SpO₂ every 3rd cycle, but relaunches reset that
+                    // counter so it rarely fired.) Each is bounded, so a moving hand just times
+                    // out that read rather than blocking the loop.
+                    await self.autoMeasureOnce(mode: .hr, timeout: 90)   // HR can need ~60s of stillness
+                    if self.idleForAutoMeasure {
+                        await self.autoMeasureOnce(mode: .spo2, timeout: 45)
+                    }
+                    try? await Task.sleep(for: .seconds(Self.autoMeasureInterval))
+                } else {
+                    // Disabled, or busy with a user measure / sync — re-check soon rather than
+                    // deferring a full interval (a one-off open-sync shouldn't push the first
+                    // HR out by 10 min).
+                    try? await Task.sleep(for: .seconds(30))
+                }
+            }
+        }
+    }
+
+    /// True only when the link is up and nothing else is using it — never interrupt a user
+    /// measurement, a sync, or the live-enter drain.
+    private var idleForAutoMeasure: Bool {
+        ready && !monitoring && !livePreparing && syncTask == nil
+    }
+
+    /// One bounded auto-measurement: enter `mode`'s live read, wait for a converged value (or
+    /// time out), then stop — which persists the reading and lets ContentView mirror it to
+    /// Health. If the user takes over mid-read (monitoring an unexpected mode), we leave their
+    /// session alone rather than cancelling it.
+    private func autoMeasureOnce(mode: LiveMode, timeout: TimeInterval) async {
+        guard idleForAutoMeasure else { return }
+        autoMeasuring = true
+        startMonitoring(mode: mode)             // sets monitoring=true; drains, enters, polls
+        let deadline = Date().addingTimeInterval(timeout)
+        while !Task.isCancelled && Date() < deadline {
+            if mode == .hr, liveHR != nil { break }
+            if mode == .spo2, liveSpO2 != nil { break }
+            // Bail if a user tap switched the mode out from under us — don't fight them.
+            if !monitoring || liveMode != mode { autoMeasuring = false; return }
+            try? await Task.sleep(for: .seconds(1))
+        }
+        // Only tear down if WE still own the live read (user didn't take over).
+        if autoMeasuring, monitoring, liveMode == mode { stopLiveMonitoring() }
+        autoMeasuring = false
     }
 
     /// Persist decoded samples to the local store (the vitals dashboard reads from it, so
@@ -340,6 +417,22 @@ final class RingSession: NSObject {
         ringLog.debug("→ write \(bytes.map { String(format: "%02x", $0) }.joined(separator: " "), privacy: .public)")
         peripheral.writeValue(Data(bytes), for: writeChar, type: .withResponse)
     }
+
+    /// Recover a half-open link. On a restored / already-connected reconnect, the persisted
+    /// notify subscription can deliver frames before THIS session has matched the notify/write
+    /// characteristics — discovery from `init` fires before the central is fully ready and
+    /// silently no-ops, so `ready` is stuck false and page-acks get dropped (the ring then
+    /// stalls waiting for an ack). Re-running discovery once data is actually flowing relands
+    /// the characteristics → `ready` flips true → keepalive/sync resume. Throttled so a burst
+    /// of frames doesn't spam discovery. Safe no-op once ready. (Ground-truthed from a device
+    /// log: "write DROPPED (no writeChar yet)" with no preceding `ready=`.)
+    func rediscoverIfNeeded() {
+        guard !ready else { return }
+        if let last = lastDiscoveryKick, Date().timeIntervalSince(last) < 2 { return }
+        lastDiscoveryKick = Date()
+        ringLog.notice("rediscover: link up but not ready (notify=\(self.notifyChar != nil), write=\(self.writeChar != nil)) — re-running discovery")
+        peripheral.discoverServices(nil)
+    }
 }
 
 extension RingSession: CBPeripheralDelegate {
@@ -363,7 +456,10 @@ extension RingSession: CBPeripheralDelegate {
             }
             self.ready = (self.notifyChar != nil && self.writeChar != nil)
             ringLog.notice("ready=\(self.ready) (notify=\(self.notifyChar != nil), write=\(self.writeChar != nil))")
-            if self.ready { self.startKeepalive() }   // begin continuous descriptor polling (primary tracker)
+            if self.ready {
+                self.startKeepalive()      // continuous descriptor polling (temp/steps/battery)
+                self.startAutoMeasure()    // periodic HR/SpO₂ reads so those refresh on their own
+            }
         }
     }
 
@@ -374,6 +470,9 @@ extension RingSession: CBPeripheralDelegate {
         let bytes = [UInt8](data)
         Task { @MainActor in
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
+            // Frames arriving while the link isn't `ready` mean discovery didn't land on this
+            // (restored) reconnect — re-run it so we can ack and the buttons enable. #reconnect
+            if !self.ready { self.rediscoverIfNeeded() }
             // The ring's onboard step counter (descriptor [4:6], §5.4) is a since-handoff DELTA that
             // resets (the official app sums it in local memory). So accumulate observed deltas
             // into a persistent daily total, reset-aware, rather than showing the raw counter
@@ -442,10 +541,17 @@ extension RingSession: CBPeripheralDelegate {
                     self.liveHRWarmup = nil
                     self.liveHRTrend.append(hr)
                     if self.liveHRTrend.count > 12 { self.liveHRTrend.removeFirst() }
+                    ringLog.notice("live HR LOCKED: \(hr) bpm")
                 } else if let raw = LiveHR.decode(bytes) {                       // short frame, still warming up
                     self.liveHRWarmup = raw
+                    ringLog.notice("live HR warmup: byte2=\(raw) (frame \(self.lastFrame ?? "", privacy: .public))")
+                } else if bytes.first == 0x15 {
+                    ringLog.notice("live 0x15 frame (no HR): \(self.lastFrame ?? "", privacy: .public)")
                 }
-                if let spo2 = LiveHR.decodeSpO2(bytes) { self.liveSpO2 = spo2 }  // long frame, 🟡
+                if let spo2 = LiveHR.decodeSpO2(bytes) {                         // long frame, 🟡
+                    self.liveSpO2 = spo2
+                    ringLog.notice("live SpO2: \(spo2)%")
+                }
             }
         }
     }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -127,12 +127,18 @@ final class RingSession: NSObject {
                 try? await Task.sleep(for: .milliseconds(250))
             }
             self?.livePreparing = false
-            // 4. Poll for live samples (~1.4/s). No `d0` here — it re-arms the mode
-            //    switch and kicks HR back to its warm-up sentinel.
+            // 4. Poll for live samples at the ring's OWN cadence (~2 s/sample, confirmed
+            //    in btsnoop_hr.log). The HR windowed average needs undisturbed time to
+            //    settle out of the warm-up sentinel (8); polling faster than the sample
+            //    rate keeps resetting it so byte[2] never climbs. The official app waits
+            //    then polls ~every 2 s, request/response. (SpO2's byte[14] survives fast
+            //    polling, which is why only HR got stuck.) No `d0` here — it re-arms the
+            //    mode switch and also kicks HR back to warm-up.
+            try? await Task.sleep(for: .seconds(2))   // let the ring settle before first poll
             while !Task.isCancelled {
                 guard let self else { return }
                 self.write(Command.poll)
-                try? await Task.sleep(for: .milliseconds(700))
+                try? await Task.sleep(for: .seconds(2))
             }
         }
     }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -51,13 +51,22 @@ final class RingSession: NSObject {
         peripheral.discoverServices(nil)
     }
 
-    /// Begin live monitoring: enter live-HR mode, then poll once a second so the ring
-    /// keeps emitting 0x15 samples. Updates `liveHR`/`liveSpO2`. Idempotent.
+    /// Begin live monitoring: open the session at *now* (so there's no history backlog
+    /// to drain and flood the link), enter HR mode (`d0` → `06 01 00` → fetch), then poll
+    /// `95 00 00` ~1/s. Writes are paced ~300 ms apart so CoreBluetooth doesn't drop them.
+    /// Updates `liveHR`/`liveSpO2`. Idempotent.
     func startLiveMonitoring() {
         guard monitorTask == nil else { return }
         monitoring = true
-        for cmd in Command.liveHRStart { write(cmd) }   // status → sync → live mode → fetch
+        let openNow = Command.syncSince(unixSeconds: Int(Date().timeIntervalSince1970))
+        let enterSeq: [[UInt8]] = [Command.status0, Command.status1, openNow,
+                                   Command.statusQuery, Command.liveHRMode, Command.fetch]
         monitorTask = Task { [weak self] in
+            for cmd in enterSeq {
+                guard let self else { return }
+                self.write(cmd)
+                try? await Task.sleep(for: .milliseconds(300))
+            }
             while !Task.isCancelled {
                 guard let self else { return }
                 self.write(Command.poll)
@@ -149,12 +158,8 @@ extension RingSession: CBPeripheralDelegate {
             //   long  `15 01 … <spo2> …`  → byte[2]=0; SpO2 at byte[14] (🟡)
             // Only the short frame carries HR — don't let a long frame zero it out.
             if frame.opcode == Frame.responseID(Opcode.poll) {
-                if bytes.count >= 4, bytes[1] == 0x00 {
-                    if let hr = LiveHR.decodeLocked(bytes) { self.liveHR = hr }  // filters warm-up
-                } else if bytes.count >= 15, bytes[1] == 0x01 {
-                    let spo2 = Int(bytes[14])
-                    if (70...100).contains(spo2) { self.liveSpO2 = spo2 }
-                }
+                if let hr = LiveHR.decodeLocked(bytes) { self.liveHR = hr }      // short frame, warm-up filtered
+                if let spo2 = LiveHR.decodeSpO2(bytes) { self.liveSpO2 = spo2 }  // long frame, 🟡
             }
         }
     }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -35,10 +35,15 @@ final class RingSession: NSObject {
     /// Experimental Light/Deep/REM/Awake staging (HR+motion heuristic, approximate —
     /// matches stage totals but not architecture; for display, not HealthKit).
     private(set) var stagedSegments: [SleepSegment] = []
-    /// True while 0x4c pages are still arriving for the current sync.
+    /// True while a history sync is in progress.
     private(set) var syncing = false
+    /// User-facing result of the last sync (e.g. "204 epochs"), or an error note.
+    private(set) var syncStatus: String?
 
     private var bulkRecords: [BulkRecord] = []
+    private var syncTask: Task<Void, Never>?
+    private var syncDone = false        // 0x50 end-of-history seen
+    private var syncQuietTicks = 0      // seconds since the last page arrived
 
     private let peripheral: CBPeripheral
     private var notifyChar: CBCharacteristic?
@@ -118,14 +123,45 @@ final class RingSession: NSObject {
     /// The ring streams 0x4c/0x47 pages, drained+decoded in didUpdateValue; results
     /// land in `historySamples` once 0x50 (end-of-history) arrives.
     func syncHistory() {
+        guard syncTask == nil else { return }   // already syncing
+        stopLiveMonitoring()                     // live polling would fight the drain
         bulkRecords.removeAll()
         historySamples.removeAll()
         sleepSegments.removeAll()
         stagedSegments.removeAll()
+        syncDone = false
+        syncQuietTicks = 0
         syncing = true
-        for cmd in [Command.status0, Command.status1, Command.syncAll, Command.fetch] {
-            write(cmd)
+        syncStatus = nil
+        syncTask = Task { [weak self] in
+            // Paced enter so CoreBluetooth doesn't drop writes.
+            for cmd in [Command.status0, Command.status1, Command.syncAll, Command.fetch] {
+                guard let self else { return }
+                self.write(cmd)
+                try? await Task.sleep(for: .milliseconds(300))
+            }
+            // Watchdog: finalize on 0x50, or when pages stop (4 s quiet), or a 45 s cap —
+            // so the sync can never hang if the end-marker or a write is lost.
+            for tick in 0 ..< 45 {
+                try? await Task.sleep(for: .seconds(1))
+                guard let self else { return }
+                if self.syncDone || self.syncQuietTicks >= 4 { break }
+                _ = tick
+            }
+            self?.finalizeSync()
         }
+    }
+
+    private func finalizeSync() {
+        guard syncing else { return }
+        historySamples = BulkSleep.samples(from: bulkRecords)
+        sleepSegments = BulkSleep.sleepSegments(from: bulkRecords)
+        stagedSegments = BulkSleep.stagedSegments(from: bulkRecords)
+        syncing = false
+        syncTask = nil
+        syncStatus = bulkRecords.isEmpty
+            ? "No data received — is the ring bonded/awake?"
+            : "Synced \(bulkRecords.count) epochs"
     }
 
     private func write(_ bytes: [UInt8]) {
@@ -168,19 +204,18 @@ extension RingSession: CBPeripheralDelegate {
             // Bulk history pages: accumulate + ack to continue draining (47→c7, 4c→cc).
             switch bytes.first {
             case 0x47:
+                if self.syncing { self.syncQuietTicks = 0 }
                 self.write(Command.pageAck47); return   // PPG page — decode TODO (issue #8)
             case 0x4C:
-                if self.syncing { self.bulkRecords += BulkSleep.records(fromPage: bytes) }
+                if self.syncing {
+                    self.bulkRecords += BulkSleep.records(fromPage: bytes)
+                    self.syncQuietTicks = 0
+                }
                 self.write(Command.pageAck4C); return   // always ack to keep draining
             case 0x50:
-                // End-of-history cursor report (§5.5) — note: NO XOR trailer, so it
-                // never reaches Frame.parse. Finalize the sync here.
-                if self.syncing {
-                    self.historySamples = BulkSleep.samples(from: self.bulkRecords)
-                    self.sleepSegments = BulkSleep.sleepSegments(from: self.bulkRecords)
-                    self.stagedSegments = BulkSleep.stagedSegments(from: self.bulkRecords)
-                    self.syncing = false
-                }
+                // End-of-history cursor report (§5.5) — NO XOR trailer, so it never
+                // reaches Frame.parse. Mark done; the sync watchdog finalizes.
+                if self.syncing { self.syncDone = true }
                 return
             default: break
             }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -31,6 +31,7 @@ final class RingSession: NSObject {
     private(set) var liveHRWarmup: Int?
     private(set) var steps: Int?          // ring onboard step count (0x10/0x87 [4:6], §5.4)
     private(set) var liveTemperature: Double?   // skin temp °C (0x10/0x87 [6:8]/[8:10], §5.4)
+    private(set) var batteryPercent: Int?       // ring battery % (0x10/0x87 [1], §5.4 🟢)
     private(set) var liveMode: LiveMode = .hr
     private(set) var monitoring = false
     /// True during the open→drain phase before the live stream starts. The ring won't
@@ -343,6 +344,8 @@ extension RingSession: CBPeripheralDelegate {
                 self.liveTemperature = t.celsius
                 self.persist([QuantitySample(kind: .temperature, start: Date(), value: t.celsius)])
             }
+            // Ring battery % is descriptor byte[1] (§5.4 🟢, ground-truthed).
+            if let b = DeviceStatus.battery(bytes) { self.batteryPercent = b }
             // Bulk history pages: accumulate + ack to continue draining (47→c7, 4c→cc).
             switch bytes.first {
             case 0x47:

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -56,6 +56,12 @@ final class RingSession: NSObject {
     private var keepaliveTask: Task<Void, Never>?
     private var autoMeasureTask: Task<Void, Never>?
 
+    /// Cached nightly sleep window — skin-temp capture is gated to this span (see the
+    /// descriptor handler). Daytime readings are too noisy/unpredictable (activity,
+    /// ambient swings, intermittent skin contact) to trend, so we only persist overnight.
+    private var nightWindow: DateInterval?
+    private var nightWindowRefreshedAt: Date?
+
     /// Sleep-vitals samples (HR/HRV/SpO2) decoded from the last history sync,
     /// finalized when the ring reports end-of-history (0x50). Feed to HealthKitWriter.
     private(set) var historySamples: [QuantitySample] = []
@@ -186,6 +192,9 @@ final class RingSession: NSObject {
     func startKeepalive() {
         guard keepaliveTask == nil else { return }
         keepaliveTask = Task { [weak self] in
+            // Resolve the night window up front so the first temp frame is gated correctly
+            // (otherwise the very first reading races the reactive refresh and could leak).
+            await self?.refreshNightWindowIfNeeded()
             // Prime a status session so the ring answers fetch with the descriptor.
             for cmd in [Command.status0, Command.status1] {
                 guard let self, !Task.isCancelled else { return }
@@ -271,6 +280,37 @@ final class RingSession: NSObject {
         // Only tear down if WE still own the live read (user didn't take over).
         if autoMeasuring, monitoring, liveMode == mode { stopLiveMonitoring() }
         autoMeasuring = false
+    }
+
+    /// Resolve and cache the nightly sleep window used to gate skin-temp capture. Re-resolves
+    /// at most every 30 min (the window only shifts day-to-day) unless `force` is set — the
+    /// capture site forces a re-resolve on a window miss so it can re-check before dropping a
+    /// sample (a stale/expired window at night-start or after midnight would otherwise silently
+    /// drop up to 30 min of onset data). Prefers the real schedule via `SleepSchedule.current`
+    /// (HealthKit, else manual).
+    func refreshNightWindowIfNeeded(force: Bool = false) async {
+        let stale = nightWindowRefreshedAt.map { Date().timeIntervalSince($0) > 30 * 60 } ?? true
+        guard stale || force else { return }
+        if let w = await SleepSchedule.current(forNightEndingNear: Date()) {
+            nightWindow = w
+        } else if let interval = SleepWindow.interval(
+            // No real schedule (default state: manual schedule disabled AND no HealthKit
+            // entitlement). Fall back to the registered DEFAULT bed/wake times even though the
+            // manual schedule is disabled — this yields a correct CROSS-MIDNIGHT window (e.g.
+            // last night 22:30 → today 06:30). A naive 00:00–06:00 calendar-day slice would
+            // drop all pre-midnight sleep onset (a 23:00→07:00 sleeper never matches), killing
+            // the feature for every default-config user.
+            bedMinutes: SleepScheduleDefaults.defaultBedMinutes,    // 1350 (22:30)
+            wakeMinutes: SleepScheduleDefaults.defaultWakeMinutes,  // 390 (06:30)
+            nightEndingNear: Date()
+        ) {
+            nightWindow = interval
+        } else {
+            // Pure fallback — should never happen with valid (non-degenerate) defaults.
+            let dayStart = Calendar.current.startOfDay(for: Date())
+            nightWindow = DateInterval(start: dayStart, end: dayStart.addingTimeInterval(6 * 3600))
+        }
+        nightWindowRefreshedAt = Date()
     }
 
     /// Persist decoded samples to the local store (the vitals dashboard reads from it, so
@@ -494,10 +534,28 @@ extension RingSession: CBPeripheralDelegate {
                 self.steps = dailyStepsTotal
             }
             // Skin temperature rides the same 0x10/0x87 descriptor (§5.4). It streams live
-            // (~30–60 s) and is NOT in the sleep sync, so capture + persist it here.
+            // (~30–60 s) and is NOT in the sleep sync, so capture + persist it here — but ONLY
+            // during the nightly sleep window. Daytime readings are too noisy/unpredictable
+            // (activity, ambient swings, intermittent skin contact) to be a usable trend, so we
+            // drop them and surface no live value outside the window.
             if let t = DeviceStatus.skinTemperature(bytes) {
-                self.liveTemperature = t.celsius
-                self.persist([QuantitySample(kind: .temperature, start: Date(), value: t.celsius)])
+                // Window-miss guard: if we're outside the cached window (or it's nil), the cache
+                // may simply be stale/expired (night just started, or midnight rolled the window
+                // forward). Force a synchronous re-resolve BEFORE deciding to drop — this whole
+                // block already runs inside the `Task { @MainActor in … }` above, so the await is
+                // safe. Otherwise (we're inside the window) refresh in the background without
+                // blocking the frame. Without the force path, up to 30 min of onset samples are
+                // silently dropped against a stale window.
+                if self.nightWindow?.contains(Date()) != true {
+                    await self.refreshNightWindowIfNeeded(force: true)
+                } else {
+                    Task { await self.refreshNightWindowIfNeeded() }   // background, don't block the frame
+                }
+                let inNightWindow = self.nightWindow?.contains(Date()) ?? false
+                self.liveTemperature = inNightWindow ? t.celsius : nil
+                if inNightWindow {
+                    self.persist([QuantitySample(kind: .temperature, start: Date(), value: t.celsius)])
+                }
             }
             // Ring battery % is descriptor byte[1] (§5.4 🟢, ground-truthed).
             if let b = DeviceStatus.battery(bytes) { self.batteryPercent = b }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -153,14 +153,25 @@ final class RingSession: NSObject {
             //    the longer cap so a big overnight backlog is fully captured.
             guard let s0 = self, !Task.isCancelled else { return }
             s0.write(Command.fetch)
-            let drainMaxTicks = quickLiveRead ? 6 : 30   // ×500 ms ⇒ ~3 s quick / ~15 s full backstop
+            // Drain backstop in 500 ms ticks. A quick read starts with a short ~3 s cap so a
+            // silent ring can't starve the HR poll (#45); the overnight path uses the full ~15 s.
+            // The shared quiet-exit (3 quiet ticks ≈ 1.5 s after the last page) ends a real drain.
+            // BUT a quick read must NOT cut off an in-flight backlog: entering live mode while
+            // 0x4c pages are still streaming (!drainDone, no quiet beat yet) leaves HR stuck at
+            // the warm-up sentinel (8). So if the short cap is reached mid-stream, promote it to
+            // the full cap and let the quiet-exit finish the drain — the short cap then only bites
+            // a genuinely silent ring (the common no-backlog case still exits at ~1.5 s, unchanged).
+            var cap = quickLiveRead ? 6 : 30   // ×500 ms ⇒ ~3 s quick / ~15 s full backstop
             var quiet = 0
-            for _ in 0 ..< drainMaxTicks {
+            var tick = 0
+            while tick < cap {
                 try? await Task.sleep(for: .milliseconds(500))
                 guard let self, !Task.isCancelled else { return }
                 if self.drainDone { break }
                 if self.drainSawPage { self.drainSawPage = false; quiet = 0 }
                 else { quiet += 1; if quiet >= 3 { break } }
+                tick += 1
+                if tick >= cap, quiet == 0, cap < 30 { cap = 30 }   // quick read still streaming a backlog → drain it fully (#45)
             }
             // Surface anything drained so overnight sleep/vitals aren't lost — the ring
             // discards delivered pages, so this is the only chance to keep them.

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -93,18 +93,13 @@ final class RingSession: NSObject {
                 self.write(cmd)
                 try? await Task.sleep(for: .milliseconds(300))
             }
-            var tick = 0
+            // Pure polling only. Do NOT inject `d0` (status query) here to refresh steps:
+            // d0 re-arms the mode switch and kicks the HR session back to its warm-up
+            // sentinel (byte[2]=8), so the reading never climbs. Steps refresh from the
+            // ring's spontaneous 0x10/0x87 frames instead.
             while !Task.isCancelled {
                 guard let self else { return }
                 self.write(Command.poll)
-                // Every ~8 s, re-pull the status descriptor (0x10/0x87) so the step
-                // count refreshes mid-session — otherwise steps only update if the ring
-                // happens to emit one spontaneously. Paced so the write isn't dropped.
-                if tick % 8 == 7 {
-                    try? await Task.sleep(for: .milliseconds(300))
-                    self.write(Command.statusQuery)
-                }
-                tick += 1
                 try? await Task.sleep(for: .seconds(1))
             }
         }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -5,11 +5,11 @@ import OpenRingKit
 
 // An active link to a connected ring: discovers the notify/write characteristics
 // by UUID, enables notifications, sends commands, and decodes responses through
-// OpenRingKit's confirmed codec. Only spec-supported behavior is implemented:
+// OpenRingKit's confirmed codec. Spec-supported behavior implemented:
 //   • live-HR poll (0x95 → 0x15, LiveHR.decode 🟡)
-// History/metric sync commands exist in the codec, but their RESPONSE record
-// formats are 🔴 (PROTOCOL.md §5) — decoding them is deliberately left as a
-// flagged TODO pending a capture, rather than invented here.
+//   • history sync: drain 0x4c activity/sleep pages → BulkSleep → HR/HRV/SpO2
+//     samples (PROTOCOL.md §5.3, 🟢 fields). 0x47 PPG pages are acked but not yet
+//     decoded (their payload is 🔴 — issue #8).
 
 @Observable
 @MainActor
@@ -18,6 +18,14 @@ final class RingSession: NSObject {
     private(set) var liveHR: Int?
     private(set) var lastFrame: String?
     private(set) var ready = false
+
+    /// Sleep-vitals samples (HR/HRV/SpO2) decoded from the last history sync,
+    /// finalized when the ring reports end-of-history (0x50). Feed to HealthKitWriter.
+    private(set) var historySamples: [QuantitySample] = []
+    /// True while 0x4c pages are still arriving for the current sync.
+    private(set) var syncing = false
+
+    private var bulkRecords: [BulkRecord] = []
 
     private let peripheral: CBPeripheral
     private var notifyChar: CBCharacteristic?
@@ -42,6 +50,18 @@ final class RingSession: NSObject {
     /// Poll for one live sample (0x95 → 0x15). Sent verbatim — NOT XOR-encoded.
     func pollLiveHR() {
         write(Command.poll)
+    }
+
+    /// Pull stored history: open the sync session (cursor = everything) and fetch.
+    /// The ring streams 0x4c/0x47 pages, drained+decoded in didUpdateValue; results
+    /// land in `historySamples` once 0x50 (end-of-history) arrives.
+    func syncHistory() {
+        bulkRecords.removeAll()
+        historySamples.removeAll()
+        syncing = true
+        for cmd in [Command.status0, Command.status1, Command.syncAll, Command.fetch] {
+            write(cmd)
+        }
     }
 
     private func write(_ bytes: [UInt8]) {
@@ -81,10 +101,21 @@ extension RingSession: CBPeripheralDelegate {
         let bytes = [UInt8](data)
         Task { @MainActor in
             self.lastFrame = data.map { String(format: "%02x", $0) }.joined(separator: " ")
-            // Bulk history pages: ack to continue draining (47→c7, 4c→cc).
+            // Bulk history pages: accumulate + ack to continue draining (47→c7, 4c→cc).
             switch bytes.first {
-            case 0x47: self.write(Command.pageAck47); return
-            case 0x4C: self.write(Command.pageAck4C); return
+            case 0x47:
+                self.write(Command.pageAck47); return   // PPG page — decode TODO (issue #8)
+            case 0x4C:
+                self.bulkRecords += BulkSleep.records(fromPage: bytes)
+                self.write(Command.pageAck4C); return
+            case 0x50:
+                // End-of-history cursor report (§5.5) — note: NO XOR trailer, so it
+                // never reaches Frame.parse. Finalize the sync here.
+                if self.syncing {
+                    self.historySamples = BulkSleep.samples(from: self.bulkRecords)
+                    self.syncing = false
+                }
+                return
             default: break
             }
             guard let frame = Frame.parse(bytes) else { return }   // XOR-validate responses

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -73,6 +73,56 @@ final class RingSession: NSObject {
     /// UI can show a subtle "auto-updating" cue instead of reading as a user measurement.
     private(set) var autoMeasuring = false
 
+    // MARK: Battery freshness (#57)
+    //
+    // Battery % is updated ONLY on 0x10/0x87 descriptor frames (DeviceStatus.battery), which
+    // are solicited by the keepalive every 60–300 s. Using the global `lastFrameAt` (refreshed
+    // on every frame, including 2-s live-HR polls) would let the battery show as "live" for up
+    // to 6 minutes (idleStaleAfter) even though the reading is tens of minutes old during a long
+    // monitoring session. A dedicated per-read timestamp + a tighter 120 s window catches a
+    // silently stale reading after roughly 2 night-keepalive intervals.
+
+    /// Wall-clock of the most recent 0x10/0x87 frame that carried a valid battery % (#57).
+    /// Separate from `lastFrameAt` (updated on every frame) — battery freshness is independent
+    /// of live-HR polling.
+    private(set) var batteryFetchedAt: Date?
+
+    /// True when the last battery reading is old enough to display as stale — i.e. no
+    /// 0x10/0x87 descriptor arrived recently (#57). Tighter than `liveReadingsStale`
+    /// (idleStaleAfter 360 s), which covers all readings. Shows "as of Xm ago" in the
+    /// connection-header battery after `batteryStaleAfter` seconds of silence.
+    var batteryStale: Bool {
+        guard batteryPercent != nil else { return false }   // nothing to call stale yet
+        guard let at = batteryFetchedAt else { return false }
+        return Date().timeIntervalSince(at) > Self.batteryStaleAfter
+    }
+    /// ~2× the tightest keepalive interval (night: 60 s). Battery shows "as of Nm ago" when
+    /// no descriptor has arrived in this window. Daytime keepalive (180–300 s) means the battery
+    /// will accurately report as stale between keepalive firings — that IS correct, the reading
+    /// IS a few minutes old.
+    private static let batteryStaleAfter: TimeInterval = 120
+
+    // MARK: Charging inference (#60)
+    //
+    // The ring's charging byte is NOT on the wire in any confirmed field (PROTOCOL.md §5).
+    // A strictly rising battery % across consecutive 0x10/0x87 frames is the best 🟢 proxy.
+    // This window is private; `inferredCharging` is computed from it via the kit's pure function.
+    // The inference is persisted before session teardown (see `invalidate`) so the connection
+    // card can surface a hint during the reconnect backoff when session == nil.
+
+    /// Rolling battery % readings (oldest→newest, capped) for charging inference (#60).
+    private var batteryTrend: [Int] = []
+    private static let batteryTrendCapacity = 4
+
+    /// True when the last few battery readings are strictly rising — suggesting the ring may
+    /// be charging (🟢 proxy). The UI labels this "inferred" to avoid asserting certainty.
+    /// Never derived from the reconnect count (#60).
+    var inferredCharging: Bool { ChargingInference.inferred(from: batteryTrend) }
+
+    /// UserDefaults key for the last-persisted charging inference (#60). Written before session
+    /// teardown so ContentView can read it during the reconnect-backoff window (session == nil).
+    private static let inferredChargingKey = "battery.inferredCharging"
+
     /// True when frames have stopped for long enough that the live readings (HR/SpO₂/battery/
     /// steps/temp) should read as STALE rather than current (#36). A silently-dropped link keeps
     /// its last values until CoreBluetooth eventually fires `didDisconnect`; this lets the UI
@@ -171,6 +221,10 @@ final class RingSession: NSObject {
     /// reading via `stopLiveMonitoring()` BEFORE this where that matters; `invalidate()` itself is
     /// a pure cancel + detach. Idempotent.
     func invalidate() {
+        // Persist the charging inference BEFORE cancelling tasks (#60): the session is about
+        // to be nil-ed by the scanner; ContentView reads from UserDefaults during the
+        // reconnect-backoff window so the hint stays live while reconnecting.
+        UserDefaults.standard.set(inferredCharging, forKey: Self.inferredChargingKey)
         monitorTask?.cancel(); monitorTask = nil
         keepaliveTask?.cancel(); keepaliveTask = nil
         autoMeasureTask?.cancel(); autoMeasureTask = nil
@@ -831,7 +885,18 @@ extension RingSession: CBPeripheralDelegate {
                 }
             }
             // Ring battery % is descriptor byte[1] (§5.4 🟢, ground-truthed).
-            if let b = DeviceStatus.battery(bytes) { self.batteryPercent = b }
+            // Also stamps `batteryFetchedAt` (#57) and extends the charging-inference trend (#60).
+            if let b = DeviceStatus.battery(bytes) {
+                self.batteryPercent = b
+                self.batteryFetchedAt = Date()   // dedicated freshness anchor (#57)
+                // Charging inference: rolling window of distinct readings (#60).
+                if self.batteryTrend.last != b {
+                    self.batteryTrend.append(b)
+                    if self.batteryTrend.count > Self.batteryTrendCapacity {
+                        self.batteryTrend.removeFirst()
+                    }
+                }
+            }
             // Bulk history pages: accumulate + ack to continue draining (47→c7, 4c→cc).
             switch bytes.first {
             case 0x47:

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -172,9 +172,12 @@ final class RingSession: NSObject {
         guard let localStore else { return }
         if !stagedSegments.isEmpty {
             let summary = SleepStaging.summary(stagedSegments)
-            // `night` = start of the sleep window (segments carry the dates; Summary doesn't).
-            let night = stagedSegments.map(\.start).min() ?? Date()
-            try? localStore.saveSleepSummary(summary, night: night)
+            // Real sleep-window clock times (segments carry the dates; Summary doesn't) — so a
+            // night-temp window aligns to actual onset/wake, not midnight. `night` (start-of-day)
+            // remains the upsert key.
+            let start = stagedSegments.map(\.start).min() ?? Date()
+            let end = stagedSegments.map(\.end).max() ?? start
+            try? localStore.saveSleepSummary(summary, night: start, inBedStart: start, inBedEnd: end)
         }
         if let steps { try? localStore.saveDailySteps(steps) }
     }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -16,8 +16,12 @@ import OpenRingKit
 final class RingSession: NSObject {
 
     private(set) var liveHR: Int?
+    private(set) var liveSpO2: Int?       // 🟡 from long 0x15 frame byte[14]
+    private(set) var monitoring = false
     private(set) var lastFrame: String?
     private(set) var ready = false
+
+    private var monitorTask: Task<Void, Never>?
 
     /// Sleep-vitals samples (HR/HRV/SpO2) decoded from the last history sync,
     /// finalized when the ring reports end-of-history (0x50). Feed to HealthKitWriter.
@@ -47,15 +51,26 @@ final class RingSession: NSObject {
         peripheral.discoverServices(nil)
     }
 
-    /// Enter live-HR mode: status → open sync (cursor=all) → live mode → fetch.
-    /// History backlog (47/4c pages) is drained by acking in didUpdateValue.
-    func startLiveHR() {
-        for cmd in Command.liveHRStart { write(cmd) }
+    /// Begin live monitoring: enter live-HR mode, then poll once a second so the ring
+    /// keeps emitting 0x15 samples. Updates `liveHR`/`liveSpO2`. Idempotent.
+    func startLiveMonitoring() {
+        guard monitorTask == nil else { return }
+        monitoring = true
+        for cmd in Command.liveHRStart { write(cmd) }   // status → sync → live mode → fetch
+        monitorTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.write(Command.poll)
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
     }
 
-    /// Poll for one live sample (0x95 → 0x15). Sent verbatim — NOT XOR-encoded.
-    func pollLiveHR() {
-        write(Command.poll)
+    /// Stop the poll loop. HR/SpO2 keep their last value.
+    func stopLiveMonitoring() {
+        monitorTask?.cancel()
+        monitorTask = nil
+        monitoring = false
     }
 
     /// Pull stored history: open the sync session (cursor = everything) and fetch.
@@ -114,8 +129,8 @@ extension RingSession: CBPeripheralDelegate {
             case 0x47:
                 self.write(Command.pageAck47); return   // PPG page — decode TODO (issue #8)
             case 0x4C:
-                self.bulkRecords += BulkSleep.records(fromPage: bytes)
-                self.write(Command.pageAck4C); return
+                if self.syncing { self.bulkRecords += BulkSleep.records(fromPage: bytes) }
+                self.write(Command.pageAck4C); return   // always ack to keep draining
             case 0x50:
                 // End-of-history cursor report (§5.5) — note: NO XOR trailer, so it
                 // never reaches Frame.parse. Finalize the sync here.
@@ -129,9 +144,17 @@ extension RingSession: CBPeripheralDelegate {
             default: break
             }
             guard let frame = Frame.parse(bytes) else { return }   // XOR-validate responses
-            // 0x15 is the live-sample stream (resp of 0x95 poll).
+            // 0x15 = live-sample stream (resp of 0x95 poll). Two shapes:
+            //   short `15 00 <hr> 0a b0`  → HR at byte[2] (🟢)
+            //   long  `15 01 … <spo2> …`  → byte[2]=0; SpO2 at byte[14] (🟡)
+            // Only the short frame carries HR — don't let a long frame zero it out.
             if frame.opcode == Frame.responseID(Opcode.poll) {
-                self.liveHR = LiveHR.decode(bytes)   // 🟡 offset tentative
+                if bytes.count >= 4, bytes[1] == 0x00 {
+                    if let hr = LiveHR.decodeLocked(bytes) { self.liveHR = hr }  // filters warm-up
+                } else if bytes.count >= 15, bytes[1] == 0x01 {
+                    let spo2 = Int(bytes[14])
+                    if (70...100).contains(spo2) { self.liveSpO2 = spo2 }
+                }
             }
         }
     }

--- a/ios/OpenRingConn/BLE/RingSession.swift
+++ b/ios/OpenRingConn/BLE/RingSession.swift
@@ -10,6 +10,8 @@ import OpenRingKit
 //   • history sync: drain 0x4c activity/sleep pages → BulkSleep → HR/HRV/SpO2
 //     samples (PROTOCOL.md §5.3, 🟢 fields). 0x47 PPG pages are acked but not yet
 //     decoded (their payload is 🔴 — issue #8).
+//   • Layer-A epoch page routing (0x47/0x4c/0x50) also feeds EpochSyncSession in
+//     parallel, gated behind `epochDecodingEnabled` (#24).
 
 @Observable
 @MainActor
@@ -35,6 +37,8 @@ final class RingSession: NSObject {
     /// so the UI shows "preparing" instead of a dead reading.
     private(set) var livePreparing = false
     private(set) var lastFrame: String?
+    private(set) var decodedEpochRecords = 0
+    private(set) var storedMetricSamples = 0
     private(set) var ready = false
 
     private var monitorTask: Task<Void, Never>?
@@ -63,12 +67,16 @@ final class RingSession: NSObject {
     private let peripheral: CBPeripheral
     private var notifyChar: CBCharacteristic?
     private var writeChar: CBCharacteristic?
+    private var localStore: LocalStore?
+    private var syncSession = EpochSyncSession()
+    private let epochDecodingEnabled = false
 
     private let notifyUUID = CBUUID(string: OpenRingKit.Transport.notifyCharUUID)
     private let writeUUID = CBUUID(string: OpenRingKit.Transport.writeCharUUID)
 
-    init(peripheral: CBPeripheral) {
+    init(peripheral: CBPeripheral, localStore: LocalStore? = nil) {
         self.peripheral = peripheral
+        self.localStore = localStore
         super.init()
         peripheral.delegate = self
         peripheral.discoverServices(nil)
@@ -141,6 +149,10 @@ final class RingSession: NSObject {
                 try? await Task.sleep(for: .seconds(2))
             }
         }
+    }
+
+    func setLocalStore(_ localStore: LocalStore) {
+        self.localStore = localStore
     }
 
     /// Start (or switch) live monitoring in a single mode. Guarantees only one metric
@@ -285,19 +297,24 @@ extension RingSession: CBPeripheralDelegate {
             case 0x47:
                 self.drainSawPage = true
                 if self.syncing { self.syncQuietTicks = 0 }
-                self.write(Command.pageAck47); return   // PPG page — decode TODO (issue #8)
+                self.write(Command.pageAck47)
+                self.handlePPGPage(data)   // Layer-A epoch decode, gated (#24)
+                return   // PPG page — BulkSleep decode TODO (issue #8)
             case 0x4C:
                 self.drainSawPage = true
                 if self.syncing || self.livePreparing {   // keep records during a sync OR a live-enter drain
                     self.bulkRecords += BulkSleep.records(fromPage: bytes)
                     self.syncQuietTicks = 0
                 }
-                self.write(Command.pageAck4C); return   // always ack to keep draining
+                self.write(Command.pageAck4C)
+                self.handleActivityPage(data)   // Layer-A epoch decode, gated (#24)
+                return   // always ack to keep draining
             case 0x50:
                 // End-of-history cursor report (§5.5) — NO XOR trailer, so it never
                 // reaches Frame.parse. Mark done; the sync watchdog / live-enter drain finalizes.
                 self.drainDone = true
                 if self.syncing { self.syncDone = true }
+                self.handleEndOfHistory(data)   // finalize epoch session, gated persist (#24)
                 return
             default: break
             }
@@ -317,6 +334,26 @@ extension RingSession: CBPeripheralDelegate {
                 }
                 if let spo2 = LiveHR.decodeSpO2(bytes) { self.liveSpO2 = spo2 }  // long frame, 🟡
             }
+        }
+    }
+
+    private func handleActivityPage(_ data: Data) {
+        decodedEpochRecords += syncSession.appendActivityPage(data).count
+    }
+
+    private func handlePPGPage(_ data: Data) {
+        decodedEpochRecords += syncSession.appendPPGPage(data).count
+    }
+
+    private func handleEndOfHistory(_ data: Data) {
+        guard syncSession.complete(with: data) != nil,
+              epochDecodingEnabled else { return }
+        let samples = syncSession.placeholderQuantitySamples()
+        guard !samples.isEmpty else { return }
+        do {
+            storedMetricSamples += try localStore?.ingest(samples).count ?? 0
+        } catch {
+            // Persistence failures should not interrupt the BLE drain/ACK loop.
         }
     }
 }

--- a/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
+++ b/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
@@ -1,0 +1,52 @@
+import BackgroundTasks
+import Foundation
+
+protocol BGTaskScheduling {
+    func register(forTaskWithIdentifier identifier: String,
+                  using queue: DispatchQueue?,
+                  launchHandler: @escaping (BGTask) -> Void) -> Bool
+    func cancel(taskRequestWithIdentifier identifier: String)
+    func submit(_ taskRequest: BGTaskRequest) throws
+}
+
+extension BGTaskScheduler: BGTaskScheduling {}
+
+struct BackgroundRefreshScheduler {
+    static let identifier = "com.openringconn.app.bgrefresh"
+    static let refreshInterval: TimeInterval = 15 * 60
+
+    private let scheduler: BGTaskScheduling
+    private let now: () -> Date
+
+    init(scheduler: BGTaskScheduling = BGTaskScheduler.shared,
+         now: @escaping () -> Date = Date.init) {
+        self.scheduler = scheduler
+        self.now = now
+    }
+
+    @discardableResult
+    func register(launchHandler: @escaping (BGTask) -> Void) -> Bool {
+        scheduler.register(
+            forTaskWithIdentifier: Self.identifier,
+            using: nil,
+            launchHandler: launchHandler
+        )
+    }
+
+    func makeRequest() -> BGAppRefreshTaskRequest {
+        let request = BGAppRefreshTaskRequest(identifier: Self.identifier)
+        request.earliestBeginDate = now().addingTimeInterval(Self.refreshInterval)
+        return request
+    }
+
+    func schedule() {
+        do {
+            scheduler.cancel(taskRequestWithIdentifier: Self.identifier)
+            try scheduler.submit(makeRequest())
+        } catch {
+            #if DEBUG
+            print("Unable to schedule background refresh: \(error)")
+            #endif
+        }
+    }
+}

--- a/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
+++ b/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
@@ -12,7 +12,7 @@ protocol BGTaskScheduling {
 extension BGTaskScheduler: BGTaskScheduling {}
 
 struct BackgroundRefreshScheduler {
-    static let identifier = "com.openringconn.app.bgrefresh"
+    static let identifier = "com.dreamality.openringconn.bgrefresh"
     static let refreshInterval: TimeInterval = 15 * 60
 
     private let scheduler: BGTaskScheduling

--- a/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
+++ b/ios/OpenRingConn/Background/BackgroundRefreshScheduler.swift
@@ -15,6 +15,16 @@ struct BackgroundRefreshScheduler {
     static let identifier = "com.dreamality.openringconn.bgrefresh"
     static let refreshInterval: TimeInterval = 15 * 60
 
+    /// Separate BGProcessingTask (#45). A processing task gets a much longer runtime window than
+    /// the ~30 s BGAppRefreshTask ceiling, so the optical-HR poll can finally clear its ~60 s
+    /// warm-up in the background. HONEST: iOS schedules processing tasks at its own discretion
+    /// (commonly overnight while charging), so this improves the odds of a real background HR
+    /// lock but does NOT guarantee a daytime one.
+    static let processingIdentifier = "com.dreamality.openringconn.bgprocessing"
+    /// Ask for the processing task less often than the app refresh — it's the heavier, longer
+    /// run, and iOS coalesces/throttles these regardless.
+    static let processingInterval: TimeInterval = 60 * 60
+
     private let scheduler: BGTaskScheduling
     private let now: () -> Date
 
@@ -33,9 +43,28 @@ struct BackgroundRefreshScheduler {
         )
     }
 
+    @discardableResult
+    func registerProcessing(launchHandler: @escaping (BGTask) -> Void) -> Bool {
+        scheduler.register(
+            forTaskWithIdentifier: Self.processingIdentifier,
+            using: nil,
+            launchHandler: launchHandler
+        )
+    }
+
     func makeRequest() -> BGAppRefreshTaskRequest {
         let request = BGAppRefreshTaskRequest(identifier: Self.identifier)
         request.earliestBeginDate = now().addingTimeInterval(Self.refreshInterval)
+        return request
+    }
+
+    func makeProcessingRequest() -> BGProcessingTaskRequest {
+        let request = BGProcessingTaskRequest(identifier: Self.processingIdentifier)
+        request.earliestBeginDate = now().addingTimeInterval(Self.processingInterval)
+        // It needs the longer WINDOW, not the charger — a daytime HR read shouldn't require power.
+        // (iOS still tends to defer processing tasks to charging/idle, but we don't mandate it.)
+        request.requiresExternalPower = false
+        request.requiresNetworkConnectivity = false
         return request
     }
 
@@ -46,6 +75,17 @@ struct BackgroundRefreshScheduler {
         } catch {
             #if DEBUG
             print("Unable to schedule background refresh: \(error)")
+            #endif
+        }
+    }
+
+    func scheduleProcessing() {
+        do {
+            scheduler.cancel(taskRequestWithIdentifier: Self.processingIdentifier)
+            try scheduler.submit(makeProcessingRequest())
+        } catch {
+            #if DEBUG
+            print("Unable to schedule background processing: \(error)")
             #endif
         }
     }

--- a/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
+++ b/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
@@ -11,6 +11,15 @@ struct RingBackgroundSyncService {
         self.health = health
     }
 
+    /// Budget for one background read. The old 20 s let the history drain eat the whole window
+    /// before the live-HR poll even started, so HR never locked in the background (#45 A). We now
+    /// run nearer the BGAppRefreshTask ceiling so the poll gets a real budget after the drain;
+    /// the task's `expirationHandler` (AppDelegate) still cancels cleanly if iOS grants less, and
+    /// the capture loop is cancellation-aware. (Honest: BGAppRefreshTask windows are short, so a
+    /// full ~60 s optical lock isn't guaranteed every run — but the drain no longer starves it,
+    /// any lock now reaches HealthKit, and the standing reconnect gives repeat chances.)
+    static let defaultTimeout: TimeInterval = 28
+
     /// One bounded background read so the app already has last night's data on open. The
     /// drain inside `captureForBackground` persists overnight HR/HRV/SpO2 + sleep + steps +
     /// skin temp to the local store (the dashboard's source) — skin temp ONLY during the
@@ -19,7 +28,7 @@ struct RingBackgroundSyncService {
     /// double-writes. Returns the BGTask success flag — true when we captured ANY data, not
     /// only a live HR, so iOS keeps scheduling us even on nights the optical HR never locks.
     @discardableResult
-    func syncVitals(timeout: TimeInterval = 20) async throws -> Bool {
+    func syncVitals(timeout: TimeInterval = RingBackgroundSyncService.defaultTimeout) async throws -> Bool {
         let scanner = RingScanner.shared
         scanner.setLocalStore(store)   // RingSession auto-persists the drained history + temp
         let capture = await scanner.captureForBackground(timeout: timeout)

--- a/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
+++ b/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
@@ -17,7 +17,7 @@ struct RingBackgroundSyncService {
     /// if an HR sample was captured (the BGTask success flag).
     @discardableResult
     func syncVitals(timeout: TimeInterval = 20) async throws -> Bool {
-        let scanner = RingScanner()
+        let scanner = RingScanner.shared
         scanner.setLocalStore(store)   // RingSession persists skin temp from the descriptor
         let hr = await scanner.readLiveHeartRate(timeout: timeout)
 

--- a/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
+++ b/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
@@ -1,0 +1,29 @@
+import Foundation
+import OpenRingKit
+
+@MainActor
+struct RingBackgroundSyncService {
+    private let store: LocalStore
+    private let health: HealthKitWriter
+
+    init(store: LocalStore, health: HealthKitWriter) {
+        self.store = store
+        self.health = health
+    }
+
+    func syncLiveHeartRate(timeout: TimeInterval = 20) async throws -> Bool {
+        let scanner = RingScanner()
+        guard let hr = await scanner.readLiveHeartRate(timeout: timeout) else {
+            return false
+        }
+
+        let now = Date()
+        let samples = try store.ingest([
+            QuantitySample(kind: .heartRate, start: now, value: Double(hr))
+        ])
+        if HealthKitWriter.isAvailable {
+            try? await health.write(samples)
+        }
+        return true
+    }
+}

--- a/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
+++ b/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
@@ -11,18 +11,20 @@ struct RingBackgroundSyncService {
         self.health = health
     }
 
-    func syncLiveHeartRate(timeout: TimeInterval = 20) async throws -> Bool {
+    /// One bounded background read: connect, grab a live HR sample AND the skin temperature
+    /// the descriptor streams on connect, persist both, disconnect. Wiring the store into the
+    /// scanner lets `RingSession` auto-persist temperature; HR is persisted here. Returns true
+    /// if an HR sample was captured (the BGTask success flag).
+    @discardableResult
+    func syncVitals(timeout: TimeInterval = 20) async throws -> Bool {
         let scanner = RingScanner()
-        guard let hr = await scanner.readLiveHeartRate(timeout: timeout) else {
-            return false
-        }
+        scanner.setLocalStore(store)   // RingSession persists skin temp from the descriptor
+        let hr = await scanner.readLiveHeartRate(timeout: timeout)
 
-        let now = Date()
-        let samples = try store.ingest([
-            QuantitySample(kind: .heartRate, start: now, value: Double(hr))
-        ])
-        if HealthKitWriter.isAvailable {
-            try? await health.write(samples)
+        guard let hr else { return false }
+        let fresh = try store.ingest([QuantitySample(kind: .heartRate, start: Date(), value: Double(hr))])
+        if HealthKitWriter.isAvailable, !fresh.isEmpty {
+            try? await health.write(fresh)
         }
         return true
     }

--- a/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
+++ b/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
@@ -11,21 +11,25 @@ struct RingBackgroundSyncService {
         self.health = health
     }
 
-    /// One bounded background read: connect, grab a live HR sample AND the skin temperature
-    /// the descriptor streams on connect, persist both, disconnect. Wiring the store into the
-    /// scanner lets `RingSession` auto-persist temperature; HR is persisted here. Returns true
-    /// if an HR sample was captured (the BGTask success flag).
+    /// One bounded background read so the app already has last night's data on open. The
+    /// drain inside `captureForBackground` persists overnight HR/HRV/SpO2 + sleep + steps +
+    /// skin temp to the local store (the dashboard's source); here we then mirror everything
+    /// pending into Apple Health, each metric watermark-gated so nothing double-writes.
+    /// Returns the BGTask success flag — true when we captured ANY data, not only a live HR,
+    /// so iOS keeps scheduling us even on nights the optical HR never locks.
     @discardableResult
     func syncVitals(timeout: TimeInterval = 20) async throws -> Bool {
         let scanner = RingScanner.shared
-        scanner.setLocalStore(store)   // RingSession persists skin temp from the descriptor
-        let hr = await scanner.readLiveHeartRate(timeout: timeout)
+        scanner.setLocalStore(store)   // RingSession auto-persists the drained history + temp
+        let capture = await scanner.captureForBackground(timeout: timeout)
 
-        guard let hr else { return false }
-        let fresh = try store.ingest([QuantitySample(kind: .heartRate, start: Date(), value: Double(hr))])
-        if HealthKitWriter.isAvailable, !fresh.isEmpty {
-            try? await health.write(fresh)
+        var mirrored = false
+        if HealthKitWriter.isAvailable {
+            mirrored = await health.flushToHealth(store: store,
+                                                  sleepSegments: capture.sleepSegments).wroteAnything
         }
-        return true
+        // Success = we captured fresh data OR mirrored previously-pending data to Health, so a
+        // run that only flushed a backlog still counts (iOS uses this to keep scheduling us).
+        return capture.gotData || mirrored
     }
 }

--- a/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
+++ b/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
@@ -20,6 +20,15 @@ struct RingBackgroundSyncService {
     /// any lock now reaches HealthKit, and the standing reconnect gives repeat chances.)
     static let defaultTimeout: TimeInterval = 28
 
+    /// Budget for the BGProcessingTask path (#45). A processing task gets minutes of runtime
+    /// (vs. the ~30 s app-refresh ceiling), so the optical-HR poll finally has room past its
+    /// ~60 s warm-up to actually lock. We change ONLY the time budget handed to the existing
+    /// capture loop — not the drain/decode logic. The loop is cancellation-aware, so if iOS
+    /// grants less the AppDelegate `expirationHandler` still tears down cleanly. HONEST: iOS
+    /// schedules processing tasks at its discretion (usually overnight on the charger), so this
+    /// makes a real background HR lock LIKELY when it runs, not guaranteed for daytime.
+    static let processingTimeout: TimeInterval = 150
+
     /// One bounded background read so the app already has last night's data on open. The
     /// drain inside `captureForBackground` persists overnight HR/HRV/SpO2 + sleep + steps +
     /// skin temp to the local store (the dashboard's source) — skin temp ONLY during the
@@ -46,6 +55,9 @@ struct RingBackgroundSyncService {
         if HealthKitWriter.isAvailable {
             mirrored = await health.flushToHealth(store: store,
                                                   sleepSegments: capture.sleepSegments).wroteAnything
+            // Record the Health write so ContentView's "Last Health write" reflects the
+            // background path too, not just the manual button (#44).
+            if mirrored { ObservabilityStore().recordHealthWrite() }
         }
         // Success = we captured fresh data OR mirrored previously-pending data to Health, so a
         // run that only flushed a backlog still counts (iOS uses this to keep scheduling us).

--- a/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
+++ b/ios/OpenRingConn/Background/RingBackgroundSyncService.swift
@@ -13,15 +13,25 @@ struct RingBackgroundSyncService {
 
     /// One bounded background read so the app already has last night's data on open. The
     /// drain inside `captureForBackground` persists overnight HR/HRV/SpO2 + sleep + steps +
-    /// skin temp to the local store (the dashboard's source); here we then mirror everything
-    /// pending into Apple Health, each metric watermark-gated so nothing double-writes.
-    /// Returns the BGTask success flag — true when we captured ANY data, not only a live HR,
-    /// so iOS keeps scheduling us even on nights the optical HR never locks.
+    /// skin temp to the local store (the dashboard's source) — skin temp ONLY during the
+    /// nightly sleep window (daytime readings are too noisy to trend); here we then mirror
+    /// everything pending into Apple Health, each metric watermark-gated so nothing
+    /// double-writes. Returns the BGTask success flag — true when we captured ANY data, not
+    /// only a live HR, so iOS keeps scheduling us even on nights the optical HR never locks.
     @discardableResult
     func syncVitals(timeout: TimeInterval = 20) async throws -> Bool {
         let scanner = RingScanner.shared
         scanner.setLocalStore(store)   // RingSession auto-persists the drained history + temp
         let capture = await scanner.captureForBackground(timeout: timeout)
+        // Resolve the night window for this connect so temp frames are gated correctly even
+        // on a fresh background session that never ran the reactive refresh. This CANNOT be
+        // hoisted above `captureForBackground`: the `RingSession` is created during that call's
+        // connect, so `scanner.session` is nil beforehand and a pre-call refresh would be a
+        // no-op. Temp frames arriving DURING the capture are already gated correctly two ways:
+        // `RingSession.startKeepalive()` primes the window the moment the session is ready, and
+        // the descriptor capture site force-re-resolves on any window miss before dropping a
+        // sample. This post-capture refresh keeps the cache warm for any trailing frames.
+        await scanner.session?.refreshNightWindowIfNeeded()
 
         var mirrored = false
         if HealthKitWriter.isAvailable {

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -92,6 +92,15 @@ struct ContentView: View {
                  ? "Measuring \(showingSpO2 ? "SpO₂" : "heart rate") — the other is off."
                  : "Pick one to start. Only one reads at a time.")
                 .font(.caption2).foregroundStyle(.secondary)
+
+            if let steps = session?.steps {
+                Divider()
+                Label("\(steps) steps today", systemImage: "figure.walk")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.green)
+                    .contentTransition(.numericText())
+                    .animation(.snappy, value: steps)
+            }
         }
     }
 
@@ -267,13 +276,21 @@ struct ContentView: View {
     private func writeToHealth(_ samples: [QuantitySample]) {
         let store = LocalStore(modelContext)
         let segments = session?.sleepSegments ?? []
+        let steps = session?.steps
         Task {
             do {
                 let freshSamples = try store.ingest(samples)
                 try await health.write(freshSamples)
                 let freshSleep = try store.ingestSleep(segments)
                 if !freshSleep.isEmpty { try await health.write(sleep: freshSleep) }
-                lastWrite = "Wrote \(freshSamples.count) samples, \(freshSleep.count) sleep segments"
+                // Steps: write today's cumulative count over [startOfDay, now].
+                if let steps, steps > 0 {
+                    let startOfDay = Calendar.current.startOfDay(for: Date())
+                    try await health.write([QuantitySample(kind: .steps, start: startOfDay,
+                                                           end: Date(), value: Double(steps))])
+                }
+                lastWrite = "Wrote \(freshSamples.count) samples, \(freshSleep.count) sleep segs"
+                    + (steps.map { ", \($0) steps" } ?? "")
             } catch {
                 lastWrite = "Error: \(error.localizedDescription)"
             }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @State private var healthAuthorized = false
     @State private var lastWrite: String?
     @State private var showDebug = false
+    @State private var showWorkout = false
 
     /// Freshness timestamps mirrored from the UserDefaults-backed observability store (#44).
     /// Held in @State because UserDefaults writes (from the background task / a flush) don't
@@ -44,6 +45,7 @@ struct ContentView: View {
                     sleepCard
                     caloriesCard
                     card { GoalsCardView() }
+                    workoutCard
                     trendsNavigationCard
                     syncCard
                     debugCard
@@ -360,6 +362,31 @@ struct ContentView: View {
     /// reflects a just-finished sync instantly via the live staged segments. (See SleepCardView.)
     private var sleepCard: some View {
         SleepCardView(liveSegments: session?.stagedSegments ?? [])
+    }
+
+    /// Workout session card — taps through to WorkoutView (#75).
+    /// Displays a start-workout prompt; tapping opens the sport-picker sheet.
+    private var workoutCard: some View {
+        Button {
+            showWorkout = true
+        } label: {
+            card {
+                HStack(spacing: 8) {
+                    Image(systemName: "figure.run").foregroundStyle(.blue)
+                    Text("WORKOUT")
+                        .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption).foregroundStyle(.tertiary)
+                }
+                Text("Record a workout with HR zones + GPS route (outdoor)")
+                    .font(.subheadline).foregroundStyle(.secondary)
+            }
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showWorkout) {
+            WorkoutView(session: session)
+        }
     }
 
     /// 7-day trends nav card — taps through to the full TrendsView (#74).

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -53,6 +53,10 @@ struct ContentView: View {
                         LabeledContent("Sleep window",
                                        value: "\(inBed.start.formatted(date: .omitted, time: .shortened))–\(inBed.end.formatted(date: .omitted, time: .shortened))")
                     }
+                    if let staged = scanner.session?.stagedSegments, !staged.isEmpty {
+                        LabeledContent("Stages (experimental)", value: stageSummary(staged))
+                            .font(.caption)
+                    }
                     if let samples = scanner.session?.historySamples, !samples.isEmpty {
                         Button("Write to Apple Health") { writeToHealth(samples) }
                             .disabled(!healthAuthorized)
@@ -80,6 +84,14 @@ struct ContentView: View {
                 lastWrite = "error: \(error.localizedDescription)"
             }
         }
+    }
+
+    /// "D 90m · R 115m · L 242m · W 13m" from staged segments (excludes inBed).
+    private func stageSummary(_ segs: [SleepSegment]) -> String {
+        func mins(_ stage: SleepStage) -> Int {
+            Int(segs.filter { $0.stage == stage }.reduce(0) { $0 + $1.duration } / 60)
+        }
+        return "D \(mins(.asleepDeep))m · R \(mins(.asleepREM))m · L \(mins(.asleepCore))m · W \(mins(.awake))m"
     }
 
     private var statusText: String {

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -203,6 +203,10 @@ struct ContentView: View {
                     }
                 }
             }
+            // Link up + subscribed but the ring sends only status replies, no data (#54) — the
+            // un-activated/un-bonded signature. Until the activate step is reverse-engineered, the
+            // only fix is to open the official app once; say so instead of spinning forever.
+            if connected, session?.notStreaming == true { activationHint }
             if !connected {
                 Button {
                     scanner.start()
@@ -213,6 +217,22 @@ struct ContentView: View {
                 .buttonStyle(.borderedProminent)
             }
         }
+    }
+
+    /// Shown when `RingSession.notStreaming` — the ring is connected but not delivering data (not
+    /// yet activated/bonded by the official app). #54.
+    private var activationHint: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Ring isn't streaming").font(.subheadline.weight(.medium))
+                Text("Connected, but the ring isn't sending data. Open the official RingConn app once to activate it, then return here.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.orange.opacity(0.12)))
     }
 
     /// A user (non-auto) HR measurement that's converging but hasn't locked yet (#45 C). The
@@ -318,7 +338,8 @@ struct ContentView: View {
             }
             .buttonStyle(.borderedProminent)
             .disabled(session?.ready != true || session?.syncing == true
-                      || session?.monitoring == true)   // stop live before syncing
+                      || session?.monitoring == true        // stop live before syncing
+                      || session?.notStreaming == true)     // a not-streaming ring would sync nothing (#54)
 
             if session?.monitoring == true {
                 Text("Stop live HR/SpO₂ before syncing.").font(.caption2).foregroundStyle(.secondary)

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -140,11 +140,20 @@ struct ContentView: View {
                     Text(hrWarmupText).font(.caption).foregroundStyle(.secondary)
                 }
                 Spacer()
-                // Ring battery (a device stat, not a body vital) sits with the connection.
+                // Ring battery (a device stat, not a body vital) sits with the connection. When
+                // the link has gone quiet (no frames), gray it and show "as of Xm ago" so a
+                // minutes-old % from a silently-dropped link doesn't read as current (#36).
                 if let b = session?.batteryPercent {
-                    Label("\(b)%", systemImage: batteryIcon(b))
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(b <= 20 ? .red : .secondary)
+                    let stale = session?.liveReadingsStale == true
+                    VStack(alignment: .trailing, spacing: 0) {
+                        Label("\(b)%", systemImage: batteryIcon(b))
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(stale ? AnyShapeStyle(.tertiary)
+                                             : AnyShapeStyle(b <= 20 ? Color.red : Color.secondary))
+                        if let asOf = batteryAsOf {
+                            Text(asOf).font(.caption2).foregroundStyle(.tertiary)
+                        }
+                    }
                 }
             }
             if !connected {
@@ -170,6 +179,17 @@ struct ContentView: View {
         if let w = session?.liveHRWarmup { return "Warming up HR… (\(w))" }
         return "Measuring HR…"
     }
+
+    /// "as of Xm ago" for the connection-header battery, shown only once the link has gone quiet
+    /// (#36) — a dropped link can otherwise show a minutes-old battery % as if it were current.
+    private var batteryAsOf: String? {
+        guard session?.liveReadingsStale == true, let at = session?.lastFrameAt else { return nil }
+        return "as of " + Self.rel.localizedString(for: at, relativeTo: Date())
+    }
+
+    private static let rel: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter(); f.unitsStyle = .abbreviated; return f
+    }()
 
     /// SF Symbol for the ring's battery level.
     private func batteryIcon(_ pct: Int) -> String {
@@ -392,7 +412,13 @@ struct ContentView: View {
         case .poweredOff: return "Bluetooth off"
         case .unauthorized: return "Bluetooth not authorized"
         case .scanning: return "Scanning…"
-        case .connecting(let n): return "Connecting to \(n)…"
+        case .connecting(let n):
+            // After repeated failed reconnects (e.g. the ring is on the charger / out of range),
+            // swap the permanent "Connecting…" for a calm note so normal charging doesn't read as
+            // a stuck connection (#35). Heuristic on elapsed attempts — not a charging byte (#41).
+            return scanner.reconnectStalled
+                ? "Ring unreachable or charging — will reconnect automatically"
+                : "Connecting to \(n)…"
         case .connected(let n): return n
         }
     }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
             ScrollView {
                 VStack(spacing: 16) {
                     connectionCard
+                    vitalsCard
                     hrCard
                     spo2Card
                     stepsCard
@@ -67,6 +68,24 @@ struct ContentView: View {
                 .buttonStyle(.borderedProminent)
             }
         }
+    }
+
+    // MARK: Vitals dashboard (persisted — always visible)
+
+    private var vitalsCard: some View {
+        card {
+            Text("VITALS").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            VitalsTableView(session: session, sleepMinutes: sleepMinutes)
+        }
+    }
+
+    /// Total time asleep for the most recent night (minutes), from the last sync's
+    /// segments — sum of the asleep stages (excludes the inBed wrapper and awake).
+    private var sleepMinutes: Int? {
+        guard let segs = session?.sleepSegments, !segs.isEmpty else { return nil }
+        let asleep = segs.filter { $0.stage != .inBed && $0.stage != .awake }
+        let secs = asleep.reduce(0.0) { $0 + $1.duration }
+        return secs > 0 ? Int(secs / 60) : nil
     }
 
     // MARK: Live — two independent sections, but only one reads at a time

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -294,6 +294,12 @@ struct ContentView: View {
                             .frame(width: total > 0 ? geo.size.width * mins(stage) / total : 0)
                     }
                 }
+
+                Section("Settings") {
+                    NavigationLink("User Profile") {
+                        UserProfileSettingsView()
+                    }
+                }
             }
             .frame(height: 12)
             .clipShape(Capsule())

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -109,6 +109,12 @@ struct ContentView: View {
                 Circle().fill(connected ? .green : .secondary).frame(width: 10, height: 10)
                 Text(statusText).font(.subheadline.weight(.medium))
                 Spacer()
+                // Ring battery (a device stat, not a body vital) sits with the connection.
+                if let b = session?.batteryPercent {
+                    Label("\(b)%", systemImage: batteryIcon(b))
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(b <= 20 ? .red : .secondary)
+                }
             }
             if !connected {
                 Button {
@@ -119,6 +125,17 @@ struct ContentView: View {
                 }
                 .buttonStyle(.borderedProminent)
             }
+        }
+    }
+
+    /// SF Symbol for the ring's battery level.
+    private func batteryIcon(_ pct: Int) -> String {
+        switch pct {
+        case ..<13: return "battery.0percent"
+        case ..<38: return "battery.25percent"
+        case ..<63: return "battery.50percent"
+        case ..<88: return "battery.75percent"
+        default: return "battery.100percent"
         }
     }
 

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -39,6 +39,7 @@ struct ContentView: View {
                     hrCard
                     spo2Card
                     stepsCard
+                    caloriesCard
                     syncCard
                     debugCard
                 }
@@ -46,6 +47,15 @@ struct ContentView: View {
             }
             .background(Color(.systemGroupedBackground))
             .navigationTitle("OpenRingConn")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink {
+                        UserProfileSettingsView()
+                    } label: {
+                        Image(systemName: "person.crop.circle")
+                    }
+                }
+            }
             .onAppear {
                 // Wire persistence into the scanner/session so the (currently gated)
                 // epoch-sync decoder can persist Layer-A records once enabled. #24
@@ -56,6 +66,10 @@ struct ContentView: View {
                 // SwiftData fetch synchronously in .onAppear blocked the launch render and
                 // showed a black screen on launch. #14
                 loadLaunchSnapshot()
+                // Reflect any prior Health authorization so the UI shows the mirrored state,
+                // and backfill anything the background refresh persisted while we were away.
+                healthAuthorized = health.isShareAuthorized
+                if healthAuthorized { flushHealth() }
             }
             // Foreground auto-refresh: reconnect to the last-known ring and pull fresh data
             // when the app becomes active, so opening it after a while shows updated vitals
@@ -66,6 +80,16 @@ struct ContentView: View {
             // Fire the armed one-shot sync the moment the (re)connected link is ready.
             .onChange(of: session?.ready) { _, ready in
                 if ready == true { maybeAutoSyncOnReady() }
+            }
+            // Seamless Apple Health mirroring: whenever a history sync finishes or live
+            // monitoring stops (both persist fresh samples to the store), push whatever's
+            // pending to Health. Each metric is watermark-gated, so this never double-writes
+            // and is a no-op until the user has authorized Health.
+            .onChange(of: session?.syncing) { _, syncing in
+                if syncing == false { flushHealth() }
+            }
+            .onChange(of: session?.monitoring) { _, monitoring in
+                if monitoring == false { flushHealth() }
             }
         }
     }
@@ -105,9 +129,16 @@ struct ContentView: View {
 
     private var connectionCard: some View {
         card {
-            HStack {
+            HStack(spacing: 8) {
                 Circle().fill(connected ? .green : .secondary).frame(width: 10, height: 10)
                 Text(statusText).font(.subheadline.weight(.medium))
+                // Top-of-screen freshness cue so opening the app reads as "updating" without
+                // scrolling to the sync card. Shows while the foreground auto-refresh (or a
+                // manual sync) is pulling fresh data.
+                if session?.syncing == true {
+                    ProgressView().controlSize(.small)
+                    Text("Updating…").font(.caption).foregroundStyle(.secondary)
+                }
                 Spacer()
                 // Ring battery (a device stat, not a body vital) sits with the connection.
                 if let b = session?.batteryPercent {
@@ -244,6 +275,12 @@ struct ContentView: View {
         }
     }
 
+    /// Calories on the home page (was buried in the profile page). Headline is today's
+    /// estimated burn; the reference figures stay as a small secondary line.
+    private var caloriesCard: some View {
+        card { CaloriesCardView() }
+    }
+
     private func metricHeader(_ title: String, icon: String, color: Color, active: Bool) -> some View {
         HStack(spacing: 8) {
             Image(systemName: icon).foregroundStyle(active ? color : .secondary)
@@ -325,7 +362,7 @@ struct ContentView: View {
                     stageBar(staged)
                 }
                 Divider()
-                healthRow(samples)
+                healthRow
             }
         }
     }
@@ -354,11 +391,15 @@ struct ContentView: View {
         }
     }
 
-    private func healthRow(_ samples: [QuantitySample]) -> some View {
+    private var healthRow: some View {
         VStack(spacing: 8) {
             if !healthAuthorized {
                 Button {
-                    Task { try? await health.requestAuthorization(); healthAuthorized = true }
+                    Task {
+                        try? await health.requestAuthorization()
+                        healthAuthorized = health.isShareAuthorized
+                        flushHealth()   // backfill everything already in the store
+                    }
                 } label: {
                     Label("Authorize Apple Health", systemImage: "heart.text.square")
                         .frame(maxWidth: .infinity)
@@ -366,13 +407,11 @@ struct ContentView: View {
                 .buttonStyle(.bordered)
                 .disabled(!HealthKitWriter.isAvailable)
             } else {
-                Button {
-                    writeToHealth(samples)
-                } label: {
-                    Label("Write to Apple Health", systemImage: "square.and.arrow.up")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent).tint(.pink)
+                // Mirroring is automatic after every sync; this is just a reassurance line
+                // plus a manual nudge for the impatient.
+                Label("Auto-syncing to Apple Health", systemImage: "checkmark.seal.fill")
+                    .font(.caption).foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
             if let lastWrite {
                 Text(lastWrite).font(.caption).foregroundStyle(.secondary)
@@ -398,12 +437,6 @@ struct ContentView: View {
                     ForEach(order, id: \.0) { stage, color, _ in
                         Rectangle().fill(color)
                             .frame(width: total > 0 ? geo.size.width * mins(stage) / total : 0)
-                    }
-                }
-
-                Section("Settings") {
-                    NavigationLink("User Profile") {
-                        UserProfileSettingsView()
                     }
                 }
             }
@@ -450,26 +483,19 @@ struct ContentView: View {
                 .fill(Color(.secondarySystemGroupedBackground)))
     }
 
-    private func writeToHealth(_ samples: [QuantitySample]) {
+    /// Push everything pending to Apple Health (scalars + sleep + step delta), each gated by
+    /// its own watermark so it never double-writes. Safe to call liberally — it's a no-op
+    /// until the user authorizes and whenever nothing is pending.
+    private func flushHealth() {
+        guard healthAuthorized else { return }
         let store = LocalStore(modelContext)
         let segments = session?.sleepSegments ?? []
-        let steps = session?.steps
         Task {
-            do {
-                let freshSamples = try store.ingest(samples)
-                try await health.write(freshSamples)
-                let freshSleep = try store.ingestSleep(segments)
-                if !freshSleep.isEmpty { try await health.write(sleep: freshSleep) }
-                // Steps: write today's cumulative count over [startOfDay, now].
-                if let steps, steps > 0 {
-                    let startOfDay = Calendar.current.startOfDay(for: Date())
-                    try await health.write([QuantitySample(kind: .steps, start: startOfDay,
-                                                           end: Date(), value: Double(steps))])
-                }
-                lastWrite = "Wrote \(freshSamples.count) samples, \(freshSleep.count) sleep segs"
-                    + (steps.map { ", \($0) steps" } ?? "")
-            } catch {
-                lastWrite = "Error: \(error.localizedDescription)"
+            let r = await health.flushToHealth(store: store, sleepSegments: segments)
+            if r.wroteAnything {
+                lastWrite = "Synced to Health: \(r.samples) samples"
+                    + (r.sleepSegments > 0 ? ", \(r.sleepSegments) sleep segs" : "")
+                    + (r.steps > 0 ? ", \(r.steps) steps" : "")
             }
         }
     }
@@ -492,15 +518,67 @@ struct ContentView: View {
         guard let snapshot = try? LaunchSnapshot.load(from: LocalStore(modelContext)) else { return }
         lastKnownHR = snapshot.lastHeartRate
     }
+}
 
-    /// One-shot foreground refresh: read a live HR, persist it, and update the snapshot.
-    /// Mirrors what the background task does, for an on-demand pull.
-    private func refreshLiveHeartRate() async {
-        guard let hr = await scanner.readLiveHeartRate(timeout: 10) else { return }
-        let sample = QuantitySample(kind: .heartRate, start: Date(), value: Double(hr))
-        if let fresh = try? LocalStore(modelContext).ingest([sample]) {
-            try? await health.write(fresh)
+/// Home-page calories card. Headline = today's estimated burn; secondary lines break it
+/// into resting (BMR prorated over the elapsed day) + active (Edwards-TRIMP from today's
+/// measured HR), then the static BMR/max-HR reference figures. Body inputs (age/weight/
+/// height/sex) still come from the profile page — the ring transmits none of them.
+struct CaloriesCardView: View {
+    // Shared @AppStorage keys with UserProfileSettingsView (single source of truth).
+    @AppStorage("userProfile.age") private var age = 35
+    @AppStorage("userProfile.weightKg") private var weightKg = 70.0
+    @AppStorage("userProfile.heightCm") private var heightCm = 170.0
+    @AppStorage("userProfile.sex") private var sexRaw = BiologicalSex.male.rawValue
+
+    /// Today's HR samples (for the active-calorie TRIMP estimate). Predicate-limited to
+    /// heart rate since start-of-day so the fetch stays small.
+    @Query private var hrSamples: [StoredSample]
+
+    init() {
+        let hr = MetricKind.heartRate.rawValue
+        let dayStart = Calendar.current.startOfDay(for: Date())
+        _hrSamples = Query(
+            filter: #Predicate { $0.kindRaw == hr && $0.start >= dayStart },
+            sort: \.start)
+    }
+
+    private var profile: UserProfile {
+        UserProfile(age: age, weightKg: max(weightKg, 1), heightCm: max(heightCm, 1),
+                    sex: BiologicalSex(rawValue: sexRaw) ?? .male)
+    }
+    private var maxHR: Int { max(220 - age, 1) }
+
+    /// Resting kcal accrued so far today: full-day BMR scaled by the elapsed fraction of today.
+    private var restingToday: Double {
+        let dayStart = Calendar.current.startOfDay(for: Date())
+        let fraction = Date().timeIntervalSince(dayStart) / 86_400
+        return Calories.bmrKcalPerDay(profile: profile) * fraction
+    }
+    /// Active kcal from today's measured HR (0 until HR is measured — it's sparse, so this
+    /// is a rough floor, not a continuous-wear estimate).
+    private var activeToday: Double {
+        let samples = hrSamples.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        return Calories.activeKcal(hrSamples: samples, maxHR: maxHR)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "flame.fill").foregroundStyle(.orange)
+                Text("CALORIES").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            }
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("\(Int((restingToday + activeToday).rounded()))")
+                    .font(.system(size: 40, weight: .bold, design: .rounded))
+                    .monospacedDigit().contentTransition(.numericText())
+                Text("kcal today").font(.subheadline.weight(.semibold)).foregroundStyle(.secondary)
+            }
+            Text("resting \(Int(restingToday.rounded())) · active \(Int(activeToday.rounded()))")
+                .font(.caption).foregroundStyle(.secondary)
+            Text("BMR \(Int(Calories.bmrKcalPerDay(profile: profile).rounded())) kcal/day · max HR \(maxHR) bpm")
+                .font(.caption2).foregroundStyle(.secondary)
         }
-        loadLaunchSnapshot()
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -24,6 +24,9 @@ struct ContentView: View {
     /// link is `ready`. A user "Scan & connect" never sets this, so the auto-refresh can't
     /// fire on top of a manual connect.
     @State private var pendingAutoSync = false
+    /// Tracks whether the ring was at 100 % (charged) in the current connection so the
+    /// charging-complete notification fires exactly once per charge cycle. (#86)
+    @State private var batteryWasFull = false
     /// Last time the foreground auto-refresh ran a sync; debounces repeated foregrounds.
     @State private var lastForegroundSync: Date?
     /// Minimum spacing between foreground auto-syncs — one bounded refresh per foreground,
@@ -51,6 +54,7 @@ struct ContentView: View {
                     if womensHealthEnabled { cycleCalendarCard }
                     trendsNavigationCard
                     syncCard
+                    deviceInfoCard
                     debugCard
                 }
                 .padding()
@@ -108,6 +112,18 @@ struct ContentView: View {
             }
             .onChange(of: session?.monitoring) { _, monitoring in
                 if monitoring == false { flushHealth() }
+            }
+            // Battery: TTE + charging-complete notification (#86).
+            .onChange(of: session?.batteryPercent) { _, pct in
+                guard let pct else { return }
+                let charging = session?.inferredCharging ?? false
+                if BatteryTTE.justReachedFull(percent: pct, inferredCharging: charging,
+                                              wasFull: batteryWasFull) {
+                    batteryWasFull = true
+                    let store = LocalStore(modelContext)
+                    Task { await HealthNotificationCenter().postChargingComplete(store: store) }
+                }
+                if pct < 100 { batteryWasFull = false }
             }
         }
     }
@@ -173,6 +189,26 @@ struct ContentView: View {
         let battery = session?.batteryPercent
         Task { await LocalAlertCenter().evaluate(batteryPercent: battery, healthAuthorized: authorized) }
         evaluateHealthAlerts()
+        evaluateReminders()
+    }
+
+    /// Evaluate the three app-side reminders (#84: sedentary / wear / bedtime) against the
+    /// current session and persisted UserDefaults state, routing survivors through the shared
+    /// notification engine (quiet hours + anti-spam backoff).
+    private func evaluateReminders() {
+        let d = UserDefaults.standard
+        SleepScheduleDefaults.register(d)
+        let bedMinutes  = d.integer(forKey: SleepScheduleDefaults.bedMinutes)
+        let wakeMinutes = d.integer(forKey: SleepScheduleDefaults.wakeMinutes)
+        let sleepEnabled = d.bool(forKey: SleepScheduleDefaults.enabled)
+        let s = session
+        Task {
+            await HealthNotificationCenter().evaluateReminders(
+                session: s,
+                sleepBedMinutes: bedMinutes,
+                sleepWakeMinutes: wakeMinutes,
+                sleepEnabled: sleepEnabled)
+        }
     }
 
     /// Evaluate the user's body-vital alert rules (#73 high-HR / low-SpO2 / elevated-HR-while-inactive
@@ -225,6 +261,14 @@ struct ContentView: View {
                                              : AnyShapeStyle(b <= 20 ? Color.red : Color.secondary))
                         if let asOf = batteryAsOf {
                             Text(asOf).font(.caption2).foregroundStyle(.tertiary)
+                        }
+                        // TTE estimate (#86): only shown when discharging (not inferred charging)
+                        // and the window has enough data for a clean rate.
+                        if session?.inferredCharging != true,
+                           let samples = session?.batteryTTESamples,
+                           let tte = BatteryTTE.timeToEmpty(samples) {
+                            Text("~\(tteString(tte)) est.")
+                                .font(.caption2).foregroundStyle(.tertiary)
                         }
                     }
                 }
@@ -334,6 +378,15 @@ struct ContentView: View {
     private static let rel: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter(); f.unitsStyle = .abbreviated; return f
     }()
+
+    /// Human-readable battery time-to-empty string (#86): "Xh Ym" or just "Xm" for < 1 h.
+    private func tteString(_ tte: TimeInterval) -> String {
+        let totalMin = Int(tte / 60)
+        let h = totalMin / 60
+        let m = totalMin % 60
+        if h > 0 { return m > 0 ? "\(h)h \(m)m" : "\(h)h" }
+        return "\(max(totalMin, 1))m"
+    }
 
     /// SF Symbol for the ring's battery level.
     private func batteryIcon(_ pct: Int) -> String {
@@ -534,6 +587,31 @@ struct ContentView: View {
                 Text(lastWrite).font(.caption).foregroundStyle(.secondary)
             }
         }
+    }
+
+    // MARK: Device Info (#79)
+
+    /// Taps through to the read-only device information screen (FW version / generation /
+    /// manufacturer / MAC address). Sits between the sync card and the debug card.
+    private var deviceInfoCard: some View {
+        NavigationLink {
+            DeviceInfoView(session: session)
+        } label: {
+            card {
+                HStack(spacing: 8) {
+                    Image(systemName: "cpu").foregroundStyle(.teal)
+                    Text("DEVICE INFO")
+                        .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    Spacer()
+                    if let v = session?.firmwareInfo.version, !v.isEmpty {
+                        Text(v).font(.caption).foregroundStyle(.secondary)
+                    }
+                    Image(systemName: "chevron.right")
+                        .font(.caption).foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: Debug

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -21,7 +21,9 @@ struct ContentView: View {
             ScrollView {
                 VStack(spacing: 16) {
                     connectionCard
-                    liveCard
+                    hrCard
+                    spo2Card
+                    stepsCard
                     syncCard
                     debugCard
                 }
@@ -53,37 +55,21 @@ struct ContentView: View {
         }
     }
 
-    // MARK: Live
+    // MARK: Live — two independent sections, but only one reads at a time
 
     private func hrActive() -> Bool { session?.monitoring == true && session?.liveMode == .hr }
     private func spo2Active() -> Bool { session?.monitoring == true && session?.liveMode == .spo2 }
 
-    private var liveCard: some View {
+    /// Heart-rate section. Shows its own latest reading; the value persists as the last
+    /// reading whenever SpO₂ has taken the link (ring measures one metric at a time).
+    private var hrCard: some View {
         card {
-            Text("LIVE").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            metricHeader("HEART RATE", icon: "heart.fill", color: .red, active: hrActive())
+            bigReading(session?.liveHR, unit: "BPM", color: .red, active: hrActive())
 
-            // Big reading = the metric currently being measured (or HR placeholder).
-            let showingSpO2 = spo2Active()
-            HStack(alignment: .center, spacing: 18) {
-                Image(systemName: showingSpO2 ? "lungs.fill" : "heart.fill")
-                    .font(.system(size: 42))
-                    .foregroundStyle(showingSpO2 ? .blue : .red)
-                    .symbolEffect(.pulse, isActive: session?.monitoring == true)
-                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    Text((showingSpO2 ? session?.liveSpO2 : session?.liveHR).map(String.init) ?? "—")
-                        .font(.system(size: 64, weight: .bold, design: .rounded))
-                        .monospacedDigit().contentTransition(.numericText())
-                        .animation(.snappy, value: showingSpO2 ? session?.liveSpO2 : session?.liveHR)
-                    Text(showingSpO2 ? "%" : "BPM")
-                        .font(.title3.weight(.semibold)).foregroundStyle(.secondary)
-                }
-                Spacer()
-            }
-
-            // HR convergence trend: optical HR is a windowed average that climbs over
-            // ~20–60 s of stillness, so a single number is misleading. Show the recent
-            // samples + range so a stuck vs. converging reading is obvious.
-            if !showingSpO2 {
+            if hrActive() {
+                // Optical HR is a windowed average that climbs over ~20–60 s of stillness,
+                // so show the trend/warm-up rather than one misleading number.
                 if let trend = session?.liveHRTrend, trend.count >= 2 {
                     let lo = trend.min() ?? 0, hi = trend.max() ?? 0
                     VStack(alignment: .leading, spacing: 2) {
@@ -94,37 +80,48 @@ struct ContentView: View {
                                       : "range \(lo)–\(hi) bpm (converging)")
                             .font(.caption2).foregroundStyle(.secondary)
                     }
-                } else if session?.monitoring == true, session?.liveHR == nil,
-                          let warm = session?.liveHRWarmup {
-                    // Short HR frames ARE arriving but byte[2] is still climbing out of
-                    // warm-up — tell the user to hold still rather than showing a dead "—".
+                } else if session?.liveHR == nil, let warm = session?.liveHRWarmup {
                     Label("Warming up… (\(warm)) — hold still, keep the ring snug",
                           systemImage: "hourglass")
                         .font(.caption2).foregroundStyle(.orange)
-                } else if session?.monitoring == true, session?.liveHR == nil {
+                } else if session?.liveHR == nil {
                     Text("Waiting for HR frames… if this never moves, the ring isn't in HR mode.")
                         .font(.caption2).foregroundStyle(.secondary)
                 }
+            } else if session?.liveHR != nil {
+                Text("Last reading — tap Measure to refresh.")
+                    .font(.caption2).foregroundStyle(.secondary)
             }
 
-            // Two mutually-exclusive buttons: starting one switches the ring's mode so
-            // the other stops reading (ring measures one metric at a time).
-            HStack(spacing: 12) {
-                liveButton(.hr, title: "Heart rate", active: hrActive(), color: .red,
-                           icon: "heart.fill")
-                liveButton(.spo2, title: "SpO₂", active: spo2Active(), color: .blue,
-                           icon: "lungs.fill")
-            }
-            Text(session?.monitoring == true
-                 ? "Measuring \(showingSpO2 ? "SpO₂" : "heart rate") — the other is off."
-                 : "Pick one to start. Only one reads at a time.")
-                .font(.caption2).foregroundStyle(.secondary)
+            liveButton(.hr, title: "Measure heart rate", active: hrActive(), color: .red,
+                       icon: "heart.fill")
+        }
+    }
 
-            // Always show the steps row once connected — hiding it when nil looked like
-            // "steps don't work." Ring's onboard count refreshes from the 0x10/0x87
-            // descriptor we re-request during monitoring.
-            if session?.ready == true {
-                Divider()
+    /// SpO₂ section — same shape, blue. Latest reading persists when HR has the link.
+    private var spo2Card: some View {
+        card {
+            metricHeader("BLOOD OXYGEN", icon: "lungs.fill", color: .blue, active: spo2Active())
+            bigReading(session?.liveSpO2, unit: "%", color: .blue, active: spo2Active())
+
+            if spo2Active() {
+                Text(session?.liveSpO2 == nil ? "Measuring… hold still." : "Measuring — live.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            } else if session?.liveSpO2 != nil {
+                Text("Last reading — tap Measure to refresh.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+
+            liveButton(.spo2, title: "Measure SpO₂", active: spo2Active(), color: .blue,
+                       icon: "lungs.fill")
+        }
+    }
+
+    /// Steps in its own compact card once connected.
+    @ViewBuilder
+    private var stepsCard: some View {
+        if session?.ready == true {
+            card {
                 let steps = session?.steps
                 Label(steps.map { "\($0) steps today" } ?? "Steps: waiting for ring…",
                       systemImage: "figure.walk")
@@ -136,6 +133,33 @@ struct ContentView: View {
         }
     }
 
+    private func metricHeader(_ title: String, icon: String, color: Color, active: Bool) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon).foregroundStyle(active ? color : .secondary)
+                .symbolEffect(.pulse, isActive: active)
+            Text(title).font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            Spacer()
+            if active {
+                Text("● MEASURING").font(.caption2.weight(.bold)).foregroundStyle(color)
+            }
+        }
+    }
+
+    private func bigReading(_ value: Int?, unit: String, color: Color, active: Bool) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(value.map(String.init) ?? "—")
+                .font(.system(size: 56, weight: .bold, design: .rounded))
+                .monospacedDigit().contentTransition(.numericText())
+                .foregroundStyle(active ? color : .primary)
+                .animation(.snappy, value: value)
+            Text(unit).font(.title3.weight(.semibold)).foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+
+    /// Start/stop control for one metric. Starting one calls `startMonitoring(mode:)`,
+    /// which switches the ring's mode so the other stops reading — preserving the
+    /// "only one at a time" guarantee. Tapping the active one stops entirely.
     private func liveButton(_ mode: RingSession.LiveMode, title: String,
                             active: Bool, color: Color, icon: String) -> some View {
         Button {

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -8,6 +8,9 @@ struct ContentView: View {
     @State private var healthAuthorized = false
     @State private var lastWrite: String?
     @State private var showDebug = false
+    /// Last HR persisted to the store (from a prior session or a background refresh),
+    /// shown on launch before BLE reconnects. #14
+    @State private var lastKnownHR: QuantitySample?
 
     private let health = HealthKitWriter()
 
@@ -35,6 +38,8 @@ struct ContentView: View {
                 // Wire persistence into the scanner/session so the (currently gated)
                 // epoch-sync decoder can persist Layer-A records once enabled. #24
                 scanner.setLocalStore(LocalStore(modelContext))
+                // Surface the last persisted HR immediately, before BLE reconnects. #14
+                loadLaunchSnapshot()
             }
         }
     }
@@ -70,7 +75,9 @@ struct ContentView: View {
     private var hrCard: some View {
         card {
             metricHeader("HEART RATE", icon: "heart.fill", color: .red, active: hrActive())
-            bigReading(session?.liveHR, unit: "BPM", color: .red, active: hrActive())
+            // Fall back to the last persisted reading on launch / before reconnect. #14
+            bigReading(session?.liveHR ?? lastKnownHR.map { Int($0.value) },
+                       unit: "BPM", color: .red, active: hrActive())
 
             if hrActive() {
                 // Optical HR is a windowed average that climbs over ~20–60 s of stillness,
@@ -99,6 +106,9 @@ struct ContentView: View {
                 }
             } else if session?.liveHR != nil {
                 Text("Last reading — tap Measure to refresh.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            } else if lastKnownHR != nil {
+                Text("Last synced reading — connect to refresh.")
                     .font(.caption2).foregroundStyle(.secondary)
             }
 
@@ -382,5 +392,24 @@ struct ContentView: View {
         case .connecting(let n): return "Connecting to \(n)…"
         case .connected(let n): return n
         }
+    }
+
+    // MARK: Background-refresh support (#14)
+
+    /// Load the last persisted HR so the UI can show it immediately on launch.
+    private func loadLaunchSnapshot() {
+        guard let snapshot = try? LaunchSnapshot.load(from: LocalStore(modelContext)) else { return }
+        lastKnownHR = snapshot.lastHeartRate
+    }
+
+    /// One-shot foreground refresh: read a live HR, persist it, and update the snapshot.
+    /// Mirrors what the background task does, for an on-demand pull.
+    private func refreshLiveHeartRate() async {
+        guard let hr = await scanner.readLiveHeartRate(timeout: 10) else { return }
+        let sample = QuantitySample(kind: .heartRate, start: Date(), value: Double(hr))
+        if let fresh = try? LocalStore(modelContext).ingest([sample]) {
+            try? await health.write(fresh)
+        }
+        loadLaunchSnapshot()
     }
 }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -83,14 +83,26 @@ struct ContentView: View {
             // HR convergence trend: optical HR is a windowed average that climbs over
             // ~20–60 s of stillness, so a single number is misleading. Show the recent
             // samples + range so a stuck vs. converging reading is obvious.
-            if !showingSpO2, let trend = session?.liveHRTrend, trend.count >= 2 {
-                let lo = trend.min() ?? 0, hi = trend.max() ?? 0
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(trend.map(String.init).joined(separator: "  "))
-                        .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
-                        .lineLimit(1).minimumScaleFactor(0.6)
-                    Text(lo == hi ? "steady at \(lo) — give it 20–60 s of stillness to settle"
-                                  : "range \(lo)–\(hi) bpm (converging)")
+            if !showingSpO2 {
+                if let trend = session?.liveHRTrend, trend.count >= 2 {
+                    let lo = trend.min() ?? 0, hi = trend.max() ?? 0
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(trend.map(String.init).joined(separator: "  "))
+                            .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
+                            .lineLimit(1).minimumScaleFactor(0.6)
+                        Text(lo == hi ? "steady at \(lo) — give it 20–60 s of stillness to settle"
+                                      : "range \(lo)–\(hi) bpm (converging)")
+                            .font(.caption2).foregroundStyle(.secondary)
+                    }
+                } else if session?.monitoring == true, session?.liveHR == nil,
+                          let warm = session?.liveHRWarmup {
+                    // Short HR frames ARE arriving but byte[2] is still climbing out of
+                    // warm-up — tell the user to hold still rather than showing a dead "—".
+                    Label("Warming up… (\(warm)) — hold still, keep the ring snug",
+                          systemImage: "hourglass")
+                        .font(.caption2).foregroundStyle(.orange)
+                } else if session?.monitoring == true, session?.liveHR == nil {
+                    Text("Waiting for HR frames… if this never moves, the ring isn't in HR mode.")
                         .font(.caption2).foregroundStyle(.secondary)
                 }
             }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -55,33 +55,65 @@ struct ContentView: View {
 
     // MARK: Live
 
+    private var liveModeBinding: Binding<RingSession.LiveMode> {
+        Binding(get: { session?.liveMode ?? .hr },
+                set: { session?.setLiveMode($0) })
+    }
+
     private var liveCard: some View {
         card {
-            Text("LIVE").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-            HStack(alignment: .center, spacing: 20) {
-                Image(systemName: "heart.fill")
-                    .font(.system(size: 44))
-                    .foregroundStyle(.red)
+            HStack {
+                Text("LIVE").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                Spacer()
+                if session?.monitoring == true { ProgressView().controlSize(.small) }
+            }
+            // Primary reading = whichever mode the ring is actively measuring.
+            let measuringHR = session?.liveMode != .spo2
+            HStack(alignment: .center, spacing: 18) {
+                Image(systemName: measuringHR ? "heart.fill" : "lungs.fill")
+                    .font(.system(size: 42))
+                    .foregroundStyle(measuringHR ? .red : .blue)
                     .symbolEffect(.pulse, isActive: session?.monitoring == true)
                 HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    Text(session?.liveHR.map(String.init) ?? "—")
-                        .font(.system(size: 72, weight: .bold, design: .rounded))
-                        .monospacedDigit()
-                        .contentTransition(.numericText())
-                        .animation(.snappy, value: session?.liveHR)
-                    Text("BPM").font(.title3.weight(.semibold)).foregroundStyle(.secondary)
+                    if measuringHR {
+                        Text(session?.liveHR.map(String.init) ?? "—")
+                            .font(.system(size: 64, weight: .bold, design: .rounded))
+                            .monospacedDigit().contentTransition(.numericText())
+                            .animation(.snappy, value: session?.liveHR)
+                        Text("BPM").font(.title3.weight(.semibold)).foregroundStyle(.secondary)
+                    } else {
+                        Text(session?.liveSpO2.map(String.init) ?? "—")
+                            .font(.system(size: 64, weight: .bold, design: .rounded))
+                            .monospacedDigit().contentTransition(.numericText())
+                            .animation(.snappy, value: session?.liveSpO2)
+                        Text("%").font(.title3.weight(.semibold)).foregroundStyle(.secondary)
+                    }
                 }
                 Spacer()
             }
-            if let spo2 = session?.liveSpO2 {
-                Label("SpO₂ \(spo2)%", systemImage: "lungs.fill")
-                    .font(.subheadline).foregroundStyle(.secondary)
+            // Secondary reading (last value of the other metric).
+            HStack(spacing: 16) {
+                if let hr = session?.liveHR, !measuringHR {
+                    Label("\(hr) bpm", systemImage: "heart.fill").foregroundStyle(.red)
+                }
+                if let spo2 = session?.liveSpO2, measuringHR {
+                    Label("\(spo2)%", systemImage: "lungs.fill").foregroundStyle(.blue)
+                }
             }
+            .font(.subheadline)
+
+            Picker("Measure", selection: liveModeBinding) {
+                Text("Heart rate").tag(RingSession.LiveMode.hr)
+                Text("SpO₂").tag(RingSession.LiveMode.spo2)
+            }
+            .pickerStyle(.segmented)
+            .disabled(session?.ready != true)
+
             Button {
                 if session?.monitoring == true { session?.stopLiveMonitoring() }
                 else { session?.startLiveMonitoring() }
             } label: {
-                Label(session?.monitoring == true ? "Stop" : "Start live HR",
+                Label(session?.monitoring == true ? "Stop" : "Start live",
                       systemImage: session?.monitoring == true ? "stop.fill" : "play.fill")
                     .frame(maxWidth: .infinity)
             }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -4,6 +4,7 @@ import OpenRingKit
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.scenePhase) private var scenePhase
     @State private var scanner = RingScanner.shared
     @State private var healthAuthorized = false
     @State private var lastWrite: String?
@@ -11,6 +12,16 @@ struct ContentView: View {
     /// Last HR persisted to the store (from a prior session or a background refresh),
     /// shown on launch before BLE reconnects. #14
     @State private var lastKnownHR: QuantitySample?
+
+    /// Armed when a foreground activation wants a one-shot history sync, fired once the
+    /// link is `ready`. A user "Scan & connect" never sets this, so the auto-refresh can't
+    /// fire on top of a manual connect.
+    @State private var pendingAutoSync = false
+    /// Last time the foreground auto-refresh ran a sync; debounces repeated foregrounds.
+    @State private var lastForegroundSync: Date?
+    /// Minimum spacing between foreground auto-syncs — one bounded refresh per foreground,
+    /// never a loop, and conservative about battery/contention with the official app.
+    private static let autoSyncInterval: TimeInterval = 120
 
     private let health = HealthKitWriter()
 
@@ -46,7 +57,48 @@ struct ContentView: View {
                 // showed a black screen on launch. #14
                 loadLaunchSnapshot()
             }
+            // Foreground auto-refresh: reconnect to the last-known ring and pull fresh data
+            // when the app becomes active, so opening it after a while shows updated vitals
+            // without a manual Scan/Sync.
+            .onChange(of: scenePhase) { _, phase in
+                if phase == .active { handleForegroundActivation() }
+            }
+            // Fire the armed one-shot sync the moment the (re)connected link is ready.
+            .onChange(of: session?.ready) { _, ready in
+                if ready == true { maybeAutoSyncOnReady() }
+            }
         }
+    }
+
+    // MARK: Foreground auto-refresh
+
+    /// On foreground: reconnect by identifier (no scan) to the saved ring and ARM a single
+    /// debounced history sync for when the link is ready. Conservative: skips entirely if
+    /// there's no saved ring or the user is mid-measurement, and never loops.
+    private func handleForegroundActivation() {
+        guard scanner.hasSavedRing else { return }      // never connected — nothing to do
+        if session?.monitoring == true { return }       // don't interrupt a live measurement
+        scanner.reconnectKnownPeripheral()              // idempotent: no-op if already connected
+        if session?.syncing != true { pendingAutoSync = true }
+        // If the link is already up, kick the sync now; otherwise onChange(ready) will.
+        if session?.ready == true { maybeAutoSyncOnReady() }
+    }
+
+    /// One-shot, debounced history sync once the link is `ready`. Only fires for an armed
+    /// foreground activation (not a user Scan), and not while a sync/live read is running.
+    /// `syncHistory()` is itself bounded (watchdog), and the descriptor stream refreshes
+    /// steps/temp meanwhile — so this is a single bounded refresh, not a poll loop.
+    private func maybeAutoSyncOnReady() {
+        guard pendingAutoSync, let session, session.ready,
+              !session.monitoring, !session.syncing else { return }
+        if let last = lastForegroundSync,
+           Date().timeIntervalSince(last) < Self.autoSyncInterval {
+            pendingAutoSync = false   // too soon — consume the request without syncing
+            return
+        }
+        pendingAutoSync = false
+        lastForegroundSync = Date()
+        session.syncHistory()
     }
 
     // MARK: Connection

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -40,6 +40,7 @@ struct ContentView: View {
                 VStack(spacing: 16) {
                     connectionCard
                     vitalsCard
+                    sleepCard
                     caloriesCard
                     syncCard
                     debugCard
@@ -331,16 +332,15 @@ struct ContentView: View {
     private var vitalsCard: some View {
         card {
             Text("VITALS").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-            VitalsTableView(session: session, sleep: sleepSummary)
+            VitalsTableView(session: session)
         }
     }
 
-    /// Sleep summary (total asleep + Deep/Light/REM/Awake breakdown) for the most recent
-    /// night, from the staged segments. Stages are an on-device ESTIMATE — the ring doesn't
-    /// transmit stage labels (PROTOCOL.md §5.3) — so the dashboard labels them "est.".
-    private var sleepSummary: SleepStaging.Summary? {
-        guard let segs = session?.stagedSegments, !segs.isEmpty else { return nil }
-        return SleepStaging.summary(segs)
+    /// Dedicated, always-visible sleep section below vitals. Reads the persisted nightly summary
+    /// so the most recent night stays on screen all day — across reconnects and syncs — and
+    /// reflects a just-finished sync instantly via the live staged segments. (See SleepCardView.)
+    private var sleepCard: some View {
+        SleepCardView(liveSegments: session?.stagedSegments ?? [])
     }
 
     /// Calories on the home page (was buried in the profile page). Headline is today's
@@ -405,44 +405,13 @@ struct ContentView: View {
                 Text(status).font(.caption).foregroundStyle(.secondary)
             }
 
-            if let samples = session?.historySamples, !samples.isEmpty {
-                Divider()
-                metricSummary(samples)
-                if let inBed = session?.sleepSegments.first(where: { $0.stage == .inBed }) {
-                    LabeledContent("Sleep window") {
-                        Text("\(inBed.start.formatted(date: .omitted, time: .shortened))–\(inBed.end.formatted(date: .omitted, time: .shortened))")
-                    }
-                    .font(.subheadline)
-                }
-                if let staged = session?.stagedSegments, !staged.isEmpty {
-                    stageBar(staged)
-                }
+            // The Health mirror controls. What this sync pulled (avg HR/HRV/SpO₂) now lives with
+            // the night it describes — the Sleep card's "overnight average" row — instead of here,
+            // where the overnight averages read as a current "latest from the ring" value and
+            // contradicted the live Vitals readings (HR/SpO₂ are also measured on demand).
+            if session?.historySamples.isEmpty == false {
                 Divider()
                 healthRow
-            }
-        }
-    }
-
-    /// avg HR / HRV / SpO2 across the synced samples.
-    private func metricSummary(_ samples: [QuantitySample]) -> some View {
-        func avg(_ kind: MetricKind, scale: Double = 1) -> String {
-            let vs = samples.filter { $0.kind == kind }.map(\.value)
-            guard !vs.isEmpty else { return "—" }
-            return String(Int((vs.reduce(0, +) / Double(vs.count)) * scale))
-        }
-        return HStack(spacing: 24) {
-            stat("HR", "\(avg(.heartRate))", "bpm")
-            stat("HRV", "\(avg(.hrvSDNN))", "ms")
-            stat("SpO₂", "\(avg(.spo2, scale: 100))", "%")
-        }
-    }
-
-    private func stat(_ label: String, _ value: String, _ unit: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(label).font(.caption).foregroundStyle(.secondary)
-            HStack(alignment: .firstTextBaseline, spacing: 2) {
-                Text(value).font(.title2.weight(.semibold)).monospacedDigit()
-                Text(unit).font(.caption2).foregroundStyle(.secondary)
             }
         }
     }
@@ -472,42 +441,6 @@ struct ContentView: View {
             }
             if let lastWrite {
                 Text(lastWrite).font(.caption).foregroundStyle(.secondary)
-            }
-        }
-    }
-
-    // MARK: Stage bar (experimental)
-
-    private func stageBar(_ segs: [SleepSegment]) -> some View {
-        let order: [(SleepStage, Color, String)] = [
-            (.asleepDeep, .indigo, "Deep"), (.asleepCore, .teal, "Light"),
-            (.asleepREM, .purple, "REM"), (.awake, .orange, "Awake"),
-        ]
-        func mins(_ s: SleepStage) -> Double {
-            segs.filter { $0.stage == s }.reduce(0) { $0 + $1.duration } / 60
-        }
-        let total = order.reduce(0.0) { $0 + mins($1.0) }
-        return VStack(alignment: .leading, spacing: 6) {
-            Text("Stages (experimental)").font(.caption).foregroundStyle(.secondary)
-            GeometryReader { geo in
-                HStack(spacing: 1) {
-                    ForEach(order, id: \.0) { stage, color, _ in
-                        Rectangle().fill(color)
-                            .frame(width: total > 0 ? geo.size.width * mins(stage) / total : 0)
-                    }
-                }
-            }
-            .frame(height: 12)
-            .clipShape(Capsule())
-            HStack(spacing: 12) {
-                ForEach(order, id: \.0) { stage, color, name in
-                    if mins(stage) > 0 {
-                        HStack(spacing: 4) {
-                            Circle().fill(color).frame(width: 7, height: 7)
-                            Text("\(name) \(Int(mins(stage)))m").font(.caption2).foregroundStyle(.secondary)
-                        }
-                    }
-                }
             }
         }
     }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -180,11 +180,14 @@ struct ContentView: View {
                 } else if session?.autoMeasuring == true {
                     ProgressView().controlSize(.small)
                     Text("Auto-measuring…").font(.caption).foregroundStyle(.secondary)
-                } else if hrMeasuring {
-                    // A user HR measure that's converging but hasn't locked — show warm-up
-                    // progress so a fresh Measure reads as "still climbing", not dead/stale (#45 C).
+                } else if session?.userMeasuring == true, session?.livePreparing == true {
+                    // User-initiated: draining the history backlog before live mode starts (#55).
                     ProgressView().controlSize(.small)
-                    Text(hrWarmupText).font(.caption).foregroundStyle(.secondary)
+                    Text("Preparing…").font(.caption).foregroundStyle(.secondary)
+                } else if userMeasureInProgress {
+                    // Polling — sensor warming up; no raw byte shown (#55).
+                    ProgressView().controlSize(.small)
+                    Text(measureStatusText).font(.caption).foregroundStyle(.secondary)
                 }
                 Spacer()
                 // Ring battery (a device stat, not a body vital) sits with the connection. When
@@ -207,6 +210,9 @@ struct ContentView: View {
             // un-activated/un-bonded signature. Until the activate step is reverse-engineered, the
             // only fix is to open the official app once; say so instead of spinning forever.
             if connected, session?.notStreaming == true { activationHint }
+            // User-initiated measure timed out without locking a reading. Persists until the
+            // user taps Measure again (which clears it naturally). (#55)
+            if session?.userMeasureFailed == true { measureFailedHint }
             if !connected {
                 Button {
                     scanner.start()
@@ -235,16 +241,42 @@ struct ContentView: View {
         .background(RoundedRectangle(cornerRadius: 10).fill(Color.orange.opacity(0.12)))
     }
 
-    /// A user (non-auto) HR measurement that's converging but hasn't locked yet (#45 C). The
-    /// auto-measure branch above takes precedence, so this only lights up for a hand-started read.
-    private var hrMeasuring: Bool {
-        session?.monitoring == true && session?.liveMode == .hr && session?.liveHR == nil
+    /// A user (non-auto) measurement that's converging but hasn't locked yet — covers both HR
+    /// and SpO₂ modes. Only true AFTER the preparing (drain) phase so "Preparing…" and
+    /// "Measuring…" are distinct states in the connection-card header. (#55)
+    private var userMeasureInProgress: Bool {
+        session?.userMeasuring == true
+            && session?.monitoring == true
+            && session?.livePreparing == false
+            && (session?.liveMode == .hr ? session?.liveHR == nil : session?.liveSpO2 == nil)
     }
-    /// Warm-up label: surfaces the climbing raw HR byte when present (proves frames are arriving
-    /// and the sensor is warming up vs. no contact), else a plain measuring note.
-    private var hrWarmupText: String {
-        if let w = session?.liveHRWarmup { return "Warming up HR… (\(w))" }
-        return "Measuring HR…"
+    /// Status copy for the polling phase of a user-initiated measure. No raw byte shown —
+    /// the warmup byte value is a low-level sentinel that reads as noise to the user. Instead,
+    /// "Hold still" when frames are arriving (liveHRWarmup != nil) proves contact without
+    /// exposing internals; a plain "Measuring" covers SpO₂ and the no-frame case. (#55)
+    private var measureStatusText: String {
+        if session?.liveMode == .hr {
+            if session?.liveHRWarmup != nil { return "Hold still — getting a reading" }
+            return "Measuring heart rate…"
+        }
+        return "Measuring SpO₂…"
+    }
+    /// Inline failure banner: shown when a user-initiated measure timed out without a lock.
+    /// Styled like `activationHint` (orange, inside the connection card) for visual consistency.
+    /// Dismissed naturally when the user taps Measure again. (#55)
+    private var measureFailedHint: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.circle.fill").foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Reading timed out").font(.subheadline.weight(.medium))
+                Text(session?.userMeasureFailedMessage
+                     ?? "Couldn't get a reading — make sure the ring is worn snugly and not on the charger, then hold still.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.orange.opacity(0.12)))
     }
 
     /// "as of Xm ago" for the connection-header battery, shown only once the link has gone quiet

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -4,7 +4,7 @@ import OpenRingKit
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
-    @State private var scanner = RingScanner()
+    @State private var scanner = RingScanner.shared
     @State private var healthAuthorized = false
     @State private var lastWrite: String?
     @State private var showDebug = false

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -55,72 +55,58 @@ struct ContentView: View {
 
     // MARK: Live
 
-    private var liveModeBinding: Binding<RingSession.LiveMode> {
-        Binding(get: { session?.liveMode ?? .hr },
-                set: { session?.setLiveMode($0) })
-    }
+    private func hrActive() -> Bool { session?.monitoring == true && session?.liveMode == .hr }
+    private func spo2Active() -> Bool { session?.monitoring == true && session?.liveMode == .spo2 }
 
     private var liveCard: some View {
         card {
-            HStack {
-                Text("LIVE").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                Spacer()
-                if session?.monitoring == true { ProgressView().controlSize(.small) }
-            }
-            // Primary reading = whichever mode the ring is actively measuring.
-            let measuringHR = session?.liveMode != .spo2
+            Text("LIVE").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+
+            // Big reading = the metric currently being measured (or HR placeholder).
+            let showingSpO2 = spo2Active()
             HStack(alignment: .center, spacing: 18) {
-                Image(systemName: measuringHR ? "heart.fill" : "lungs.fill")
+                Image(systemName: showingSpO2 ? "lungs.fill" : "heart.fill")
                     .font(.system(size: 42))
-                    .foregroundStyle(measuringHR ? .red : .blue)
+                    .foregroundStyle(showingSpO2 ? .blue : .red)
                     .symbolEffect(.pulse, isActive: session?.monitoring == true)
                 HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    if measuringHR {
-                        Text(session?.liveHR.map(String.init) ?? "—")
-                            .font(.system(size: 64, weight: .bold, design: .rounded))
-                            .monospacedDigit().contentTransition(.numericText())
-                            .animation(.snappy, value: session?.liveHR)
-                        Text("BPM").font(.title3.weight(.semibold)).foregroundStyle(.secondary)
-                    } else {
-                        Text(session?.liveSpO2.map(String.init) ?? "—")
-                            .font(.system(size: 64, weight: .bold, design: .rounded))
-                            .monospacedDigit().contentTransition(.numericText())
-                            .animation(.snappy, value: session?.liveSpO2)
-                        Text("%").font(.title3.weight(.semibold)).foregroundStyle(.secondary)
-                    }
+                    Text((showingSpO2 ? session?.liveSpO2 : session?.liveHR).map(String.init) ?? "—")
+                        .font(.system(size: 64, weight: .bold, design: .rounded))
+                        .monospacedDigit().contentTransition(.numericText())
+                        .animation(.snappy, value: showingSpO2 ? session?.liveSpO2 : session?.liveHR)
+                    Text(showingSpO2 ? "%" : "BPM")
+                        .font(.title3.weight(.semibold)).foregroundStyle(.secondary)
                 }
                 Spacer()
             }
-            // Secondary reading (last value of the other metric).
-            HStack(spacing: 16) {
-                if let hr = session?.liveHR, !measuringHR {
-                    Label("\(hr) bpm", systemImage: "heart.fill").foregroundStyle(.red)
-                }
-                if let spo2 = session?.liveSpO2, measuringHR {
-                    Label("\(spo2)%", systemImage: "lungs.fill").foregroundStyle(.blue)
-                }
-            }
-            .font(.subheadline)
 
-            Picker("Measure", selection: liveModeBinding) {
-                Text("Heart rate").tag(RingSession.LiveMode.hr)
-                Text("SpO₂").tag(RingSession.LiveMode.spo2)
+            // Two mutually-exclusive buttons: starting one switches the ring's mode so
+            // the other stops reading (ring measures one metric at a time).
+            HStack(spacing: 12) {
+                liveButton(.hr, title: "Heart rate", active: hrActive(), color: .red,
+                           icon: "heart.fill")
+                liveButton(.spo2, title: "SpO₂", active: spo2Active(), color: .blue,
+                           icon: "lungs.fill")
             }
-            .pickerStyle(.segmented)
-            .disabled(session?.ready != true)
-
-            Button {
-                if session?.monitoring == true { session?.stopLiveMonitoring() }
-                else { session?.startLiveMonitoring() }
-            } label: {
-                Label(session?.monitoring == true ? "Stop" : "Start live",
-                      systemImage: session?.monitoring == true ? "stop.fill" : "play.fill")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.bordered)
-            .tint(session?.monitoring == true ? .red : .accentColor)
-            .disabled(session?.ready != true)
+            Text(session?.monitoring == true
+                 ? "Measuring \(showingSpO2 ? "SpO₂" : "heart rate") — the other is off."
+                 : "Pick one to start. Only one reads at a time.")
+                .font(.caption2).foregroundStyle(.secondary)
         }
+    }
+
+    private func liveButton(_ mode: RingSession.LiveMode, title: String,
+                            active: Bool, color: Color, icon: String) -> some View {
+        Button {
+            if active { session?.stopLiveMonitoring() }
+            else { session?.startMonitoring(mode: mode) }
+        } label: {
+            Label(active ? "Stop" : title, systemImage: active ? "stop.fill" : icon)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(active ? color : Color(.systemGray3))
+        .disabled(session?.ready != true)
     }
 
     // MARK: Sync + Health

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -207,6 +207,14 @@ struct ContentView: View {
             // un-activated/un-bonded signature. Until the activate step is reverse-engineered, the
             // only fix is to open the official app once; say so instead of spinning forever.
             if connected, session?.notStreaming == true { activationHint }
+            // Connected + streaming, but the ring reads off-wrist / on the charger (#56) — surface
+            // it (estimated) instead of silently backing the auto-measure off. notStreaming takes
+            // precedence (an un-activated ring's wear state is meaningless), and we hide it during
+            // an active measurement so it can't contradict the "measuring" cue.
+            if connected, session?.notStreaming != true, session?.monitoring != true,
+               session?.appearsNotWorn == true {
+                notWornHint
+            }
             if !connected {
                 Button {
                     scanner.start()
@@ -233,6 +241,18 @@ struct ContentView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(10)
         .background(RoundedRectangle(cornerRadius: 10).fill(Color.orange.opacity(0.12)))
+    }
+
+    /// Shown when `RingSession.appearsNotWorn` — connected but the ring reads off-wrist / on the
+    /// charger (a proxy from auto-measures that never lock + a cold skin-temp reading, #56). Honest
+    /// that it's an estimate; manual Measure/Sync are never blocked by it.
+    private var notWornHint: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "pause.circle").foregroundStyle(.secondary)
+            Text("Ring looks off-wrist or charging (estimated) — auto-measure paused")
+                .font(.caption).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// A user (non-auto) HR measurement that's converging but hasn't locked yet (#45 C). The

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -70,7 +70,11 @@ struct ContentView: View {
             if hrActive() {
                 // Optical HR is a windowed average that climbs over ~20–60 s of stillness,
                 // so show the trend/warm-up rather than one misleading number.
-                if let trend = session?.liveHRTrend, trend.count >= 2 {
+                if session?.livePreparing == true {
+                    Label("Preparing… syncing the ring's history first",
+                          systemImage: "arrow.triangle.2.circlepath")
+                        .font(.caption2).foregroundStyle(.secondary)
+                } else if let trend = session?.liveHRTrend, trend.count >= 2 {
                     let lo = trend.min() ?? 0, hi = trend.max() ?? 0
                     VStack(alignment: .leading, spacing: 2) {
                         Text(trend.map(String.init).joined(separator: "  "))
@@ -105,7 +109,8 @@ struct ContentView: View {
             bigReading(session?.liveSpO2, unit: "%", color: .blue, active: spo2Active())
 
             if spo2Active() {
-                Text(session?.liveSpO2 == nil ? "Measuring… hold still." : "Measuring — live.")
+                Text(session?.livePreparing == true ? "Preparing… syncing the ring's history first"
+                     : session?.liveSpO2 == nil ? "Measuring… hold still." : "Measuring — live.")
                     .font(.caption2).foregroundStyle(.secondary)
             } else if session?.liveSpO2 != nil {
                 Text("Last reading — tap Measure to refresh.")

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -133,6 +133,11 @@ struct ContentView: View {
                 } else if session?.autoMeasuring == true {
                     ProgressView().controlSize(.small)
                     Text("Auto-measuring…").font(.caption).foregroundStyle(.secondary)
+                } else if hrMeasuring {
+                    // A user HR measure that's converging but hasn't locked — show warm-up
+                    // progress so a fresh Measure reads as "still climbing", not dead/stale (#45 C).
+                    ProgressView().controlSize(.small)
+                    Text(hrWarmupText).font(.caption).foregroundStyle(.secondary)
                 }
                 Spacer()
                 // Ring battery (a device stat, not a body vital) sits with the connection.
@@ -152,6 +157,18 @@ struct ContentView: View {
                 .buttonStyle(.borderedProminent)
             }
         }
+    }
+
+    /// A user (non-auto) HR measurement that's converging but hasn't locked yet (#45 C). The
+    /// auto-measure branch above takes precedence, so this only lights up for a hand-started read.
+    private var hrMeasuring: Bool {
+        session?.monitoring == true && session?.liveMode == .hr && session?.liveHR == nil
+    }
+    /// Warm-up label: surfaces the climbing raw HR byte when present (proves frames are arriving
+    /// and the sensor is warming up vs. no contact), else a plain measuring note.
+    private var hrWarmupText: String {
+        if let w = session?.liveHRWarmup { return "Warming up HR… (\(w))" }
+        return "Measuring HR…"
     }
 
     /// SF Symbol for the ring's battery level.

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -362,6 +362,9 @@ struct ContentView: View {
                 lastWrite = "Synced to Health: \(r.samples) samples"
                     + (r.sleepSegments > 0 ? ", \(r.sleepSegments) sleep segs" : "")
                     + (r.steps > 0 ? ", \(r.steps) steps" : "")
+                    + (r.restingDays > 0 ? ", \(r.restingDays) resting HR" : "")
+                    + (r.passiveHours > 0 ? ", \(r.passiveHours)h basal" : "")
+                    + (r.activeKcal > 0 ? ", \(Int(r.activeKcal.rounded())) active kcal" : "")
             }
         }
     }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -491,6 +491,7 @@ struct ContentView: View {
                     + (r.restingDays > 0 ? ", \(r.restingDays) resting HR" : "")
                     + (r.passiveHours > 0 ? ", \(r.passiveHours)h basal" : "")
                     + (r.activeKcal > 0 ? ", \(Int(r.activeKcal.rounded())) active kcal" : "")
+                    + (r.naps > 0 ? ", \(r.naps) nap\(r.naps == 1 ? "" : "s")" : "")
             }
         }
     }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -115,7 +115,7 @@ struct ContentView: View {
         }
         .buttonStyle(.borderedProminent)
         .tint(active ? color : Color(.systemGray3))
-        .disabled(session?.ready != true)
+        .disabled(session?.ready != true || session?.syncing == true)   // no live while syncing
     }
 
     // MARK: Sync + Health
@@ -135,8 +135,12 @@ struct ContentView: View {
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
-            .disabled(session?.ready != true || session?.syncing == true)
+            .disabled(session?.ready != true || session?.syncing == true
+                      || session?.monitoring == true)   // stop live before syncing
 
+            if session?.monitoring == true {
+                Text("Stop live HR/SpO₂ before syncing.").font(.caption2).foregroundStyle(.secondary)
+            }
             if let status = session?.syncStatus, session?.syncing != true {
                 Text(status).font(.caption).foregroundStyle(.secondary)
             }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -43,6 +43,8 @@ struct ContentView: View {
                     vitalsStatusCard
                     sleepCard
                     caloriesCard
+                    card { GoalsCardView() }
+                    trendsNavigationCard
                     syncCard
                     debugCard
                 }
@@ -360,6 +362,25 @@ struct ContentView: View {
         SleepCardView(liveSegments: session?.stagedSegments ?? [])
     }
 
+    /// 7-day trends nav card — taps through to the full TrendsView (#74).
+    private var trendsNavigationCard: some View {
+        NavigationLink {
+            TrendsView()
+        } label: {
+            card {
+                HStack(spacing: 8) {
+                    Image(systemName: "chart.line.uptrend.xyaxis").foregroundStyle(.purple)
+                    Text("7-DAY TRENDS")
+                        .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption).foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
     /// Calories on the home page (was buried in the profile page). Headline is today's
     /// estimated burn; the reference figures stay as a small secondary line.
     private var caloriesCard: some View {
@@ -505,9 +526,11 @@ struct ContentView: View {
                 lastWrite = "Synced to Health: \(r.samples) samples"
                     + (r.sleepSegments > 0 ? ", \(r.sleepSegments) sleep segs" : "")
                     + (r.steps > 0 ? ", \(r.steps) steps" : "")
+                    + (r.distanceM > 0 ? ", \(Int(r.distanceM.rounded()))m est." : "")
                     + (r.restingDays > 0 ? ", \(r.restingDays) resting HR" : "")
                     + (r.passiveHours > 0 ? ", \(r.passiveHours)h basal" : "")
                     + (r.activeKcal > 0 ? ", \(Int(r.activeKcal.rounded())) active kcal" : "")
+                    + (r.exerciseMinutes > 0 ? ", \(Int(r.exerciseMinutes.rounded()))min exercise est." : "")
                     + (r.naps > 0 ? ", \(r.naps) nap\(r.naps == 1 ? "" : "s")" : "")
             }
         }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -75,17 +75,16 @@ struct ContentView: View {
     private var vitalsCard: some View {
         card {
             Text("VITALS").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-            VitalsTableView(session: session, sleepMinutes: sleepMinutes)
+            VitalsTableView(session: session, sleep: sleepSummary)
         }
     }
 
-    /// Total time asleep for the most recent night (minutes), from the last sync's
-    /// segments — sum of the asleep stages (excludes the inBed wrapper and awake).
-    private var sleepMinutes: Int? {
-        guard let segs = session?.sleepSegments, !segs.isEmpty else { return nil }
-        let asleep = segs.filter { $0.stage != .inBed && $0.stage != .awake }
-        let secs = asleep.reduce(0.0) { $0 + $1.duration }
-        return secs > 0 ? Int(secs / 60) : nil
+    /// Sleep summary (total asleep + Deep/Light/REM/Awake breakdown) for the most recent
+    /// night, from the staged segments. Stages are an on-device ESTIMATE — the ring doesn't
+    /// transmit stage labels (PROTOCOL.md §5.3) — so the dashboard labels them "est.".
+    private var sleepSummary: SleepStaging.Summary? {
+        guard let segs = session?.stagedSegments, !segs.isEmpty else { return nil }
+        return SleepStaging.summary(segs)
     }
 
     // MARK: Live — two independent sections, but only one reads at a time

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import SwiftData
 import OpenRingKit
 
 struct ContentView: View {
+    @Environment(\.modelContext) private var modelContext
     @State private var scanner = RingScanner()
     @State private var healthAuthorized = false
+    @State private var lastWrite: String?
 
     private let health = HealthKitWriter()
 
@@ -51,19 +54,31 @@ struct ContentView: View {
                                        value: "\(inBed.start.formatted(date: .omitted, time: .shortened))–\(inBed.end.formatted(date: .omitted, time: .shortened))")
                     }
                     if let samples = scanner.session?.historySamples, !samples.isEmpty {
-                        Button("Write to Apple Health") {
-                            Task {
-                                try? await health.write(samples)
-                                if let segs = scanner.session?.sleepSegments, !segs.isEmpty {
-                                    try? await health.write(sleep: segs)
-                                }
-                            }
-                        }
-                        .disabled(!healthAuthorized)
+                        Button("Write to Apple Health") { writeToHealth(samples) }
+                            .disabled(!healthAuthorized)
                     }
+                    if let lastWrite { LabeledContent("Last write", value: lastWrite) }
                 }
             }
             .navigationTitle("OpenRingConn")
+        }
+    }
+
+    /// Persist + dedup via LocalStore (cursor-based), then write only the NEW
+    /// samples/segments to HealthKit — so re-syncs backfill without duplicating.
+    private func writeToHealth(_ samples: [QuantitySample]) {
+        let store = LocalStore(modelContext)
+        let segments = scanner.session?.sleepSegments ?? []
+        Task {
+            do {
+                let freshSamples = try store.ingest(samples)
+                try await health.write(freshSamples)
+                let freshSleep = try store.ingestSleep(segments)
+                if !freshSleep.isEmpty { try await health.write(sleep: freshSleep) }
+                lastWrite = "\(freshSamples.count) new samples, \(freshSleep.count) sleep segs"
+            } catch {
+                lastWrite = "error: \(error.localizedDescription)"
+            }
         }
     }
 

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -40,6 +40,7 @@ struct ContentView: View {
                 VStack(spacing: 16) {
                     connectionCard
                     vitalsCard
+                    vitalsStatusCard
                     sleepCard
                     caloriesCard
                     syncCard
@@ -95,6 +96,7 @@ struct ContentView: View {
                 if syncing == false {
                     recordForegroundSync()
                     flushHealth()
+                    evaluateHealthAlerts()   // #73/#85: a fresh sync may cross a threshold
                 }
             }
             .onChange(of: session?.monitoring) { _, monitoring in
@@ -163,6 +165,16 @@ struct ContentView: View {
         if authorized { observability.markHealthEverAuthorized() }
         let battery = session?.batteryPercent
         Task { await LocalAlertCenter().evaluate(batteryPercent: battery, healthAuthorized: authorized) }
+        evaluateHealthAlerts()
+    }
+
+    /// Evaluate the user's body-vital alert rules (#73 high-HR / low-SpO2 / elevated-HR-while-inactive
+    /// and #85 skin-temp / fever) against the latest stored + just-synced readings, posting any that
+    /// cross a threshold through the ONE shared notification engine (quiet hours + anti-spam backoff).
+    private func evaluateHealthAlerts() {
+        let store = LocalStore(modelContext)
+        let s = session
+        Task { await HealthNotificationCenter().evaluate(store: store, session: s) }
     }
 
     // MARK: Connection
@@ -335,6 +347,11 @@ struct ContentView: View {
             VitalsTableView(session: session)
         }
     }
+
+    /// Vitals Status (#72): compares the latest day's resting HR / overnight SpO₂ / overnight HRV /
+    /// skin temp to the user's PERSONAL 7–30 day baseline and surfaces normal / watch / anomaly with
+    /// the contributing signals (incl. suspected fever). Self-contained view (its own @Query).
+    private var vitalsStatusCard: some View { VitalsStatusCardView() }
 
     /// Dedicated, always-visible sleep section below vitals. Reads the persisted nightly summary
     /// so the most recent night stays on screen all day — across reconnects and syncs — and

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -80,6 +80,21 @@ struct ContentView: View {
                 Spacer()
             }
 
+            // HR convergence trend: optical HR is a windowed average that climbs over
+            // ~20–60 s of stillness, so a single number is misleading. Show the recent
+            // samples + range so a stuck vs. converging reading is obvious.
+            if !showingSpO2, let trend = session?.liveHRTrend, trend.count >= 2 {
+                let lo = trend.min() ?? 0, hi = trend.max() ?? 0
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(trend.map(String.init).joined(separator: "  "))
+                        .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
+                        .lineLimit(1).minimumScaleFactor(0.6)
+                    Text(lo == hi ? "steady at \(lo) — give it 20–60 s of stillness to settle"
+                                  : "range \(lo)–\(hi) bpm (converging)")
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+
             // Two mutually-exclusive buttons: starting one switches the ring's mode so
             // the other stops reading (ring measures one metric at a time).
             HStack(spacing: 12) {
@@ -93,11 +108,16 @@ struct ContentView: View {
                  : "Pick one to start. Only one reads at a time.")
                 .font(.caption2).foregroundStyle(.secondary)
 
-            if let steps = session?.steps {
+            // Always show the steps row once connected — hiding it when nil looked like
+            // "steps don't work." Ring's onboard count refreshes from the 0x10/0x87
+            // descriptor we re-request during monitoring.
+            if session?.ready == true {
                 Divider()
-                Label("\(steps) steps today", systemImage: "figure.walk")
+                let steps = session?.steps
+                Label(steps.map { "\($0) steps today" } ?? "Steps: waiting for ring…",
+                      systemImage: "figure.walk")
                     .font(.subheadline.weight(.medium))
-                    .foregroundStyle(.green)
+                    .foregroundStyle(steps == nil ? Color.secondary : Color.green)
                     .contentTransition(.numericText())
                     .animation(.snappy, value: steps)
             }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -38,7 +38,11 @@ struct ContentView: View {
                 // Wire persistence into the scanner/session so the (currently gated)
                 // epoch-sync decoder can persist Layer-A records once enabled. #24
                 scanner.setLocalStore(LocalStore(modelContext))
-                // Surface the last persisted HR immediately, before BLE reconnects. #14
+            }
+            .task {
+                // Load the last persisted HR AFTER the first frame renders. Running this
+                // SwiftData fetch synchronously in .onAppear blocked the launch render and
+                // showed a black screen on launch. #14
                 loadLaunchSnapshot()
             }
         }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -9,9 +9,6 @@ struct ContentView: View {
     @State private var healthAuthorized = false
     @State private var lastWrite: String?
     @State private var showDebug = false
-    /// Last HR persisted to the store (from a prior session or a background refresh),
-    /// shown on launch before BLE reconnects. #14
-    @State private var lastKnownHR: QuantitySample?
 
     /// Armed when a foreground activation wants a one-shot history sync, fired once the
     /// link is `ready`. A user "Scan & connect" never sets this, so the auto-refresh can't
@@ -36,9 +33,6 @@ struct ContentView: View {
                 VStack(spacing: 16) {
                     connectionCard
                     vitalsCard
-                    hrCard
-                    spo2Card
-                    stepsCard
                     caloriesCard
                     syncCard
                     debugCard
@@ -62,12 +56,10 @@ struct ContentView: View {
                 scanner.setLocalStore(LocalStore(modelContext))
             }
             .task {
-                // Load the last persisted HR AFTER the first frame renders. Running this
-                // SwiftData fetch synchronously in .onAppear blocked the launch render and
-                // showed a black screen on launch. #14
-                loadLaunchSnapshot()
                 // Reflect any prior Health authorization so the UI shows the mirrored state,
                 // and backfill anything the background refresh persisted while we were away.
+                // Runs in `.task` (after first frame), never `.onAppear` — a synchronous store
+                // read there once blocked the launch render into a black screen. #14
                 healthAuthorized = health.isShareAuthorized
                 if healthAuthorized { flushHealth() }
             }
@@ -138,6 +130,9 @@ struct ContentView: View {
                 if session?.syncing == true {
                     ProgressView().controlSize(.small)
                     Text("Updating…").font(.caption).foregroundStyle(.secondary)
+                } else if session?.autoMeasuring == true {
+                    ProgressView().controlSize(.small)
+                    Text("Auto-measuring…").font(.caption).foregroundStyle(.secondary)
                 }
                 Spacer()
                 // Ring battery (a device stat, not a body vital) sits with the connection.
@@ -187,139 +182,10 @@ struct ContentView: View {
         return SleepStaging.summary(segs)
     }
 
-    // MARK: Live — two independent sections, but only one reads at a time
-
-    private func hrActive() -> Bool { session?.monitoring == true && session?.liveMode == .hr }
-    private func spo2Active() -> Bool { session?.monitoring == true && session?.liveMode == .spo2 }
-
-    /// Heart-rate section. Shows its own latest reading; the value persists as the last
-    /// reading whenever SpO₂ has taken the link (ring measures one metric at a time).
-    private var hrCard: some View {
-        card {
-            metricHeader("HEART RATE", icon: "heart.fill", color: .red, active: hrActive())
-            // Fall back to the last persisted reading on launch / before reconnect. #14
-            bigReading(session?.liveHR ?? lastKnownHR.map { Int($0.value) },
-                       unit: "BPM", color: .red, active: hrActive())
-
-            if hrActive() {
-                // Optical HR is a windowed average that climbs over ~20–60 s of stillness,
-                // so show the trend/warm-up rather than one misleading number.
-                if session?.livePreparing == true {
-                    Label("Preparing… syncing the ring's history first",
-                          systemImage: "arrow.triangle.2.circlepath")
-                        .font(.caption2).foregroundStyle(.secondary)
-                } else if let trend = session?.liveHRTrend, trend.count >= 2 {
-                    let lo = trend.min() ?? 0, hi = trend.max() ?? 0
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(trend.map(String.init).joined(separator: "  "))
-                            .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
-                            .lineLimit(1).minimumScaleFactor(0.6)
-                        Text(lo == hi ? "steady at \(lo) — give it 20–60 s of stillness to settle"
-                                      : "range \(lo)–\(hi) bpm (converging)")
-                            .font(.caption2).foregroundStyle(.secondary)
-                    }
-                } else if session?.liveHR == nil, let warm = session?.liveHRWarmup {
-                    Label("Warming up… (\(warm)) — hold still, keep the ring snug",
-                          systemImage: "hourglass")
-                        .font(.caption2).foregroundStyle(.orange)
-                } else if session?.liveHR == nil {
-                    Text("Waiting for HR frames… if this never moves, the ring isn't in HR mode.")
-                        .font(.caption2).foregroundStyle(.secondary)
-                }
-            } else if session?.liveHR != nil {
-                Text("Last reading — tap Measure to refresh.")
-                    .font(.caption2).foregroundStyle(.secondary)
-            } else if lastKnownHR != nil {
-                Text("Last synced reading — connect to refresh.")
-                    .font(.caption2).foregroundStyle(.secondary)
-            }
-
-            liveButton(.hr, title: "Measure heart rate", active: hrActive(), color: .red,
-                       icon: "heart.fill")
-        }
-    }
-
-    /// SpO₂ section — same shape, blue. Latest reading persists when HR has the link.
-    private var spo2Card: some View {
-        card {
-            metricHeader("BLOOD OXYGEN", icon: "lungs.fill", color: .blue, active: spo2Active())
-            bigReading(session?.liveSpO2, unit: "%", color: .blue, active: spo2Active())
-
-            if spo2Active() {
-                Text(session?.livePreparing == true ? "Preparing… syncing the ring's history first"
-                     : session?.liveSpO2 == nil ? "Measuring… hold still." : "Measuring — live.")
-                    .font(.caption2).foregroundStyle(.secondary)
-            } else if session?.liveSpO2 != nil {
-                Text("Last reading — tap Measure to refresh.")
-                    .font(.caption2).foregroundStyle(.secondary)
-            }
-
-            liveButton(.spo2, title: "Measure SpO₂", active: spo2Active(), color: .blue,
-                       icon: "lungs.fill")
-        }
-    }
-
-    /// Steps in its own compact card once connected.
-    @ViewBuilder
-    private var stepsCard: some View {
-        if session?.ready == true {
-            card {
-                let steps = session?.steps
-                Label(steps.map { "\($0) steps today" } ?? "Steps: waiting for ring…",
-                      systemImage: "figure.walk")
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(steps == nil ? Color.secondary : Color.green)
-                    .contentTransition(.numericText())
-                    .animation(.snappy, value: steps)
-            }
-        }
-    }
-
     /// Calories on the home page (was buried in the profile page). Headline is today's
     /// estimated burn; the reference figures stay as a small secondary line.
     private var caloriesCard: some View {
         card { CaloriesCardView() }
-    }
-
-    private func metricHeader(_ title: String, icon: String, color: Color, active: Bool) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: icon).foregroundStyle(active ? color : .secondary)
-                .symbolEffect(.pulse, isActive: active)
-            Text(title).font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-            Spacer()
-            if active {
-                Text("● MEASURING").font(.caption2.weight(.bold)).foregroundStyle(color)
-            }
-        }
-    }
-
-    private func bigReading(_ value: Int?, unit: String, color: Color, active: Bool) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text(value.map(String.init) ?? "—")
-                .font(.system(size: 56, weight: .bold, design: .rounded))
-                .monospacedDigit().contentTransition(.numericText())
-                .foregroundStyle(active ? color : .primary)
-                .animation(.snappy, value: value)
-            Text(unit).font(.title3.weight(.semibold)).foregroundStyle(.secondary)
-            Spacer()
-        }
-    }
-
-    /// Start/stop control for one metric. Starting one calls `startMonitoring(mode:)`,
-    /// which switches the ring's mode so the other stops reading — preserving the
-    /// "only one at a time" guarantee. Tapping the active one stops entirely.
-    private func liveButton(_ mode: RingSession.LiveMode, title: String,
-                            active: Bool, color: Color, icon: String) -> some View {
-        Button {
-            if active { session?.stopLiveMonitoring() }
-            else { session?.startMonitoring(mode: mode) }
-        } label: {
-            Label(active ? "Stop" : title, systemImage: active ? "stop.fill" : icon)
-                .frame(maxWidth: .infinity)
-        }
-        .buttonStyle(.borderedProminent)
-        .tint(active ? color : Color(.systemGray3))
-        .disabled(session?.ready != true || session?.syncing == true)   // no live while syncing
     }
 
     // MARK: Sync + Health
@@ -509,14 +375,6 @@ struct ContentView: View {
         case .connecting(let n): return "Connecting to \(n)…"
         case .connected(let n): return n
         }
-    }
-
-    // MARK: Background-refresh support (#14)
-
-    /// Load the last persisted HR so the UI can show it immediately on launch.
-    private func loadLaunchSnapshot() {
-        guard let snapshot = try? LaunchSnapshot.load(from: LocalStore(modelContext)) else { return }
-        lastKnownHR = snapshot.lastHeartRate
     }
 }
 

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -7,101 +7,265 @@ struct ContentView: View {
     @State private var scanner = RingScanner()
     @State private var healthAuthorized = false
     @State private var lastWrite: String?
+    @State private var showDebug = false
 
     private let health = HealthKitWriter()
 
+    private var session: RingSession? { scanner.session }
+    private var connected: Bool {
+        if case .connected = scanner.state { return true } else { return false }
+    }
+
     var body: some View {
         NavigationStack {
-            List {
-                Section("Ring") {
-                    LabeledContent("Status", value: statusText)
-                    if let hr = scanner.session?.liveHR {
-                        LabeledContent("Live HR", value: "\(hr) bpm")
-                    }
-                    if let frame = scanner.session?.lastFrame {
-                        LabeledContent("Last frame", value: frame)
-                            .font(.caption.monospaced())
-                    }
+            ScrollView {
+                VStack(spacing: 16) {
+                    connectionCard
+                    liveCard
+                    syncCard
+                    debugCard
                 }
-
-                Section("Actions") {
-                    Button("Scan & connect") { scanner.start() }
-                    Button("Start live HR") { scanner.session?.startLiveHR() }
-                        .disabled(scanner.session?.ready != true)
-                    Button("Poll live HR") { scanner.session?.pollLiveHR() }
-                        .disabled(scanner.session?.ready != true)
-                    Button(healthAuthorized ? "Health authorized" : "Authorize Apple Health") {
-                        Task {
-                            try? await health.requestAuthorization()
-                            healthAuthorized = true
-                        }
-                    }
-                    .disabled(!HealthKitWriter.isAvailable)
-                }
-
-                Section("Sleep & history") {
-                    Button(scanner.session?.syncing == true ? "Syncing…" : "Sync history") {
-                        scanner.session?.syncHistory()
-                    }
-                    .disabled(scanner.session?.ready != true || scanner.session?.syncing == true)
-
-                    if let samples = scanner.session?.historySamples, !samples.isEmpty {
-                        LabeledContent("Decoded samples", value: "\(samples.count)")
-                    }
-                    if let segs = scanner.session?.sleepSegments, !segs.isEmpty,
-                       let inBed = segs.first(where: { $0.stage == .inBed }) {
-                        LabeledContent("Sleep window",
-                                       value: "\(inBed.start.formatted(date: .omitted, time: .shortened))–\(inBed.end.formatted(date: .omitted, time: .shortened))")
-                    }
-                    if let staged = scanner.session?.stagedSegments, !staged.isEmpty {
-                        LabeledContent("Stages (experimental)", value: stageSummary(staged))
-                            .font(.caption)
-                    }
-                    if let samples = scanner.session?.historySamples, !samples.isEmpty {
-                        Button("Write to Apple Health") { writeToHealth(samples) }
-                            .disabled(!healthAuthorized)
-                    }
-                    if let lastWrite { LabeledContent("Last write", value: lastWrite) }
-                }
+                .padding()
             }
+            .background(Color(.systemGroupedBackground))
             .navigationTitle("OpenRingConn")
         }
     }
 
-    /// Persist + dedup via LocalStore (cursor-based), then write only the NEW
-    /// samples/segments to HealthKit — so re-syncs backfill without duplicating.
+    // MARK: Connection
+
+    private var connectionCard: some View {
+        card {
+            HStack {
+                Circle().fill(connected ? .green : .secondary).frame(width: 10, height: 10)
+                Text(statusText).font(.subheadline.weight(.medium))
+                Spacer()
+            }
+            if !connected {
+                Button {
+                    scanner.start()
+                } label: {
+                    Label("Scan & connect", systemImage: "dot.radiowaves.left.and.right")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    // MARK: Live
+
+    private var liveCard: some View {
+        card {
+            Text("LIVE").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            HStack(alignment: .center, spacing: 20) {
+                Image(systemName: "heart.fill")
+                    .font(.system(size: 44))
+                    .foregroundStyle(.red)
+                    .symbolEffect(.pulse, isActive: session?.monitoring == true)
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(session?.liveHR.map(String.init) ?? "—")
+                        .font(.system(size: 72, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                        .animation(.snappy, value: session?.liveHR)
+                    Text("BPM").font(.title3.weight(.semibold)).foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            if let spo2 = session?.liveSpO2 {
+                Label("SpO₂ \(spo2)%", systemImage: "lungs.fill")
+                    .font(.subheadline).foregroundStyle(.secondary)
+            }
+            Button {
+                if session?.monitoring == true { session?.stopLiveMonitoring() }
+                else { session?.startLiveMonitoring() }
+            } label: {
+                Label(session?.monitoring == true ? "Stop" : "Start live HR",
+                      systemImage: session?.monitoring == true ? "stop.fill" : "play.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .tint(session?.monitoring == true ? .red : .accentColor)
+            .disabled(session?.ready != true)
+        }
+    }
+
+    // MARK: Sync + Health
+
+    private var syncCard: some View {
+        card {
+            HStack {
+                Text("History & sleep").font(.headline)
+                Spacer()
+                if session?.syncing == true { ProgressView() }
+            }
+            Button {
+                session?.syncHistory()
+            } label: {
+                Label(session?.syncing == true ? "Syncing…" : "Sync from ring",
+                      systemImage: "arrow.triangle.2.circlepath")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(session?.ready != true || session?.syncing == true)
+
+            if let samples = session?.historySamples, !samples.isEmpty {
+                Divider()
+                metricSummary(samples)
+                if let inBed = session?.sleepSegments.first(where: { $0.stage == .inBed }) {
+                    LabeledContent("Sleep window") {
+                        Text("\(inBed.start.formatted(date: .omitted, time: .shortened))–\(inBed.end.formatted(date: .omitted, time: .shortened))")
+                    }
+                    .font(.subheadline)
+                }
+                if let staged = session?.stagedSegments, !staged.isEmpty {
+                    stageBar(staged)
+                }
+                Divider()
+                healthRow(samples)
+            }
+        }
+    }
+
+    /// avg HR / HRV / SpO2 across the synced samples.
+    private func metricSummary(_ samples: [QuantitySample]) -> some View {
+        func avg(_ kind: MetricKind, scale: Double = 1) -> String {
+            let vs = samples.filter { $0.kind == kind }.map(\.value)
+            guard !vs.isEmpty else { return "—" }
+            return String(Int((vs.reduce(0, +) / Double(vs.count)) * scale))
+        }
+        return HStack(spacing: 24) {
+            stat("HR", "\(avg(.heartRate))", "bpm")
+            stat("HRV", "\(avg(.hrvSDNN))", "ms")
+            stat("SpO₂", "\(avg(.spo2, scale: 100))", "%")
+        }
+    }
+
+    private func stat(_ label: String, _ value: String, _ unit: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            HStack(alignment: .firstTextBaseline, spacing: 2) {
+                Text(value).font(.title2.weight(.semibold)).monospacedDigit()
+                Text(unit).font(.caption2).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func healthRow(_ samples: [QuantitySample]) -> some View {
+        VStack(spacing: 8) {
+            if !healthAuthorized {
+                Button {
+                    Task { try? await health.requestAuthorization(); healthAuthorized = true }
+                } label: {
+                    Label("Authorize Apple Health", systemImage: "heart.text.square")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(!HealthKitWriter.isAvailable)
+            } else {
+                Button {
+                    writeToHealth(samples)
+                } label: {
+                    Label("Write to Apple Health", systemImage: "square.and.arrow.up")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent).tint(.pink)
+            }
+            if let lastWrite {
+                Text(lastWrite).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: Stage bar (experimental)
+
+    private func stageBar(_ segs: [SleepSegment]) -> some View {
+        let order: [(SleepStage, Color, String)] = [
+            (.asleepDeep, .indigo, "Deep"), (.asleepCore, .teal, "Light"),
+            (.asleepREM, .purple, "REM"), (.awake, .orange, "Awake"),
+        ]
+        func mins(_ s: SleepStage) -> Double {
+            segs.filter { $0.stage == s }.reduce(0) { $0 + $1.duration } / 60
+        }
+        let total = order.reduce(0.0) { $0 + mins($1.0) }
+        return VStack(alignment: .leading, spacing: 6) {
+            Text("Stages (experimental)").font(.caption).foregroundStyle(.secondary)
+            GeometryReader { geo in
+                HStack(spacing: 1) {
+                    ForEach(order, id: \.0) { stage, color, _ in
+                        Rectangle().fill(color)
+                            .frame(width: total > 0 ? geo.size.width * mins(stage) / total : 0)
+                    }
+                }
+            }
+            .frame(height: 12)
+            .clipShape(Capsule())
+            HStack(spacing: 12) {
+                ForEach(order, id: \.0) { stage, color, name in
+                    if mins(stage) > 0 {
+                        HStack(spacing: 4) {
+                            Circle().fill(color).frame(width: 7, height: 7)
+                            Text("\(name) \(Int(mins(stage)))m").font(.caption2).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Debug
+
+    private var debugCard: some View {
+        card {
+            DisclosureGroup(isExpanded: $showDebug) {
+                Text(session?.lastFrame ?? "no frames yet")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 4)
+            } label: {
+                Text("Debug — last frame").font(.subheadline.weight(.medium))
+            }
+        }
+    }
+
+    // MARK: Helpers
+
+    @ViewBuilder
+    private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 12) { content() }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
     private func writeToHealth(_ samples: [QuantitySample]) {
         let store = LocalStore(modelContext)
-        let segments = scanner.session?.sleepSegments ?? []
+        let segments = session?.sleepSegments ?? []
         Task {
             do {
                 let freshSamples = try store.ingest(samples)
                 try await health.write(freshSamples)
                 let freshSleep = try store.ingestSleep(segments)
                 if !freshSleep.isEmpty { try await health.write(sleep: freshSleep) }
-                lastWrite = "\(freshSamples.count) new samples, \(freshSleep.count) sleep segs"
+                lastWrite = "Wrote \(freshSamples.count) samples, \(freshSleep.count) sleep segments"
             } catch {
-                lastWrite = "error: \(error.localizedDescription)"
+                lastWrite = "Error: \(error.localizedDescription)"
             }
         }
     }
 
-    /// "D 90m · R 115m · L 242m · W 13m" from staged segments (excludes inBed).
-    private func stageSummary(_ segs: [SleepSegment]) -> String {
-        func mins(_ stage: SleepStage) -> Int {
-            Int(segs.filter { $0.stage == stage }.reduce(0) { $0 + $1.duration } / 60)
-        }
-        return "D \(mins(.asleepDeep))m · R \(mins(.asleepREM))m · L \(mins(.asleepCore))m · W \(mins(.awake))m"
-    }
-
     private var statusText: String {
         switch scanner.state {
-        case .idle: return "Idle"
+        case .idle: return "Ready"
         case .poweredOff: return "Bluetooth off"
-        case .unauthorized: return "Bluetooth unauthorized"
+        case .unauthorized: return "Bluetooth not authorized"
         case .scanning: return "Scanning…"
         case .connecting(let n): return "Connecting to \(n)…"
-        case .connected(let n): return "Connected: \(n)"
+        case .connected(let n): return n
         }
     }
 }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -10,6 +10,8 @@ struct ContentView: View {
     @State private var lastWrite: String?
     @State private var showDebug = false
     @State private var showWorkout = false
+    /// Women's health feature gate (#78). Matches the key in UserProfileSettingsView.
+    @AppStorage("userProfile.womensHealthEnabled") private var womensHealthEnabled = false
 
     /// Freshness timestamps mirrored from the UserDefaults-backed observability store (#44).
     /// Held in @State because UserDefaults writes (from the background task / a flush) don't
@@ -46,6 +48,7 @@ struct ContentView: View {
                     caloriesCard
                     card { GoalsCardView() }
                     workoutCard
+                    if womensHealthEnabled { cycleCalendarCard }
                     trendsNavigationCard
                     syncCard
                     debugCard
@@ -387,6 +390,29 @@ struct ContentView: View {
         .sheet(isPresented: $showWorkout) {
             WorkoutView(session: session)
         }
+    }
+
+    /// Cycle calendar nav card — taps through to CycleCalendarView (#78).
+    /// Only rendered when `womensHealthEnabled` (settings toggle). All predictions
+    /// are labeled as estimates in the destination view.
+    private var cycleCalendarCard: some View {
+        NavigationLink {
+            CycleCalendarView()
+        } label: {
+            card {
+                HStack(spacing: 8) {
+                    Image(systemName: "calendar.badge.clock").foregroundStyle(.pink)
+                    Text("CYCLE CALENDAR")
+                        .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption).foregroundStyle(.tertiary)
+                }
+                Text("Log periods, view predictions, fertile window (estimates only)")
+                    .font(.subheadline).foregroundStyle(.secondary)
+            }
+        }
+        .buttonStyle(.plain)
     }
 
     /// 7-day trends nav card — taps through to the full TrendsView (#74).

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -35,6 +35,21 @@ struct ContentView: View {
                     }
                     .disabled(!HealthKitWriter.isAvailable)
                 }
+
+                Section("Sleep & history") {
+                    Button(scanner.session?.syncing == true ? "Syncing…" : "Sync history") {
+                        scanner.session?.syncHistory()
+                    }
+                    .disabled(scanner.session?.ready != true || scanner.session?.syncing == true)
+
+                    if let samples = scanner.session?.historySamples, !samples.isEmpty {
+                        LabeledContent("Decoded samples", value: "\(samples.count)")
+                        Button("Write to Apple Health") {
+                            Task { try? await health.write(samples) }
+                        }
+                        .disabled(!healthAuthorized)
+                    }
+                }
             }
             .navigationTitle("OpenRingConn")
         }

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -10,6 +10,13 @@ struct ContentView: View {
     @State private var lastWrite: String?
     @State private var showDebug = false
 
+    /// Freshness timestamps mirrored from the UserDefaults-backed observability store (#44).
+    /// Held in @State because UserDefaults writes (from the background task / a flush) don't
+    /// publish to SwiftUI — we re-read them on the lifecycle hooks below.
+    @State private var lastSyncAt: Date?
+    @State private var lastHealthWriteAt: Date?
+    private let observability = ObservabilityStore()
+
     /// Armed when a foreground activation wants a one-shot history sync, fired once the
     /// link is `ready`. A user "Scan & connect" never sets this, so the auto-refresh can't
     /// fire on top of a manual connect.
@@ -61,13 +68,19 @@ struct ContentView: View {
                 // Runs in `.task` (after first frame), never `.onAppear` — a synchronous store
                 // read there once blocked the launch render into a black screen. #14
                 healthAuthorized = health.isShareAuthorized
+                if healthAuthorized { observability.markHealthEverAuthorized() }
+                refreshObservability()
                 if healthAuthorized { flushHealth() }
             }
             // Foreground auto-refresh: reconnect to the last-known ring and pull fresh data
             // when the app becomes active, so opening it after a while shows updated vitals
             // without a manual Scan/Sync.
             .onChange(of: scenePhase) { _, phase in
-                if phase == .active { handleForegroundActivation() }
+                if phase == .active {
+                    handleForegroundActivation()
+                    refreshObservability()        // pick up anything a background run wrote
+                    evaluateForegroundAlerts()    // live battery + Health-auth check (#44)
+                }
             }
             // Fire the armed one-shot sync the moment the (re)connected link is ready.
             .onChange(of: session?.ready) { _, ready in
@@ -78,7 +91,10 @@ struct ContentView: View {
             // pending to Health. Each metric is watermark-gated, so this never double-writes
             // and is a no-op until the user has authorized Health.
             .onChange(of: session?.syncing) { _, syncing in
-                if syncing == false { flushHealth() }
+                if syncing == false {
+                    recordForegroundSync()
+                    flushHealth()
+                }
             }
             .onChange(of: session?.monitoring) { _, monitoring in
                 if monitoring == false { flushHealth() }
@@ -115,6 +131,37 @@ struct ContentView: View {
         pendingAutoSync = false
         lastForegroundSync = Date()
         session.syncHistory()
+    }
+
+    // MARK: Observability (#44)
+
+    /// Re-read the persisted freshness timestamps into @State (UserDefaults writes don't publish
+    /// to SwiftUI on their own).
+    private func refreshObservability() {
+        lastSyncAt = observability.lastSuccessfulSync
+        lastHealthWriteAt = observability.lastHealthWrite
+    }
+
+    /// A foreground history sync just finished — record its outcome so "Last successful sync"
+    /// reflects manual/auto foreground refreshes too, not only background runs. Success = the
+    /// session actually received frames on this connection.
+    private func recordForegroundSync() {
+        let gotData = session?.lastFrameAt != nil || (session?.historySamples.isEmpty == false)
+        observability.recordSyncOutcome(kind: .foreground, success: gotData,
+                                        detail: gotData ? "synced from ring" : "no frames received")
+        refreshObservability()
+    }
+
+    /// Foreground alert evaluation with a LIVE battery reading (the background path can't see
+    /// battery once its session is torn down) and a fresh Health-auth probe (so a revocation made
+    /// in Settings while we were away is caught). Latches "ever authorized" so an auth-lost alert
+    /// can be told apart from a user who simply never opted into Health.
+    private func evaluateForegroundAlerts() {
+        let authorized = health.isShareAuthorized
+        healthAuthorized = authorized
+        if authorized { observability.markHealthEverAuthorized() }
+        let battery = session?.batteryPercent
+        Task { await LocalAlertCenter().evaluate(batteryPercent: battery, healthAuthorized: authorized) }
     }
 
     // MARK: Connection
@@ -227,6 +274,32 @@ struct ContentView: View {
 
     // MARK: Sync + Health
 
+    /// Prominent "is this thing actually working?" line (#44): when we last pulled from the ring
+    /// and when we last wrote to Apple Health, tapping through to the full background-activity log.
+    private var freshnessRow: some View {
+        NavigationLink {
+            ActivityLogView()
+        } label: {
+            HStack(spacing: 16) {
+                freshnessStat("Last sync", lastSyncAt)
+                Divider().frame(height: 30)
+                freshnessStat("Health write", lastHealthWriteAt)
+                Spacer()
+                Image(systemName: "chevron.right").font(.caption).foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func freshnessStat(_ label: String, _ date: Date?) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label).font(.caption2).foregroundStyle(.secondary)
+            Text(date.map { Self.rel.localizedString(for: $0, relativeTo: Date()) } ?? "never")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(date == nil ? .secondary : .primary)
+        }
+    }
+
     private var syncCard: some View {
         card {
             HStack {
@@ -234,6 +307,8 @@ struct ContentView: View {
                 Spacer()
                 if session?.syncing == true { ProgressView() }
             }
+            freshnessRow
+            Divider()
             Button {
                 session?.syncHistory()
             } label: {
@@ -301,6 +376,7 @@ struct ContentView: View {
                     Task {
                         try? await health.requestAuthorization()
                         healthAuthorized = health.isShareAuthorized
+                        if healthAuthorized { observability.markHealthEverAuthorized() }
                         flushHealth()   // backfill everything already in the store
                     }
                 } label: {
@@ -396,6 +472,8 @@ struct ContentView: View {
         Task {
             let r = await health.flushToHealth(store: store, sleepSegments: segments)
             if r.wroteAnything {
+                observability.recordHealthWrite()
+                refreshObservability()
                 lastWrite = "Synced to Health: \(r.samples) samples"
                     + (r.sleepSegments > 0 ? ", \(r.sleepSegments) sleep segs" : "")
                     + (r.steps > 0 ? ", \(r.steps) steps" : "")

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -188,10 +188,13 @@ struct ContentView: View {
                 }
                 Spacer()
                 // Ring battery (a device stat, not a body vital) sits with the connection. When
-                // the link has gone quiet (no frames), gray it and show "as of Xm ago" so a
-                // minutes-old % from a silently-dropped link doesn't read as current (#36).
+                // no 0x10/0x87 descriptor has arrived recently, gray it and show "as of Xm ago"
+                // so a minutes-old % doesn't read as current (#36 / #57). Uses the dedicated
+                // battery-freshness window (batteryStale, ~120 s) rather than the broader
+                // liveReadingsStale (360 s) — battery updates only on descriptor frames, not
+                // the 2-s live-HR polls that keep liveReadingsStale fresh during monitoring.
                 if let b = session?.batteryPercent {
-                    let stale = session?.liveReadingsStale == true
+                    let stale = session?.batteryStale == true   // (#57) dedicated battery freshness
                     VStack(alignment: .trailing, spacing: 0) {
                         Label("\(b)%", systemImage: batteryIcon(b))
                             .font(.subheadline.weight(.medium))
@@ -247,10 +250,12 @@ struct ContentView: View {
         return "Measuring HR…"
     }
 
-    /// "as of Xm ago" for the connection-header battery, shown only once the link has gone quiet
-    /// (#36) — a dropped link can otherwise show a minutes-old battery % as if it were current.
+    /// "as of Xm ago" for the connection-header battery, shown once the battery reading goes
+    /// stale (#36 / #57). Anchored to `batteryFetchedAt` (the last 0x10/0x87 descriptor that
+    /// carried a valid %) rather than `lastFrameAt` (any frame), so a 2-s HR poll doesn't
+    /// keep the timestamp artificially fresh while the actual battery reading is minutes old.
     private var batteryAsOf: String? {
-        guard session?.liveReadingsStale == true, let at = session?.lastFrameAt else { return nil }
+        guard session?.batteryStale == true, let at = session?.batteryFetchedAt else { return nil }
         return "as of " + Self.rel.localizedString(for: at, relativeTo: Date())
     }
 
@@ -512,14 +517,24 @@ struct ContentView: View {
         case .unauthorized: return "Bluetooth not authorized"
         case .scanning: return "Scanning…"
         case .connecting(let n):
-            // After repeated failed reconnects (e.g. the ring is on the charger / out of range),
-            // swap the permanent "Connecting…" for a calm note so normal charging doesn't read as
-            // a stuck connection (#35). Heuristic on elapsed attempts — not a charging byte (#41).
-            return scanner.reconnectStalled
-                ? "Ring unreachable or charging — will reconnect automatically"
-                : "Connecting to \(n)…"
+            // After repeated failed reconnects, swap the permanent "Connecting…" for a calm note
+            // (#35). The backoff count is NOT a charging signal — we never claim the ring is
+            // charging from the reconnect count (#41 / #60). "Ring unreachable" is the honest state.
+            // If the last session's battery trend was strictly rising (🟢 proxy), append an honest
+            // "inferred charging" hint — labeled so to avoid overstating certainty (#60).
+            if scanner.reconnectStalled {
+                let chargingHint = lastInferredCharging ? " · inferred charging" : ""
+                return "Ring unreachable\(chargingHint) — reconnecting automatically"
+            }
+            return "Connecting to \(n)…"
         case .connected(let n): return n
         }
+    }
+
+    /// The charging inference from the last session, persisted to UserDefaults before session
+    /// teardown (#60). Readable during the reconnect-backoff window when session == nil.
+    private var lastInferredCharging: Bool {
+        UserDefaults.standard.bool(forKey: "battery.inferredCharging")
     }
 }
 

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -128,6 +128,10 @@ struct ContentView: View {
             .buttonStyle(.borderedProminent)
             .disabled(session?.ready != true || session?.syncing == true)
 
+            if let status = session?.syncStatus, session?.syncing != true {
+                Text(status).font(.caption).foregroundStyle(.secondary)
+            }
+
             if let samples = session?.historySamples, !samples.isEmpty {
                 Divider()
                 metricSummary(samples)

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -31,6 +31,11 @@ struct ContentView: View {
             }
             .background(Color(.systemGroupedBackground))
             .navigationTitle("OpenRingConn")
+            .onAppear {
+                // Wire persistence into the scanner/session so the (currently gated)
+                // epoch-sync decoder can persist Layer-A records once enabled. #24
+                scanner.setLocalStore(LocalStore(modelContext))
+            }
         }
     }
 

--- a/ios/OpenRingConn/ContentView.swift
+++ b/ios/OpenRingConn/ContentView.swift
@@ -44,8 +44,20 @@ struct ContentView: View {
 
                     if let samples = scanner.session?.historySamples, !samples.isEmpty {
                         LabeledContent("Decoded samples", value: "\(samples.count)")
+                    }
+                    if let segs = scanner.session?.sleepSegments, !segs.isEmpty,
+                       let inBed = segs.first(where: { $0.stage == .inBed }) {
+                        LabeledContent("Sleep window",
+                                       value: "\(inBed.start.formatted(date: .omitted, time: .shortened))–\(inBed.end.formatted(date: .omitted, time: .shortened))")
+                    }
+                    if let samples = scanner.session?.historySamples, !samples.isEmpty {
                         Button("Write to Apple Health") {
-                            Task { try? await health.write(samples) }
+                            Task {
+                                try? await health.write(samples)
+                                if let segs = scanner.session?.sleepSegments, !segs.isEmpty {
+                                    try? await health.write(sleep: segs)
+                                }
+                            }
                         }
                         .disabled(!healthAuthorized)
                     }

--- a/ios/OpenRingConn/CycleCalendarView.swift
+++ b/ios/OpenRingConn/CycleCalendarView.swift
@@ -161,11 +161,15 @@ struct CycleCalendarView: View {
             }
         }
         .sheet(isPresented: $showLogSheet) {
+            // Capture the original start so editing can RELOCATE the row (not duplicate it) if
+            // the user changes the start date, and reset the HK watermark on a clinical change.
+            let originalStart = editingEntry?.start
             PeriodLogSheet(editing: editingEntry) { start, end, flow, symptoms, notes in
                 let store = LocalStore(modelContext)
                 try? store.savePeriodEntry(
                     start: start, end: end, flowLevelRaw: flow.rawValue,
-                    symptoms: symptoms.map(\.rawValue), notes: notes)
+                    symptoms: symptoms.map(\.rawValue), notes: notes,
+                    originalStart: originalStart)
             }
         }
     }
@@ -392,10 +396,14 @@ struct CycleCalendarView: View {
             } label: {
                 Image(systemName: "pencil").foregroundStyle(.secondary)
             }
-            // Delete button
+            // Delete button — also removes the previously-written Apple Health sample(s) so a
+            // deleted period doesn't leave an orphaned menstrual-flow entry in Health.
             Button(role: .destructive) {
                 let store = LocalStore(modelContext)
-                try? store.deletePeriodEntry(start: entry.start)
+                let staleUUIDs = (try? store.deletePeriodEntry(start: entry.start)) ?? []
+                if !staleUUIDs.isEmpty {
+                    Task { await HealthKitWriter().deleteMenstrualFlowSamples(uuidStrings: staleUUIDs) }
+                }
             } label: {
                 Image(systemName: "trash").foregroundStyle(.red.opacity(0.8))
             }

--- a/ios/OpenRingConn/CycleCalendarView.swift
+++ b/ios/OpenRingConn/CycleCalendarView.swift
@@ -1,0 +1,533 @@
+import SwiftUI
+import SwiftData
+import OpenRingKit
+
+// Women's health — period logging, cycle calendar + prediction (#78).
+//
+// Gated behind `userProfile.womensHealthEnabled` (settings toggle) so users
+// who don't want this feature never see it. All cycle predictions are labeled
+// as ESTIMATES and come with a medical-disclaimer footer.
+//
+// Temperature corroboration consumes `StoredSleepSummary.skinTempC` via
+// `SkinTempBaseline` — it never adds a new temperature write path. (#78 scope).
+
+// MARK: - Symptoms catalog
+
+enum PeriodSymptom: String, CaseIterable, Identifiable {
+    case cramping      = "Cramping"
+    case bloating      = "Bloating"
+    case headache      = "Headache"
+    case moodChanges   = "Mood changes"
+    case backPain      = "Back pain"
+    case breastTender  = "Breast tenderness"
+    case fatigue       = "Fatigue"
+    case acne          = "Acne"
+    var id: String { rawValue }
+}
+
+// MARK: - Main calendar view
+
+struct CycleCalendarView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    /// All logged period entries, sorted by start.
+    @Query(sort: \StoredPeriodEntry.start, order: .forward)
+    private var entries: [StoredPeriodEntry]
+
+    /// Trailing sleep summaries for skin-temp corroboration — bounded query.
+    @Query(sort: \StoredSleepSummary.night, order: .reverse)
+    private var sleepSummaries: [StoredSleepSummary]
+
+    @State private var displayedMonth: Date = Calendar.current.startOfDay(for: Date())
+    @State private var showLogSheet = false
+    @State private var editingEntry: StoredPeriodEntry? = nil
+
+    private let cal = Calendar.current
+
+    // MARK: Prediction inputs
+
+    /// Convert stored period entries to `CyclePredictor.PeriodEntry` values.
+    private var predictorEntries: [CyclePredictor.PeriodEntry] {
+        entries.map { CyclePredictor.PeriodEntry(start: $0.start, end: $0.end) }
+    }
+
+    /// Nightly skin-temp deviations from the trailing sleep summaries.
+    /// Consumes the canonical `skinTempC` values + the 30-night rolling
+    /// baseline from `SkinTempBaseline` — no new temperature write. (#78)
+    private var skinTempDeviations: [(night: Date, offsetC: Double)] {
+        let nights = sleepSummaries
+            .filter { $0.skinTempC > 0 }
+            .map { SkinTempBaseline.NightlyTemp(night: $0.night, celsius: $0.skinTempC) }
+        guard nights.count >= SkinTempBaseline.minBaselineNights else { return [] }
+        return nights.compactMap { n in
+            // Exclude tonight from the prior nights used to build its own baseline.
+            let prior = nights.filter { $0.night < n.night }
+            guard let base = SkinTempBaseline.baseline(priorNights: prior) else { return nil }
+            return (night: n.night, offsetC: SkinTempBaseline.offset(tonight: n.celsius, baseline: base))
+        }
+    }
+
+    /// The current cycle prediction (nil < 2 logged cycles).
+    private var prediction: CyclePredictor.CyclePrediction? {
+        CyclePredictor.predict(from: predictorEntries, skinTempDeviations: skinTempDeviations)
+    }
+
+    // MARK: Calendar grid helpers
+
+    private var monthStart: Date {
+        cal.date(from: cal.dateComponents([.year, .month], from: displayedMonth))!
+    }
+
+    private var monthTitle: String {
+        monthStart.formatted(.dateTime.year().month(.wide))
+    }
+
+    /// All dates shown in the 6-row grid (padding before month-start with prior-month days).
+    private var gridDates: [Date] {
+        let firstWeekday = cal.component(.weekday, from: monthStart)  // 1 = Sun
+        let offset = firstWeekday - 1   // days to prepend from prior month
+        return (-offset ..< 42 - offset).compactMap {
+            cal.date(byAdding: .day, value: $0, to: monthStart)
+        }
+    }
+
+    // MARK: Day classification
+
+    private func isCurrentMonth(_ date: Date) -> Bool {
+        cal.component(.month, from: date) == cal.component(.month, from: monthStart)
+            && cal.component(.year, from: date) == cal.component(.year, from: monthStart)
+    }
+
+    private func isToday(_ date: Date) -> Bool { cal.isDateInToday(date) }
+
+    private func isLoggedPeriod(_ date: Date) -> Bool {
+        CyclePredictor.isLoggedPeriodDay(date, entries: predictorEntries, calendar: cal)
+    }
+
+    private func isPredictedPeriod(_ date: Date) -> Bool {
+        guard let p = prediction else { return false }
+        return CyclePredictor.isInPredictedPeriod(date, prediction: p, calendar: cal)
+    }
+
+    private func isFertile(_ date: Date) -> Bool {
+        guard let p = prediction else { return false }
+        return CyclePredictor.isInFertileWindow(date, prediction: p, calendar: cal)
+    }
+
+    private func isOvulation(_ date: Date) -> Bool {
+        guard let p = prediction else { return false }
+        return CyclePredictor.isOvulationDay(date, prediction: p, calendar: cal)
+    }
+
+    // MARK: Day tile coloring
+
+    private func tileFill(_ date: Date) -> Color {
+        if isLoggedPeriod(date) { return Color.red.opacity(0.75) }
+        if isPredictedPeriod(date) { return Color.orange.opacity(0.25) }
+        if isOvulation(date) { return Color.green.opacity(0.35) }
+        if isFertile(date) { return Color.green.opacity(0.15) }
+        return Color.clear
+    }
+
+    private func tileTextColor(_ date: Date) -> Color {
+        if !isCurrentMonth(date) { return Color(uiColor: .tertiaryLabel) }
+        if isToday(date) { return .white }
+        if isLoggedPeriod(date) { return .white }
+        return .primary
+    }
+
+    // MARK: Body
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                calendarSection
+                predictionSection
+                loggedPeriodsSection
+                disclaimerFooter
+            }
+            .padding()
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle("Cycle Calendar")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    editingEntry = nil
+                    showLogSheet = true
+                } label: {
+                    Label("Log Period", systemImage: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showLogSheet) {
+            PeriodLogSheet(editing: editingEntry) { start, end, flow, symptoms, notes in
+                let store = LocalStore(modelContext)
+                try? store.savePeriodEntry(
+                    start: start, end: end, flowLevelRaw: flow.rawValue,
+                    symptoms: symptoms.map(\.rawValue), notes: notes)
+            }
+        }
+    }
+
+    // MARK: Calendar section
+
+    private var calendarSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Month nav header
+            HStack {
+                Button {
+                    displayedMonth = cal.date(byAdding: .month, value: -1, to: displayedMonth)!
+                } label: {
+                    Image(systemName: "chevron.left")
+                }
+                Spacer()
+                Text(monthTitle).font(.headline)
+                Spacer()
+                Button {
+                    displayedMonth = cal.date(byAdding: .month, value: 1, to: displayedMonth)!
+                } label: {
+                    Image(systemName: "chevron.right")
+                }
+            }
+
+            // Day-of-week header
+            let weekdaySymbols = cal.veryShortWeekdaySymbols
+            HStack(spacing: 0) {
+                ForEach(weekdaySymbols, id: \.self) { sym in
+                    Text(sym)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+
+            // Day grid — 6 rows × 7 columns
+            let columns = Array(repeating: GridItem(.flexible(), spacing: 2), count: 7)
+            LazyVGrid(columns: columns, spacing: 4) {
+                ForEach(Array(gridDates.enumerated()), id: \.offset) { _, date in
+                    dayTile(date)
+                }
+            }
+
+            legendRow
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16)
+            .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private func dayTile(_ date: Date) -> some View {
+        let dayNum = cal.component(.day, from: date)
+        let fill = tileFill(date)
+        let textColor = tileTextColor(date)
+
+        return ZStack {
+            // Today gets a solid circle
+            if isToday(date) {
+                Circle().fill(Color.accentColor)
+            } else if fill != .clear {
+                Circle().fill(fill)
+            }
+            // Predicted period gets an orange ring outline
+            if isPredictedPeriod(date) && !isLoggedPeriod(date) {
+                Circle().stroke(Color.orange.opacity(0.7), lineWidth: 1.5)
+            }
+            // Ovulation day gets a green ring outline
+            if isOvulation(date) && !isLoggedPeriod(date) {
+                Circle().stroke(Color.green.opacity(0.8), lineWidth: 1.5)
+            }
+            Text("\(dayNum)")
+                .font(.system(size: 14, weight: isToday(date) ? .bold : .regular))
+                .foregroundStyle(textColor)
+        }
+        .frame(width: 36, height: 36)
+    }
+
+    private var legendRow: some View {
+        HStack(spacing: 12) {
+            legendItem(color: .red.opacity(0.75), label: "Period")
+            legendItem(color: .orange.opacity(0.25), label: "Predicted", outlined: .orange)
+            legendItem(color: .green.opacity(0.15), label: "Fertile")
+            legendItem(color: .green.opacity(0.35), label: "Ovulation est.")
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+
+    private func legendItem(color: Color, label: String,
+                             outlined: Color? = nil) -> some View {
+        HStack(spacing: 4) {
+            ZStack {
+                Circle().fill(color).frame(width: 12, height: 12)
+                if let outline = outlined {
+                    Circle().stroke(outline.opacity(0.8), lineWidth: 1).frame(width: 12, height: 12)
+                }
+            }
+            Text(label)
+        }
+    }
+
+    // MARK: Prediction section
+
+    @ViewBuilder
+    private var predictionSection: some View {
+        if let p = prediction {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 6) {
+                    Image(systemName: "chart.xyaxis.line").foregroundStyle(.purple)
+                    Text("CYCLE PREDICTION (ESTIMATE)")
+                        .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                }
+
+                predictionRow("Next period",
+                              value: p.nextPeriodStart.formatted(.dateTime.month().day()),
+                              note: "~\(Int(p.avgCycleLengthDays.rounded()))-day avg cycle")
+
+                predictionRow("Fertile window",
+                              value: fertileWindowLabel(p),
+                              note: "estimate only")
+
+                predictionRow("Ovulation est.",
+                              value: p.ovulationEstimate.formatted(.dateTime.month().day()),
+                              note: "estimate only")
+
+                if p.tempCorroborated {
+                    HStack(spacing: 6) {
+                        Image(systemName: "thermometer.medium").foregroundStyle(.orange)
+                        Text("Skin-temp data shows a rise near the predicted ovulation window (soft signal only — not a confirmation).")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    .padding(8)
+                    .background(RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.orange.opacity(0.1)))
+                }
+
+                Text("Based on \(Int(p.avgCycleLengthDays.rounded()))-day average from \(predictorEntries.count) logged period(s).")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.secondarySystemGroupedBackground)))
+        } else {
+            noPredictionCard
+        }
+    }
+
+    private var noPredictionCard: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "calendar.badge.plus").foregroundStyle(.secondary)
+            Text("Log at least 2 periods to see cycle predictions.")
+                .font(.subheadline).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16)
+            .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private func predictionRow(_ label: String, value: String, note: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label).font(.subheadline)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(value).font(.subheadline.weight(.semibold))
+                Text(note).font(.caption2).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func fertileWindowLabel(_ p: CyclePredictor.CyclePrediction) -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "MMM d"
+        return "\(fmt.string(from: p.fertileWindowStart))–\(fmt.string(from: p.fertileWindowEnd))"
+    }
+
+    // MARK: Logged periods section
+
+    @ViewBuilder
+    private var loggedPeriodsSection: some View {
+        if !entries.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("LOGGED PERIODS")
+                    .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+
+                ForEach(entries.reversed()) { entry in
+                    periodRow(entry)
+                }
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.secondarySystemGroupedBackground)))
+        }
+    }
+
+    private func periodRow(_ entry: StoredPeriodEntry) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Circle().fill(Color.red.opacity(0.7)).frame(width: 8, height: 8)
+                    Text(entry.start.formatted(.dateTime.month().day().year()))
+                        .font(.subheadline.weight(.medium))
+                    if let end = entry.end {
+                        Text("–")
+                        Text(end.formatted(.dateTime.month().day()))
+                            .font(.subheadline)
+                    }
+                }
+                HStack(spacing: 8) {
+                    Text(entry.flowLabel)
+                        .font(.caption).foregroundStyle(.secondary)
+                    if !entry.symptoms.isEmpty {
+                        Text(entry.symptoms.prefix(3).joined(separator: ", "))
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+            }
+            Spacer()
+            // Edit button
+            Button {
+                editingEntry = entry
+                showLogSheet = true
+            } label: {
+                Image(systemName: "pencil").foregroundStyle(.secondary)
+            }
+            // Delete button
+            Button(role: .destructive) {
+                let store = LocalStore(modelContext)
+                try? store.deletePeriodEntry(start: entry.start)
+            } label: {
+                Image(systemName: "trash").foregroundStyle(.red.opacity(0.8))
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: Disclaimer footer
+
+    private var disclaimerFooter: some View {
+        Text("Cycle predictions are statistical estimates only. OpenRingConn is not a medical device. Do not use these estimates for contraception or medical decisions. If you have concerns about your menstrual health, consult a qualified healthcare professional.")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 4)
+    }
+}
+
+// MARK: - Period log sheet
+
+struct PeriodLogSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    /// Existing entry being edited, nil for a new entry.
+    let editing: StoredPeriodEntry?
+    /// Called on save with (start, end?, flowLevel, symptoms, notes).
+    let onSave: (Date, Date?, FlowLevel, Set<PeriodSymptom>, String) throws -> Void
+
+    @State private var startDate: Date
+    @State private var hasEndDate: Bool
+    @State private var endDate: Date
+    @State private var flowLevel: FlowLevel
+    @State private var selectedSymptoms: Set<PeriodSymptom>
+    @State private var notes: String
+    @State private var saveError: String? = nil
+
+    /// App-facing flow level (mirrors StoredPeriodEntry.flowLevelRaw).
+    enum FlowLevel: Int, CaseIterable {
+        case light = 1, medium = 2, heavy = 3
+        var label: String {
+            switch self {
+            case .light:  return "Light"
+            case .medium: return "Medium"
+            case .heavy:  return "Heavy"
+            }
+        }
+    }
+
+    init(editing: StoredPeriodEntry?,
+         onSave: @escaping (Date, Date?, FlowLevel, Set<PeriodSymptom>, String) throws -> Void) {
+        self.editing = editing
+        self.onSave = onSave
+
+        let start = editing?.start ?? Calendar.current.startOfDay(for: Date())
+        let end   = editing?.end
+        let flow  = FlowLevel(rawValue: editing?.flowLevelRaw ?? 2) ?? .medium
+        let syms  = Set(
+            (editing?.symptoms ?? []).compactMap { PeriodSymptom(rawValue: $0) }
+        )
+        _startDate       = State(initialValue: start)
+        _hasEndDate      = State(initialValue: end != nil)
+        _endDate         = State(initialValue: end ?? start.addingTimeInterval(4 * 86_400))
+        _flowLevel       = State(initialValue: flow)
+        _selectedSymptoms = State(initialValue: syms)
+        _notes           = State(initialValue: editing?.notes ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Period") {
+                    DatePicker("Start date", selection: $startDate,
+                               displayedComponents: .date)
+                    Toggle("Log end date", isOn: $hasEndDate)
+                    if hasEndDate {
+                        DatePicker("End date", selection: $endDate,
+                                   in: startDate...,
+                                   displayedComponents: .date)
+                    }
+                }
+
+                Section("Flow") {
+                    Picker("Flow level", selection: $flowLevel) {
+                        ForEach(FlowLevel.allCases, id: \.rawValue) { fl in
+                            Text(fl.label).tag(fl)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("Symptoms") {
+                    ForEach(PeriodSymptom.allCases) { sym in
+                        Toggle(sym.rawValue, isOn: Binding(
+                            get: { selectedSymptoms.contains(sym) },
+                            set: { on in
+                                if on { selectedSymptoms.insert(sym) }
+                                else  { selectedSymptoms.remove(sym) }
+                            }
+                        ))
+                    }
+                }
+
+                Section("Notes") {
+                    TextField("Optional notes", text: $notes, axis: .vertical)
+                        .lineLimit(3...)
+                }
+
+                if let err = saveError {
+                    Section {
+                        Text(err).foregroundStyle(.red).font(.caption)
+                    }
+                }
+            }
+            .navigationTitle(editing == nil ? "Log Period" : "Edit Period")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                }
+            }
+        }
+    }
+
+    private func save() {
+        do {
+            let end = hasEndDate ? endDate : nil
+            try onSave(startDate, end, flowLevel, selectedSymptoms, notes)
+            dismiss()
+        } catch {
+            saveError = error.localizedDescription
+        }
+    }
+}

--- a/ios/OpenRingConn/CycleStore.swift
+++ b/ios/OpenRingConn/CycleStore.swift
@@ -5,8 +5,10 @@ import SwiftData
 // Period entries are user-entered — not derived from BLE data.
 
 /// One manually-logged period entry. Keyed by `start` (UPSERTED so editing the
-/// same period replaces it). `healthWritten` gates the single HealthKit
-/// menstrual-flow write, so re-editing a saved entry doesn't double-write.
+/// same period replaces it). `healthWritten` gates the HealthKit menstrual-flow
+/// write so a finalized period isn't re-written; `hkSampleUUIDs` records the exact
+/// HKCategorySample(s) written for this entry so an edit can delete-then-rewrite
+/// (HealthKit is append-only) and a delete can remove them from Apple Health.
 ///
 /// Every column is defaulted for SwiftData lightweight migration (cf. #21).
 @Model
@@ -21,10 +23,16 @@ final class StoredPeriodEntry {
     var symptoms: [String] = []
     /// Optional free-text notes.
     var notes: String = ""
-    /// True once this entry's flow sample has been written to Apple Health.
-    /// Set after a confirmed save; never overwritten back to false on re-edit
-    /// so the HK sample is only created once (callers delete + re-insert for edits).
+    /// True once this entry has been fully mirrored to Apple Health. For a FINALIZED
+    /// period (`end != nil`) this is set after the write so it isn't re-written. For an
+    /// OPEN period (`end == nil`) it stays `false` so each flush extends the per-day
+    /// samples as new days elapse. Reset to `false` on any clinical edit so the writer
+    /// deletes the stale sample(s) (see `hkSampleUUIDs`) and re-writes the corrected one.
     var healthWritten: Bool = false
+    /// UUID strings of the HKCategorySample(s) last written for this entry. Used to delete
+    /// the prior Apple Health sample(s) before re-writing on edit, and to remove them on
+    /// delete — without this the append-only HealthKit store would accumulate duplicates.
+    var hkSampleUUIDs: [String] = []
     var updatedAt: Date = Date()
 
     init(start: Date = Date.distantPast,
@@ -33,6 +41,7 @@ final class StoredPeriodEntry {
          symptoms: [String] = [],
          notes: String = "",
          healthWritten: Bool = false,
+         hkSampleUUIDs: [String] = [],
          updatedAt: Date = Date()) {
         self.start = start
         self.end = end
@@ -40,6 +49,7 @@ final class StoredPeriodEntry {
         self.symptoms = symptoms
         self.notes = notes
         self.healthWritten = healthWritten
+        self.hkSampleUUIDs = hkSampleUUIDs
         self.updatedAt = updatedAt
     }
 
@@ -57,25 +67,60 @@ final class StoredPeriodEntry {
 
 extension LocalStore {
 
-    /// Upsert one period entry, keyed by `start`. Re-logging the same start date
-    /// updates the existing row (preserving `healthWritten` only when no clinical
-    /// fields changed — callers that change flow/symptoms set `resetHKFlag = true`
-    /// if they want to trigger a fresh HK write).
+    /// Upsert one period entry. When `originalStart` is supplied and differs from `start`,
+    /// the user moved an existing entry's start date: the original row is RELOCATED (not left
+    /// behind as a duplicate), carrying its `hkSampleUUIDs` so the flush can delete the stale
+    /// Apple Health sample(s). On any clinical change (flow / end / symptoms) `healthWritten`
+    /// is reset to `false` so `HealthKitWriter.flushMenstrualFlow` deletes the prior sample(s)
+    /// and re-writes the corrected entry — keeping Apple Health in sync without duplicating.
     func savePeriodEntry(start: Date,
                          end: Date?,
                          flowLevelRaw: Int,
                          symptoms: [String],
-                         notes: String) throws {
+                         notes: String,
+                         originalStart: Date? = nil) throws {
+        // Start-date moved while editing: relocate the original row's identity to the new
+        // start so we don't insert a second row (and orphan the first) for one logical edit.
+        if let orig = originalStart, orig != start {
+            // If a row already occupies the new start, fold it away first (carry its HK
+            // sample UUIDs onto the row we keep so the flush still cleans them up).
+            var inheritedUUIDs: [String] = []
+            let clashDesc = FetchDescriptor<StoredPeriodEntry>(predicate: #Predicate { $0.start == start })
+            if let clash = try? context.fetch(clashDesc).first {
+                inheritedUUIDs = clash.hkSampleUUIDs
+                context.delete(clash)
+            }
+            let origDesc = FetchDescriptor<StoredPeriodEntry>(predicate: #Predicate { $0.start == orig })
+            if let origRow = try? context.fetch(origDesc).first {
+                origRow.start = start
+                origRow.end = end
+                origRow.flowLevelRaw = flowLevelRaw
+                origRow.symptoms = symptoms
+                origRow.notes = notes
+                origRow.updatedAt = Date()
+                origRow.hkSampleUUIDs += inheritedUUIDs
+                origRow.healthWritten = false   // re-write at the new dates; flush deletes old samples
+                try context.save()
+                return
+            }
+            // Original vanished (unexpected) — fall through to a plain upsert by `start`.
+        }
+
         let descriptor = FetchDescriptor<StoredPeriodEntry>(
             predicate: #Predicate { $0.start == start })
         if let existing = try? context.fetch(descriptor).first {
+            let clinicalChanged = existing.flowLevelRaw != flowLevelRaw
+                || existing.end != end
+                || existing.symptoms != symptoms
             existing.end = end
             existing.flowLevelRaw = flowLevelRaw
             existing.symptoms = symptoms
             existing.notes = notes
             existing.updatedAt = Date()
-            // Do NOT reset `healthWritten` here — let the caller decide.
-            // A fresh HK write is triggered by HealthKitWriter once `healthWritten == false`.
+            // Reset the HK watermark only when a clinically-relevant field changed, so the
+            // writer deletes the stale sample(s) and re-writes the corrected entry. (A pure
+            // notes-only edit doesn't touch Apple Health.)
+            if clinicalChanged { existing.healthWritten = false }
         } else {
             context.insert(StoredPeriodEntry(
                 start: start, end: end, flowLevelRaw: flowLevelRaw,
@@ -84,15 +129,18 @@ extension LocalStore {
         try context.save()
     }
 
-    /// Delete a period entry by start date. Also resets the HK written state so
-    /// a re-inserted entry with the same start will be written again.
-    func deletePeriodEntry(start: Date) throws {
+    /// Delete a period entry by start date and return the UUID strings of its previously-written
+    /// Apple Health sample(s) so the caller can remove them from HealthKit (the store layer is
+    /// HK-agnostic). Returns `[]` when the row didn't exist or had no HK samples.
+    @discardableResult
+    func deletePeriodEntry(start: Date) throws -> [String] {
         let descriptor = FetchDescriptor<StoredPeriodEntry>(
             predicate: #Predicate { $0.start == start })
-        if let row = try? context.fetch(descriptor).first {
-            context.delete(row)
-            try context.save()
-        }
+        guard let row = try? context.fetch(descriptor).first else { return [] }
+        let uuids = row.hkSampleUUIDs
+        context.delete(row)
+        try context.save()
+        return uuids
     }
 
     /// All logged period entries, sorted by start (oldest first).
@@ -110,12 +158,17 @@ extension LocalStore {
         return try context.fetch(descriptor)
     }
 
-    /// Mark a period entry as written to Apple Health.
-    func markPeriodEntryWritten(start: Date) throws {
+    /// Record the result of a HealthKit menstrual-flow write for a period entry: store the
+    /// written sample UUIDs and set the written watermark. A FINALIZED period (`finalized ==
+    /// true`) sets `healthWritten = true` so it isn't re-written; an OPEN period keeps it
+    /// `false` so each subsequent flush extends the per-day samples as new days elapse (the
+    /// flush deletes the stored UUIDs before re-writing, so no duplicates accumulate).
+    func recordPeriodEntryHK(start: Date, hkSampleUUIDs: [String], finalized: Bool) throws {
         let descriptor = FetchDescriptor<StoredPeriodEntry>(
             predicate: #Predicate { $0.start == start })
         guard let row = try? context.fetch(descriptor).first else { return }
-        row.healthWritten = true
+        row.hkSampleUUIDs = hkSampleUUIDs
+        row.healthWritten = finalized
         try context.save()
     }
 }

--- a/ios/OpenRingConn/CycleStore.swift
+++ b/ios/OpenRingConn/CycleStore.swift
@@ -1,0 +1,121 @@
+import Foundation
+import SwiftData
+
+// SwiftData model + LocalStore extension for women's health period logging (#78).
+// Period entries are user-entered — not derived from BLE data.
+
+/// One manually-logged period entry. Keyed by `start` (UPSERTED so editing the
+/// same period replaces it). `healthWritten` gates the single HealthKit
+/// menstrual-flow write, so re-editing a saved entry doesn't double-write.
+///
+/// Every column is defaulted for SwiftData lightweight migration (cf. #21).
+@Model
+final class StoredPeriodEntry {
+    @Attribute(.unique) var start: Date = Date.distantPast
+    /// Optional end date — nil when the user hasn't logged the last day yet.
+    var end: Date? = nil
+    /// Flow level: 1 = light, 2 = medium, 3 = heavy. 2 is the default.
+    var flowLevelRaw: Int = 2
+    /// User-selected symptom tags (e.g. "cramping", "bloating"). `[String]` is
+    /// supported by SwiftData directly and small enough to store inline.
+    var symptoms: [String] = []
+    /// Optional free-text notes.
+    var notes: String = ""
+    /// True once this entry's flow sample has been written to Apple Health.
+    /// Set after a confirmed save; never overwritten back to false on re-edit
+    /// so the HK sample is only created once (callers delete + re-insert for edits).
+    var healthWritten: Bool = false
+    var updatedAt: Date = Date()
+
+    init(start: Date = Date.distantPast,
+         end: Date? = nil,
+         flowLevelRaw: Int = 2,
+         symptoms: [String] = [],
+         notes: String = "",
+         healthWritten: Bool = false,
+         updatedAt: Date = Date()) {
+        self.start = start
+        self.end = end
+        self.flowLevelRaw = flowLevelRaw
+        self.symptoms = symptoms
+        self.notes = notes
+        self.healthWritten = healthWritten
+        self.updatedAt = updatedAt
+    }
+
+    /// Convenience flow-level label.
+    var flowLabel: String {
+        switch flowLevelRaw {
+        case 1: return "Light"
+        case 3: return "Heavy"
+        default: return "Medium"
+        }
+    }
+}
+
+// MARK: LocalStore extension — period logging operations
+
+extension LocalStore {
+
+    /// Upsert one period entry, keyed by `start`. Re-logging the same start date
+    /// updates the existing row (preserving `healthWritten` only when no clinical
+    /// fields changed — callers that change flow/symptoms set `resetHKFlag = true`
+    /// if they want to trigger a fresh HK write).
+    func savePeriodEntry(start: Date,
+                         end: Date?,
+                         flowLevelRaw: Int,
+                         symptoms: [String],
+                         notes: String) throws {
+        let descriptor = FetchDescriptor<StoredPeriodEntry>(
+            predicate: #Predicate { $0.start == start })
+        if let existing = try? context.fetch(descriptor).first {
+            existing.end = end
+            existing.flowLevelRaw = flowLevelRaw
+            existing.symptoms = symptoms
+            existing.notes = notes
+            existing.updatedAt = Date()
+            // Do NOT reset `healthWritten` here — let the caller decide.
+            // A fresh HK write is triggered by HealthKitWriter once `healthWritten == false`.
+        } else {
+            context.insert(StoredPeriodEntry(
+                start: start, end: end, flowLevelRaw: flowLevelRaw,
+                symptoms: symptoms, notes: notes))
+        }
+        try context.save()
+    }
+
+    /// Delete a period entry by start date. Also resets the HK written state so
+    /// a re-inserted entry with the same start will be written again.
+    func deletePeriodEntry(start: Date) throws {
+        let descriptor = FetchDescriptor<StoredPeriodEntry>(
+            predicate: #Predicate { $0.start == start })
+        if let row = try? context.fetch(descriptor).first {
+            context.delete(row)
+            try context.save()
+        }
+    }
+
+    /// All logged period entries, sorted by start (oldest first).
+    func allPeriodEntries() throws -> [StoredPeriodEntry] {
+        let descriptor = FetchDescriptor<StoredPeriodEntry>(
+            sortBy: [SortDescriptor(\.start, order: .forward)])
+        return try context.fetch(descriptor)
+    }
+
+    /// Period entries not yet written to Apple Health (oldest first).
+    func pendingPeriodEntries() throws -> [StoredPeriodEntry] {
+        let descriptor = FetchDescriptor<StoredPeriodEntry>(
+            predicate: #Predicate { $0.healthWritten == false },
+            sortBy: [SortDescriptor(\.start, order: .forward)])
+        return try context.fetch(descriptor)
+    }
+
+    /// Mark a period entry as written to Apple Health.
+    func markPeriodEntryWritten(start: Date) throws {
+        let descriptor = FetchDescriptor<StoredPeriodEntry>(
+            predicate: #Predicate { $0.start == start })
+        guard let row = try? context.fetch(descriptor).first else { return }
+        row.healthWritten = true
+        try context.save()
+    }
+}

--- a/ios/OpenRingConn/DeviceInfoView.swift
+++ b/ios/OpenRingConn/DeviceInfoView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import OpenRingKit
+
+/// Read-only device information screen (#79). Shows the DIS fields recovered from the
+/// connected ring — firmware version (with generation label), manufacturer, hardware
+/// revision, and MAC address — plus a non-alarming banner when the firmware version
+/// differs from the pinned build we reverse-engineered.
+///
+/// Data source: the `RingSession`'s `firmwareInfo` property, populated incrementally
+/// as each DIS characteristic is read after connection. Unread fields show "--".
+struct DeviceInfoView: View {
+    var session: RingSession?
+
+    private var info: FirmwareInfo { session?.firmwareInfo ?? FirmwareInfo() }
+
+    var body: some View {
+        List {
+            // FW-pin warning banner — only when a version IS known and it mismatches.
+            if info.hasFirmwareMismatch {
+                Section {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "info.circle.fill").foregroundStyle(.blue)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Firmware version differs from tested build")
+                                .font(.subheadline.weight(.medium))
+                            Text("This app was reverse-engineered on \(FirmwareInfo.pinnedVersion). "
+                                 + "The ring may still work, but some sensor offsets could differ. "
+                                 + "If you see unexpected readings, check for app updates.")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+
+            Section("Firmware") {
+                infoRow("Version",    value: info.version)
+                infoRow("Generation", value: info.generation.rawValue)
+                infoRow("Pinned build", value: FirmwareInfo.pinnedVersion)
+            }
+
+            Section("Hardware") {
+                infoRow("Model",     value: info.modelName)
+                infoRow("Manufacturer", value: info.manufacturer)
+                infoRow("Hardware revision", value: info.hardwareRevision)
+            }
+
+            Section("Connectivity") {
+                infoRow("MAC address", value: info.mac)
+                Text("The MAC address is read from the Device Information Service "
+                     + "(DIS 0x2A23 System ID). CoreBluetooth hides the live MAC on iOS; "
+                     + "this is the only way to recover it without Bluetooth scanning permissions.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Device Info")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func infoRow(_ label: String, value: String?) -> some View {
+        LabeledContent(label) {
+            Text(value?.isEmpty == false ? value! : "--")
+                .foregroundStyle(value?.isEmpty == false ? .primary : .tertiary)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/ios/OpenRingConn/ExportView.swift
+++ b/ios/OpenRingConn/ExportView.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+import SwiftData
+import OpenRingKit
+
+/// Local data export screen (#80). Lets the user pick a date range and format
+/// (CSV or JSON), then shares the exported file via the system share sheet.
+///
+/// All exported data comes from the local SwiftData store — no network calls.
+/// The export is entirely opt-in and is triggered only by an explicit user tap.
+struct ExportView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var startDate: Date = Calendar.current.date(
+        byAdding: .day, value: -30, to: Date()) ?? Date()
+    @State private var endDate: Date = Date()
+    @State private var format: ExportFormat = .csv
+    @State private var exportURL: URL?
+    @State private var showShareSheet = false
+    @State private var isExporting = false
+    @State private var errorMessage: String?
+
+    enum ExportFormat: String, CaseIterable {
+        case csv  = "CSV"
+        case json = "JSON"
+    }
+
+    var body: some View {
+        Form {
+            Section("Date range") {
+                DatePicker("Start", selection: $startDate,
+                           in: ...endDate, displayedComponents: .date)
+                DatePicker("End", selection: $endDate,
+                           in: startDate..., displayedComponents: .date)
+            }
+
+            Section("Format") {
+                Picker("Format", selection: $format) {
+                    ForEach(ExportFormat.allCases, id: \.self) { f in
+                        Text(f.rawValue).tag(f)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section {
+                Button {
+                    Task { await runExport() }
+                } label: {
+                    if isExporting {
+                        HStack {
+                            ProgressView().controlSize(.small)
+                            Text("Preparing export…")
+                        }
+                        .frame(maxWidth: .infinity)
+                    } else {
+                        Label("Export", systemImage: "square.and.arrow.up")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isExporting)
+
+                if let err = errorMessage {
+                    Text(err).font(.caption).foregroundStyle(.red)
+                }
+            }
+
+            Section {
+                Text("Exports all stored samples (HR, SpO₂, temperature, HRV, RR), "
+                     + "nightly sleep summaries, and daily step rollups for the selected range. "
+                     + "Data stays on your device and is only shared when YOU tap Export.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Data Export")
+        .sheet(isPresented: $showShareSheet) {
+            if let url = exportURL {
+                ShareActivityView(url: url)
+            }
+        }
+    }
+
+    // MARK: - Export
+
+    @MainActor
+    private func runExport() async {
+        isExporting = true
+        errorMessage = nil
+        defer { isExporting = false }
+
+        let store = LocalStore(modelContext)
+        let rangeStart = Calendar.current.startOfDay(for: startDate)
+        let rangeEnd   = Calendar.current.date(byAdding: .day, value: 1,
+                                               to: Calendar.current.startOfDay(for: endDate)) ?? endDate
+
+        // Collect samples for all mirrored kinds
+        var sampleRows: [ExportEngine.SampleRow] = []
+        for kind in LocalStore.healthMirroredKinds {
+            let samples = (try? store.samples(kind: kind, from: rangeStart, to: rangeEnd)) ?? []
+            sampleRows += samples.map {
+                ExportEngine.SampleRow(kind: $0.kind.rawValue,
+                                       start: $0.start, end: $0.end, value: $0.value)
+            }
+        }
+        sampleRows.sort { $0.start < $1.start }
+
+        // Collect sleep summaries
+        let nights = (try? store.recentSleepSummaries(limit: 1_000)) ?? []
+        let sleepRows = nights
+            .filter { $0.night >= rangeStart && $0.night < rangeEnd }
+            .map {
+                ExportEngine.SleepRow(
+                    night: $0.night, asleepMin: $0.asleepMin,
+                    deepMin: $0.deepMin, lightMin: $0.lightMin,
+                    remMin: $0.remMin, awakeMin: $0.awakeMin,
+                    efficiency: $0.efficiency, skinTempC: $0.skinTempC,
+                    sleepScore: $0.sleepScore, stressScore: $0.stressScore)
+            }
+
+        // Collect daily rollups
+        let dailies = (try? store.recentDailies(limit: 1_000)) ?? []
+        let dailyRows = dailies
+            .filter { $0.day >= rangeStart && $0.day < rangeEnd }
+            .map { ExportEngine.DailyRow(day: $0.day, steps: $0.steps) }
+
+        // Serialise
+        let content: String
+        let ext: String
+        switch format {
+        case .csv:
+            content = [
+                ExportEngine.samplesCSV(sampleRows),
+                "",
+                ExportEngine.sleepCSV(sleepRows),
+                "",
+                ExportEngine.dailyCSV(dailyRows)
+            ].joined(separator: "\n")
+            ext = "csv"
+        case .json:
+            guard let json = ExportEngine.toJSON(samples: sampleRows, sleep: sleepRows,
+                                                  daily: dailyRows) else {
+                errorMessage = "Failed to serialise JSON — please try again."
+                return
+            }
+            content = json
+            ext = "json"
+        }
+
+        // Write to a temp file
+        let fileName = "openringconn-export-\(isoDate(Date())).\(ext)"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        do {
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            errorMessage = "Failed to write export file: \(error.localizedDescription)"
+            return
+        }
+
+        exportURL = url
+        showShareSheet = true
+    }
+
+    private func isoDate(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f.string(from: date)
+    }
+}
+
+// MARK: - UIActivityViewController bridge
+
+/// Wraps `UIActivityViewController` for the system share sheet (iOS 17 compatible).
+private struct ShareActivityView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: [url], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/ios/OpenRingConn/GoalsCardView.swift
+++ b/ios/OpenRingConn/GoalsCardView.swift
@@ -1,0 +1,173 @@
+// Daily goal progress card (#77) — steps, active calories, activity minutes, sleep.
+//
+// Goals are APP-SIDE ONLY. No values are written to the ring. Activity-minute goal
+// sharpens once the activity-epoch payload is decoded (#93); the current estimate
+// is the basic elevated-HR threshold from ExerciseMinutes.swift (#82).
+//
+// APK evidence: `TargetSyncModel` type 0=step / 1=calorie / 2=sleep / 3=bedSchedule;
+// `workday_step_goal` / `weekend_step_goal` (pp.txt:111295); `calTarget`;
+// `keySettingActivityDurationGoal`; `workdaySleepGoal` / `weekendSleepGoal`.
+
+import SwiftUI
+import SwiftData
+import OpenRingKit
+
+struct GoalsCardView: View {
+
+    // MARK: Goal settings (shared with UserProfileSettingsView / GoalDefaults)
+    @AppStorage(GoalDefaults.workdaySteps)    private var workdaySteps    = GoalDefaults.defaultWorkdaySteps
+    @AppStorage(GoalDefaults.weekendSteps)    private var weekendSteps    = GoalDefaults.defaultWeekendSteps
+    @AppStorage(GoalDefaults.activeKcal)      private var activeKcalGoal  = GoalDefaults.defaultActiveKcal
+    @AppStorage(GoalDefaults.activityMinutes) private var actMinGoal      = GoalDefaults.defaultActivityMinutes
+    @AppStorage(GoalDefaults.workdaySleepMin) private var workdaySleepMin = GoalDefaults.defaultWorkdaySleepMin
+    @AppStorage(GoalDefaults.weekendSleepMin) private var weekendSleepMin = GoalDefaults.defaultWeekendSleepMin
+
+    // Profile (for maxHR → exercise threshold)
+    @AppStorage("userProfile.age") private var age = 35
+
+    // MARK: Data queries (bounded — no unbounded fetches)
+    /// Today's step rollup.
+    @Query private var todayDaily: [StoredDaily]
+    /// Today's HR samples for active-kcal + exercise-minutes estimates.
+    @Query private var todayHR: [StoredSample]
+    /// Most recent sleep summary for last-night's sleep duration + sleep window exclusion.
+    @Query private var latestSleep: [StoredSleepSummary]
+
+    init() {
+        let dayStart = Calendar.current.startOfDay(for: Date())
+        let hourStart = Calendar.current.dateInterval(of: .hour, for: Date())?.start ?? Date()
+        let hrKind = MetricKind.heartRate.rawValue
+
+        _todayDaily = Query(
+            filter: #Predicate<StoredDaily> { $0.day == dayStart },
+            sort: \.day)
+
+        _todayHR = Query(FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == hrKind && $0.start >= dayStart && $0.start <= hourStart && $0.value > 0 },
+            sortBy: [SortDescriptor(\.start, order: .forward)]))
+
+        var sleepDesc = FetchDescriptor<StoredSleepSummary>(
+            sortBy: [SortDescriptor(\.night, order: .reverse)])
+        sleepDesc.fetchLimit = 1
+        _latestSleep = Query(sleepDesc)
+    }
+
+    // MARK: Computed values
+
+    private var stepsGoal: Int {
+        GoalDefaults.isWeekend() ? weekendSteps : workdaySteps
+    }
+
+    private var currentSteps: Int { todayDaily.first?.steps ?? 0 }
+
+    private var currentActiveKcal: Double {
+        let samples = todayHR.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        let maxHR = max(220 - age, 1)
+        return Calories.activeKcal(hrSamples: samples, maxHR: maxHR)
+    }
+
+    private var currentActivityMin: Double {
+        let samples = todayHR.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        let maxHR = max(220 - age, 1)
+        let sleepWindow: DateInterval? = latestSleep.first.flatMap { s in
+            guard s.inBedStart > Date.distantPast else { return nil }
+            return DateInterval(start: s.inBedStart, end: s.inBedEnd)
+        }
+        return ExerciseMinutes.estimate(hrSamples: samples, maxHR: maxHR, sleepWindow: sleepWindow)
+    }
+
+    private var lastNightSleepMin: Int { latestSleep.first?.asleepMin ?? 0 }
+
+    private var sleepGoalMin: Int {
+        GoalDefaults.isWeekend() ? weekendSleepMin : workdaySleepMin
+    }
+
+    private var progress: DailyGoalProgress {
+        DailyGoalProgress(
+            steps:           GoalProgress(current: Double(currentSteps),     goal: Double(stepsGoal)),
+            activeKcal:      GoalProgress(current: currentActiveKcal,        goal: activeKcalGoal),
+            activityMinutes: GoalProgress(current: currentActivityMin,       goal: actMinGoal),
+            sleepMinutes:    GoalProgress(current: Double(lastNightSleepMin), goal: Double(sleepGoalMin))
+        )
+    }
+
+    // MARK: View
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "target").foregroundStyle(.green)
+                Text("DAILY GOALS").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            }
+            HStack(spacing: 16) {
+                goalRing(progress: progress.steps,
+                         label: "Steps",
+                         current: "\(currentSteps.formatted())",
+                         goal: "\(stepsGoal.formatted())",
+                         color: .green)
+                goalRing(progress: progress.activeKcal,
+                         label: "Active kcal",
+                         current: "\(Int(currentActiveKcal))",
+                         goal: "\(Int(activeKcalGoal))",
+                         color: .orange)
+                goalRing(progress: progress.activityMinutes,
+                         label: "Move min\u{B9}",
+                         current: "\(Int(currentActivityMin))",
+                         goal: "\(Int(actMinGoal))",
+                         color: .blue)
+                goalRing(progress: progress.sleepMinutes,
+                         label: "Sleep",
+                         current: formatDuration(lastNightSleepMin),
+                         goal: formatDuration(sleepGoalMin),
+                         color: .purple)
+            }
+            Text("\u{B9} Activity estimate: elevated HR minutes (basic threshold). Full accuracy follows ring activity-payload decode.")
+                .font(.caption2).foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func goalRing(progress p: GoalProgress, label: String,
+                          current: String, goal: String, color: Color) -> some View {
+        VStack(spacing: 4) {
+            ZStack {
+                Circle()
+                    .stroke(color.opacity(0.15), lineWidth: 7)
+                Circle()
+                    .trim(from: 0, to: p.fraction)
+                    .stroke(color, style: StrokeStyle(lineWidth: 7, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .animation(.easeOut(duration: 0.5), value: p.fraction)
+                if p.met {
+                    Image(systemName: "checkmark")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(color)
+                } else {
+                    Text("\(Int(p.fraction * 100))%")
+                        .font(.system(size: 9, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 52, height: 52)
+            Text(current)
+                .font(.caption.weight(.semibold))
+                .monospacedDigit()
+                .contentTransition(.numericText())
+                .foregroundStyle(p.met ? color : .primary)
+            Text(label)
+                .font(.caption2).foregroundStyle(.secondary)
+                .lineLimit(1).minimumScaleFactor(0.7)
+            Text("/ \(goal)")
+                .font(.caption2).foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func formatDuration(_ minutes: Int) -> String {
+        let h = minutes / 60, m = minutes % 60
+        if h > 0 && m > 0 { return "\(h)h\(m)m" }
+        if h > 0 { return "\(h)h" }
+        return "\(m)m"
+    }
+}

--- a/ios/OpenRingConn/GoalsCardView.swift
+++ b/ios/OpenRingConn/GoalsCardView.swift
@@ -35,15 +35,17 @@ struct GoalsCardView: View {
 
     init() {
         let dayStart = Calendar.current.startOfDay(for: Date())
-        let hourStart = Calendar.current.dateInterval(of: .hour, for: Date())?.start ?? Date()
         let hrKind = MetricKind.heartRate.rawValue
 
         _todayDaily = Query(
             filter: #Predicate<StoredDaily> { $0.day == dayStart },
             sort: \.day)
 
+        // Count ALL of today's HR (no upper-hour cap) so this card matches CaloriesCardView and
+        // doesn't lag up to 59 min behind it — e.g. right after an on-demand measurement. The
+        // stable `dayStart` lower bound already keeps the @Query descriptor stable.
         _todayHR = Query(FetchDescriptor<StoredSample>(
-            predicate: #Predicate { $0.kindRaw == hrKind && $0.start >= dayStart && $0.start <= hourStart && $0.value > 0 },
+            predicate: #Predicate { $0.kindRaw == hrKind && $0.start >= dayStart && $0.value > 0 },
             sortBy: [SortDescriptor(\.start, order: .forward)]))
 
         var sleepDesc = FetchDescriptor<StoredSleepSummary>(
@@ -106,7 +108,7 @@ struct GoalsCardView: View {
                          goal: "\(stepsGoal.formatted())",
                          color: .green)
                 goalRing(progress: progress.activeKcal,
-                         label: "Active kcal",
+                         label: "Active kcal\u{B9}",
                          current: "\(Int(currentActiveKcal))",
                          goal: "\(Int(activeKcalGoal))",
                          color: .orange)
@@ -121,7 +123,7 @@ struct GoalsCardView: View {
                          goal: formatDuration(sleepGoalMin),
                          color: .purple)
             }
-            Text("\u{B9} Activity estimate: elevated HR minutes (basic threshold). Full accuracy follows ring activity-payload decode.")
+            Text("\u{B9} Active calories & activity minutes are estimates derived from heart rate (Edwards-TRIMP / elevated-HR threshold). Full accuracy follows the ring activity-payload decode.")
                 .font(.caption2).foregroundStyle(.tertiary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -48,6 +48,7 @@ final class HealthKitWriter {
         for k in MetricKind.allCases {
             if let t = Self.quantityType(for: k) { set.insert(t) }
         }
+        set.insert(HKQuantityType(.basalEnergyBurned))
         set.insert(HKCategoryType(.sleepAnalysis))
         return set
     }
@@ -65,6 +66,40 @@ final class HealthKitWriter {
         }
         guard !hkSamples.isEmpty else { return }
         try await store.save(hkSamples)
+    }
+
+    func writePassiveCalories(profile: UserProfile, date: Date) async throws {
+        let type = HKQuantityType(.basalEnergyBurned)
+        let quantity = HKQuantity(
+            unit: .kilocalorie(),
+            doubleValue: Calories.bmrKcalPerHour(profile: profile)
+        )
+        let sample = HKQuantitySample(
+            type: type,
+            quantity: quantity,
+            start: date,
+            end: date.addingTimeInterval(3600)
+        )
+        try await store.save(sample)
+    }
+
+    func writeActiveCalories(kcal: Double, date: Date) async throws {
+        guard kcal > 0 else { return }
+        let type = HKQuantityType(.activeEnergyBurned)
+        let quantity = HKQuantity(unit: .kilocalorie(), doubleValue: kcal)
+        let sample = HKQuantitySample(
+            type: type,
+            quantity: quantity,
+            start: date,
+            end: date.addingTimeInterval(3600)
+        )
+        try await store.save(sample)
+    }
+
+    func writeActiveCalories(hrSamples: [HRSample], profile: UserProfile, date: Date) async throws {
+        let maxHR = max(220 - profile.age, 1)
+        let kcal = Calories.activeKcal(hrSamples: hrSamples, maxHR: maxHR)
+        try await writeActiveCalories(kcal: kcal, date: date)
     }
 
     /// Write a night as contiguous sleepAnalysis category samples (mapping notes).

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -9,6 +9,13 @@ import OpenRingKit
 @MainActor
 final class HealthKitWriter {
     private let store = HKHealthStore()
+    /// Reentrancy guard for `flushToHealth`: the method suspends on each HealthKit `save`,
+    /// and it's triggered from several UI/lifecycle points — without this, two overlapping
+    /// flushes could both read the same pending set before either advanced its watermark and
+    /// double-write to Health. STATIC so it serializes across the separate foreground and
+    /// background-task `HealthKitWriter` instances too (both run on the MainActor, which reads/
+    /// writes this synchronously around the awaits — they share one underlying SQLite store).
+    private static var isFlushing = false
 
     static var isAvailable: Bool { HKHealthStore.isHealthDataAvailable() }
 
@@ -51,6 +58,59 @@ final class HealthKitWriter {
         set.insert(HKQuantityType(.basalEnergyBurned))
         set.insert(HKCategoryType(.sleepAnalysis))
         return set
+    }
+
+    /// True once the user has granted share access (probed on heart rate as a representative
+    /// type). Lets the app auto-flush to Health without a button tap, while staying silent
+    /// when access was never granted. (HealthKit hides READ status for privacy, but SHARE
+    /// status is reportable.)
+    var isShareAuthorized: Bool {
+        Self.isAvailable
+            && store.authorizationStatus(for: HKQuantityType(.heartRate)) == .sharingAuthorized
+    }
+
+    /// What a `flushToHealth` pass actually wrote (for a status line); all-zero when there
+    /// was nothing pending or share access isn't granted.
+    struct FlushResult: Equatable {
+        var samples = 0, sleepSegments = 0, steps = 0
+        var wroteAnything: Bool { samples > 0 || sleepSegments > 0 || steps > 0 }
+    }
+
+    /// Mirror everything pending into Apple Health in one pass — scalar vitals, the night's
+    /// sleep, and today's step delta — each gated by its own watermark so nothing double-
+    /// writes. No-op (and advances no watermark) when share access isn't granted, so the
+    /// data backfills on the first flush after the user authorizes. Best-effort: a failure
+    /// on one metric doesn't block the others or advance its watermark.
+    @discardableResult
+    func flushToHealth(store: LocalStore, sleepSegments: [SleepSegment] = []) async -> FlushResult {
+        var result = FlushResult()
+        guard isShareAuthorized, !Self.isFlushing else { return result }
+        Self.isFlushing = true
+        defer { Self.isFlushing = false }
+
+        // Scalars: write, THEN advance the watermark, so a failed save backfills next time.
+        if let pending = try? store.pendingHealthSamples(), !pending.isEmpty {
+            do { try await write(pending); try store.markHealthWritten(pending); result.samples = pending.count }
+            catch { /* leave the watermark; retry next flush */ }
+        }
+        // Sleep: same write-then-mark order (a failed save must not lose the night).
+        if let pendingSleep = try? store.pendingHealthSleep(sleepSegments), !pendingSleep.isEmpty {
+            do { try await write(sleep: pendingSleep); try store.markSleepWritten(pendingSleep); result.sleepSegments = pendingSleep.count }
+            catch { /* leave the .sleep cursor; retry next flush */ }
+        }
+        // Steps: the store holds the authoritative pending delta (total − already-written), so
+        // gate on it directly — no live reading needed (this also lets a launch-time flush push
+        // steps the background refresh persisted). HealthKit SUMS stepCount, so writing the
+        // delta lands the day on the running total, not a re-add.
+        if let delta = try? store.pendingStepDelta(), delta > 0 {
+            let startOfDay = Calendar.current.startOfDay(for: Date())
+            do {
+                try await write([QuantitySample(kind: .steps, start: startOfDay, end: Date(), value: Double(delta))])
+                try store.advanceStepsWritten(by: delta)
+                result.steps = delta
+            } catch { /* leave the watermark; retry next flush */ }
+        }
+        return result
     }
 
     func requestAuthorization() async throws {

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -40,6 +40,10 @@ final class HealthKitWriter {
         case .steps: id = .stepCount
         case .activeEnergy: id = .activeEnergyBurned
         case .sleep: return nil
+        // ESTIMATE — steps × stride. See DistanceEstimate.swift for the derivation (#81).
+        case .distance: id = .distanceWalkingRunning
+        // ESTIMATE — elevated HR minutes. Basic threshold; 4-level intensity follows #93 (#82).
+        case .exerciseMinutes: id = .appleExerciseTime
         }
         return HKQuantityType(id)
     }
@@ -55,6 +59,8 @@ final class HealthKitWriter {
         case .steps: return .count()
         case .activeEnergy: return .kilocalorie()
         case .sleep: return .count()                  // unused
+        case .distance: return .meter()              // ESTIMATE — steps × stride
+        case .exerciseMinutes: return .minute()      // ESTIMATE — elevated HR minutes
         }
     }
 
@@ -84,9 +90,12 @@ final class HealthKitWriter {
         var restingDays = 0, passiveHours = 0
         var activeKcal = 0.0
         var naps = 0
+        var distanceM = 0.0         // estimated distance written (#81)
+        var exerciseMinutes = 0.0   // estimated exercise minutes written (#82)
         var wroteAnything: Bool {
             samples > 0 || sleepSegments > 0 || steps > 0
                 || restingDays > 0 || passiveHours > 0 || activeKcal > 0 || naps > 0
+                || distanceM > 0 || exerciseMinutes > 0
         }
     }
 
@@ -115,16 +124,30 @@ final class HealthKitWriter {
         // Naps (#76): each carries its own `healthWritten` flag (NOT the night's `.sleep` cursor),
         // so a daytime nap and the overnight night write independently and never collide.
         result.naps = await flushNaps(store: store)
-        // Steps: the store holds the authoritative pending delta (total − already-written), so
-        // gate on it directly — no live reading needed (this also lets a launch-time flush push
-        // steps the background refresh persisted). HealthKit SUMS stepCount, so writing the
-        // delta lands the day on the running total, not a re-add.
+
+        // Profile is used for distance stride + calorie TRIMP — resolved once here so all three
+        // derived writes use the same snapshot. Body inputs come from the shared profile defaults;
+        // the ring transmits none of them.
+        let profile = Self.storedUserProfile()
+
+        // Steps + distance estimate (#81): write both atomically from the same pending delta.
+        // HealthKit SUMS stepCount / distanceWalkingRunning, so writing the delta lands the
+        // day's running total without re-adding on every sync. Distance is an ESTIMATE
+        // (steps × height-based stride — not GPS) and is labeled as such in HealthKit metadata.
         if let delta = try? store.pendingStepDelta(), delta > 0 {
             let startOfDay = Calendar.current.startOfDay(for: Date())
+            let distanceM = DistanceEstimate.meters(steps: delta, profile: profile)
+            var toWrite: [QuantitySample] = [
+                QuantitySample(kind: .steps, start: startOfDay, end: Date(), value: Double(delta))
+            ]
+            if distanceM > 0 {
+                toWrite.append(QuantitySample(kind: .distance, start: startOfDay, end: Date(), value: distanceM))
+            }
             do {
-                try await write([QuantitySample(kind: .steps, start: startOfDay, end: Date(), value: Double(delta))])
+                try await write(toWrite)
                 try store.advanceStepsWritten(by: delta)
                 result.steps = delta
+                result.distanceM = distanceM
             } catch { /* leave the watermark; retry next flush */ }
         }
         // Derived daily resting HR — one sample per finalized day (#18, #37). Idempotency is a
@@ -132,12 +155,14 @@ final class HealthKitWriter {
         // `hk:` cursor rows belong to the raw-sample mirror above.
         result.restingDays = await flushRestingHR(local: store, sleepSegments: sleepSegments)
 
-        // Energy: passive (hourly BMR) + active (HR-derived Edwards TRIMP). Each carries its own
-        // UserDefaults watermark so repeated flushes never double-count (#37). Body inputs come
-        // from the shared profile defaults — the ring transmits none of them.
-        let profile = Self.storedUserProfile()
+        // Energy: passive (hourly BMR) + active (HR-derived Edwards TRIMP). Watermark-gated (#37).
         result.passiveHours = await flushPassiveCalories(profile: profile)
         result.activeKcal = await flushActiveCalories(local: store, profile: profile)
+
+        // Exercise minutes estimate (#82): elevated-HR minutes outside the sleep window.
+        // ESTIMATE — basic 50% maxHR threshold. Full 4-level intensity follows #93 decode.
+        result.exerciseMinutes = await flushExerciseMinutes(local: store, profile: profile)
+
         return result
     }
 
@@ -205,6 +230,11 @@ final class HealthKitWriter {
     static func metadata(for kind: MetricKind) -> [String: Any]? {
         switch kind {
         case .hrvSDNN: return [hrvStatisticMetadataKey: "RMSSD"]
+        // Distance is an ESTIMATE (steps × height-based stride, not GPS). Tag it so Health
+        // readers can filter or label it appropriately (#81). Replaced by decoded device
+        // distance once the activity-epoch [15:22] payload is decoded (#93).
+        case .distance: return [HKMetadataKeyWasUserEntered: false,
+                                "OpenRingConnDistanceSource": "steps×stride-estimate"]
         default: return nil
         }
     }
@@ -262,6 +292,11 @@ final class HealthKitWriter {
     private static let basalWatermarkKey = "hk.basalEnergy.nextHour" // first hour not yet written
     private static let activeDayKey = "hk.activeEnergy.day"          // start-of-day of the accumulator
     private static let activeWrittenKey = "hk.activeEnergy.writtenKcal"
+    // Exercise minutes (#82) watermark — like active energy, delta-based per day.
+    private static let exerciseDayKey     = "hk.exerciseTime.day"         // start-of-day
+    private static let exerciseWrittenKey = "hk.exerciseTime.writtenMin"  // total minutes already pushed
+    // Metadata key for estimated exercise time samples
+    static let exerciseEstimateMetadataKey = "OpenRingConnExerciseTimeEstimated"
     /// A day's resting HR is finalized once the day is ~half over, so a pre-dawn flush can't
     /// freeze a partial-night value, yet last night's RHR still lands the same day (by midday).
     private static let restingFinalizationDelay: TimeInterval = 12 * 3600
@@ -374,6 +409,54 @@ final class HealthKitWriter {
 
     private static func startOfHour(_ date: Date, _ cal: Calendar = .current) -> Date {
         cal.date(from: cal.dateComponents([.year, .month, .day, .hour], from: date)) ?? date
+    }
+
+    /// Write today's exercise-minute DELTA (elevated-HR minutes not yet pushed to Health),
+    /// returning minutes written. ESTIMATE — basic 50% maxHR threshold (#82).
+    /// Full 4-level intensity (Vigorous/Moderate/Low/Inactive) follows the activity-epoch
+    /// decode (#93). Uses a per-day UserDefaults accumulator identical to active energy.
+    private func flushExerciseMinutes(local: LocalStore, profile: UserProfile) async -> Double {
+        let cal = Calendar.current
+        let now = Date()
+        let today = cal.startOfDay(for: now)
+        let defaults = UserDefaults.standard
+        let storedDay = Date(timeIntervalSince1970: defaults.double(forKey: Self.exerciseDayKey))
+        var writtenMin = defaults.double(forKey: Self.exerciseWrittenKey)
+        if cal.startOfDay(for: storedDay) != today { writtenMin = 0 }
+
+        guard let rawSamples = try? local.samples(kind: .heartRate, from: today, to: now),
+              !rawSamples.isEmpty else {
+            defaults.set(today.timeIntervalSince1970, forKey: Self.exerciseDayKey)
+            defaults.set(writtenMin, forKey: Self.exerciseWrittenKey)
+            return 0
+        }
+        // Exclude the latest detected sleep window so sleeping elevated HR doesn't count.
+        let sleepWindow: DateInterval? = (try? local.latestSleepSummary()).flatMap { s in
+            guard s.inBedStart > Date.distantPast else { return nil }
+            return DateInterval(start: s.inBedStart, end: s.inBedEnd)
+        }
+        let hrSamples = rawSamples.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        let maxHR = max(220 - profile.age, 1)
+        let totalMin = ExerciseMinutes.estimate(hrSamples: hrSamples, maxHR: maxHR,
+                                                sleepWindow: sleepWindow)
+        let pendingMin = totalMin - writtenMin
+        guard pendingMin >= 1.0 else {
+            defaults.set(today.timeIntervalSince1970, forKey: Self.exerciseDayKey)
+            defaults.set(writtenMin, forKey: Self.exerciseWrittenKey)
+            return 0
+        }
+        do {
+            let type = HKQuantityType(.appleExerciseTime)
+            let qty = HKQuantity(unit: .minute(), doubleValue: pendingMin)
+            // Tag as estimated so Health readers know this came from a basic HR threshold,
+            // NOT the ring's native activity-intensity sensor data (#93).
+            let sample = HKQuantitySample(type: type, quantity: qty, start: today, end: now,
+                                          metadata: [Self.exerciseEstimateMetadataKey: true])
+            try await store.save(sample)
+            defaults.set(today.timeIntervalSince1970, forKey: Self.exerciseDayKey)
+            defaults.set(totalMin, forKey: Self.exerciseWrittenKey)
+            return pendingMin
+        } catch { return 0 }
     }
 
     /// Write a night as contiguous sleepAnalysis category samples (mapping notes).

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -74,6 +74,9 @@ final class HealthKitWriter {
         // Workout types (#75): HKWorkout + GPS route (workout sessions feature).
         set.insert(HKWorkoutType.workoutType())
         set.insert(HKSeriesType.workoutRoute())
+        // Cycling distance is written for cycling workouts (foot-based sports use the
+        // .distanceWalkingRunning type already covered by MetricKind.distance above).
+        set.insert(HKQuantityType(.distanceCycling))
         // Women's health (#78): user-logged period flow written to Health.
         // NOTE: temperature is NOT added here — it already ships via the canonical
         // `.basalBodyTemperature` path (MetricKind.temperature). No triple-write.
@@ -146,20 +149,26 @@ final class HealthKitWriter {
         // HealthKit SUMS stepCount / distanceWalkingRunning, so writing the delta lands the
         // day's running total without re-adding on every sync. Distance is an ESTIMATE
         // (steps × height-based stride — not GPS) and is labeled as such in HealthKit metadata.
+        // To avoid double counting against a recorded foot-based workout's GPS distance (which
+        // also writes .distanceWalkingRunning), the estimate is netted by any uncredited workout
+        // GPS distance for today — preferring the accurate GPS measurement (#).
         if let delta = try? store.pendingStepDelta(), delta > 0 {
-            let startOfDay = Calendar.current.startOfDay(for: Date())
-            let distanceM = DistanceEstimate.meters(steps: delta, profile: profile)
+            let now = Date()
+            let startOfDay = Calendar.current.startOfDay(for: now)
+            let rawDistanceM = DistanceEstimate.meters(steps: delta, profile: profile)
+            let (netDistanceM, gpsReduction) = Self.netDistanceEstimate(rawDistanceM, day: startOfDay)
             var toWrite: [QuantitySample] = [
-                QuantitySample(kind: .steps, start: startOfDay, end: Date(), value: Double(delta))
+                QuantitySample(kind: .steps, start: startOfDay, end: now, value: Double(delta))
             ]
-            if distanceM > 0 {
-                toWrite.append(QuantitySample(kind: .distance, start: startOfDay, end: Date(), value: distanceM))
+            if netDistanceM > 0 {
+                toWrite.append(QuantitySample(kind: .distance, start: startOfDay, end: now, value: netDistanceM))
             }
             do {
                 try await write(toWrite)
                 try store.advanceStepsWritten(by: delta)
+                Self.commitDistanceGPSCredit(gpsReduction, day: startOfDay)
                 result.steps = delta
-                result.distanceM = distanceM
+                result.distanceM = netDistanceM
             } catch { /* leave the watermark; retry next flush */ }
         }
         // Derived daily resting HR — one sample per finalized day (#18, #37). Idempotency is a
@@ -199,50 +208,80 @@ final class HealthKitWriter {
         return written
     }
 
-    /// Write pending user-logged period flow entries to Apple Health as
-    /// `menstrualFlow` category samples, returning the count written.
-    /// Each entry is gated by its own `healthWritten` flag — independent of
-    /// all other HK writes. One HKCategorySample per period entry spanning
-    /// start…end (or start + 5 days when no end is logged yet).
-    /// `HKMetadataKeyMenstrualCycleStart: true` marks each as the first day
-    /// of a new cycle (period start = cycle start). (#78)
+    /// Write pending user-logged period flow entries to Apple Health, returning the count
+    /// written. Apple Health Cycle Tracking models flow as one sample PER DAY, so each logged
+    /// day from start through the logged end (capped at today) is mirrored as its own one-day
+    /// `menstrualFlow` sample. We NEVER invent a duration: an OPEN period (no logged end) only
+    /// mirrors days up to today and stays pending, so subsequent days are added as they are
+    /// actually logged/elapse. Before re-writing (after an edit, or extending an open period)
+    /// the previously-written sample(s) are deleted by UUID so the append-only HealthKit store
+    /// doesn't accumulate duplicates. (#78)
     private func flushMenstrualFlow(localStore: LocalStore) async -> Int {
         guard let pending = try? localStore.pendingPeriodEntries(), !pending.isEmpty else { return 0 }
         var written = 0
         for entry in pending {
+            // Remove any prior samples for this entry first (edit / open-period extension).
+            if !entry.hkSampleUUIDs.isEmpty {
+                await deleteMenstrualFlowSamples(uuidStrings: entry.hkSampleUUIDs)
+            }
+            let finalized = entry.end != nil
             do {
-                try await writeMenstrualFlow(entry: entry)
-                try localStore.markPeriodEntryWritten(start: entry.start)
-                written += 1
+                let uuids = try await writeMenstrualFlow(entry: entry)
+                try localStore.recordPeriodEntryHK(start: entry.start,
+                                                   hkSampleUUIDs: uuids, finalized: finalized)
+                if !uuids.isEmpty { written += 1 }
             } catch { break }   // stop on first failure; unwritten entries retry next flush
         }
         return written
     }
 
-    /// Write a single `menstrualFlow` category sample for a period entry.
-    private func writeMenstrualFlow(entry: StoredPeriodEntry) async throws {
+    /// Write one single-day `menstrualFlow` category sample per logged day of a period (start
+    /// through the logged end, capped at today — future days are never asserted). Returns the
+    /// UUID strings of the samples saved so the caller can persist them for later delete/replace.
+    /// `HKMetadataKeyMenstrualCycleStart: true` is set on the FIRST day only (period start =
+    /// cycle start). Never fabricates a duration the user didn't log (P1 fix).
+    private func writeMenstrualFlow(entry: StoredPeriodEntry) async throws -> [String] {
         let type = HKCategoryType(.menstrualFlow)
-        // Map app flow level to HKCategoryValueMenstrualFlow.
         let flowValue: HKCategoryValueMenstrualFlow
         switch entry.flowLevelRaw {
         case 1: flowValue = .light
         case 3: flowValue = .heavy
         default: flowValue = .medium
         }
-        // Use logged end date, or start + 5 days as a sensible stand-in when the
-        // user hasn't closed the period yet. HK only stores what the user logged.
-        let endDate = entry.end ?? entry.start.addingTimeInterval(5 * 86_400)
-        let sample = HKCategorySample(
-            type: type,
-            value: flowValue.rawValue,
-            start: entry.start,
-            end: endDate,
-            metadata: [
-                // Mark the first day of the period as the first day of the cycle.
-                HKMetadataKeyMenstrualCycleStart: true,
-            ]
-        )
-        try await store.save(sample)
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: Date())
+        let firstDay = cal.startOfDay(for: entry.start)
+        // Finalized period: through the logged end day. Open period: only up to today.
+        // Either way, never write a day in the future.
+        let endCandidate = entry.end.map { cal.startOfDay(for: $0) } ?? today
+        let lastDay = min(endCandidate, today)
+        guard lastDay >= firstDay else { return [] }
+
+        var samples: [HKCategorySample] = []
+        var day = firstDay
+        var isFirstDay = true
+        while day <= lastDay {
+            let dayEnd = cal.date(byAdding: .day, value: 1, to: day) ?? day.addingTimeInterval(86_400)
+            // Mark only the first day of the period as the first day of the cycle.
+            let metadata: [String: Any]? = isFirstDay ? [HKMetadataKeyMenstrualCycleStart: true] : nil
+            samples.append(HKCategorySample(type: type, value: flowValue.rawValue,
+                                            start: day, end: dayEnd, metadata: metadata))
+            isFirstDay = false
+            day = dayEnd
+        }
+        guard !samples.isEmpty else { return [] }
+        try await store.save(samples)
+        return samples.map { $0.uuid.uuidString }
+    }
+
+    /// Delete previously-written `menstrualFlow` samples by UUID (best-effort). Used when a
+    /// logged period is edited (delete-then-rewrite) or deleted in-app, so Apple Health never
+    /// keeps a stale or orphaned flow sample. (#78)
+    func deleteMenstrualFlowSamples(uuidStrings: [String]) async {
+        let uuids = Set(uuidStrings.compactMap { UUID(uuidString: $0) })
+        guard !uuids.isEmpty, Self.isAvailable else { return }
+        let predicate = HKQuery.predicateForObjects(with: uuids)
+        _ = try? await store.deleteObjects(of: HKCategoryType(.menstrualFlow), predicate: predicate)
     }
 
     func requestAuthorization() async throws {
@@ -355,6 +394,63 @@ final class HealthKitWriter {
     private static let exerciseWrittenKey = "hk.exerciseTime.writtenMin"  // total minutes already pushed
     // Metadata key for estimated exercise time samples
     static let exerciseEstimateMetadataKey = "OpenRingConnExerciseTimeEstimated"
+
+    // Distance double-count avoidance (steps×stride estimate vs workout GPS).
+    // WorkoutSessionManager records foot-based (walk/run/hike) GPS distance written to
+    // .distanceWalkingRunning today via `recordWorkoutWalkRunDistance`; the daily steps×stride
+    // estimate nets out this GPS distance so the same foot-distance isn't summed twice in
+    // Health's "Walking + Running Distance" total. Cycling GPS goes to .distanceCycling, which
+    // doesn't overlap the walk/run estimate, so it's never netted. GPS is preferred (the
+    // accurate measurement is kept; only the estimate is reduced for the overlapping window).
+    static let workoutWalkRunDistanceDayKey    = "hk.workoutWalkRunDistance.day"
+    static let workoutWalkRunDistanceMetersKey = "hk.workoutWalkRunDistance.meters"
+    private static let estimateGPSCreditedDayKey    = "hk.distanceEstimate.gpsCreditedDay"
+    private static let estimateGPSCreditedMetersKey = "hk.distanceEstimate.gpsCreditedMeters"
+
+    /// Record foot-based workout GPS distance (meters) written to .distanceWalkingRunning today,
+    /// so the daily steps×stride estimate can net it out and avoid double counting. Day-keyed.
+    static func recordWorkoutWalkRunDistance(_ meters: Double, now: Date = Date(),
+                                             _ defaults: UserDefaults = .standard) {
+        guard meters > 0 else { return }
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: now)
+        let storedDay = Date(timeIntervalSince1970: defaults.double(forKey: workoutWalkRunDistanceDayKey))
+        var total = cal.startOfDay(for: storedDay) == today
+            ? defaults.double(forKey: workoutWalkRunDistanceMetersKey) : 0
+        total += meters
+        defaults.set(today.timeIntervalSince1970, forKey: workoutWalkRunDistanceDayKey)
+        defaults.set(total, forKey: workoutWalkRunDistanceMetersKey)
+    }
+
+    /// Reduce a raw steps×stride distance estimate by however much workout GPS walk/run distance
+    /// hasn't yet been netted out today, preferring the accurate GPS measurement. Returns the
+    /// net meters to write (≥ 0) and the reduction applied (to commit after a successful write).
+    private static func netDistanceEstimate(_ raw: Double, day today: Date,
+                                            _ defaults: UserDefaults = .standard) -> (net: Double, reduction: Double) {
+        let cal = Calendar.current
+        let gpsDay = Date(timeIntervalSince1970: defaults.double(forKey: workoutWalkRunDistanceDayKey))
+        let gpsTotal = cal.startOfDay(for: gpsDay) == today
+            ? defaults.double(forKey: workoutWalkRunDistanceMetersKey) : 0
+        let creditedDay = Date(timeIntervalSince1970: defaults.double(forKey: estimateGPSCreditedDayKey))
+        let credited = cal.startOfDay(for: creditedDay) == today
+            ? defaults.double(forKey: estimateGPSCreditedMetersKey) : 0
+        let uncredited = max(0, gpsTotal - credited)
+        let reduction = min(max(raw, 0), uncredited)
+        return (raw - reduction, reduction)
+    }
+
+    /// Commit a distance-estimate GPS netting after a successful write (advances the credited
+    /// accumulator so the same GPS meters aren't subtracted again on a later flush).
+    private static func commitDistanceGPSCredit(_ reduction: Double, day today: Date,
+                                                _ defaults: UserDefaults = .standard) {
+        guard reduction > 0 else { return }
+        let cal = Calendar.current
+        let creditedDay = Date(timeIntervalSince1970: defaults.double(forKey: estimateGPSCreditedDayKey))
+        let credited = cal.startOfDay(for: creditedDay) == today
+            ? defaults.double(forKey: estimateGPSCreditedMetersKey) : 0
+        defaults.set(today.timeIntervalSince1970, forKey: estimateGPSCreditedDayKey)
+        defaults.set(credited + reduction, forKey: estimateGPSCreditedMetersKey)
+    }
     /// A day's resting HR is finalized once the day is ~half over, so a pre-dawn flush can't
     /// freeze a partial-night value, yet last night's RHR still lands the same day (by midday).
     private static let restingFinalizationDelay: TimeInterval = 12 * 3600

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -83,9 +83,10 @@ final class HealthKitWriter {
         var samples = 0, sleepSegments = 0, steps = 0
         var restingDays = 0, passiveHours = 0
         var activeKcal = 0.0
+        var naps = 0
         var wroteAnything: Bool {
             samples > 0 || sleepSegments > 0 || steps > 0
-                || restingDays > 0 || passiveHours > 0 || activeKcal > 0
+                || restingDays > 0 || passiveHours > 0 || activeKcal > 0 || naps > 0
         }
     }
 
@@ -111,6 +112,9 @@ final class HealthKitWriter {
             do { try await write(sleep: pendingSleep); try store.markSleepWritten(pendingSleep); result.sleepSegments = pendingSleep.count }
             catch { /* leave the .sleep cursor; retry next flush */ }
         }
+        // Naps (#76): each carries its own `healthWritten` flag (NOT the night's `.sleep` cursor),
+        // so a daytime nap and the overnight night write independently and never collide.
+        result.naps = await flushNaps(store: store)
         // Steps: the store holds the authoritative pending delta (total − already-written), so
         // gate on it directly — no live reading needed (this also lets a launch-time flush push
         // steps the background refresh persisted). HealthKit SUMS stepCount, so writing the
@@ -135,6 +139,27 @@ final class HealthKitWriter {
         result.passiveHours = await flushPassiveCalories(profile: profile)
         result.activeKcal = await flushActiveCalories(local: store, profile: profile)
         return result
+    }
+
+    /// Write each pending nap to Apple Health as sleep (a coarse inBed + asleepCore pair over the
+    /// nap window) and mark it written, returning the count. Gated by each nap's own
+    /// `healthWritten` flag — independent of the night's `.sleep` cursor — so naps and the night
+    /// never collide. Best-effort: a failed save leaves the flag so it retries next flush.
+    private func flushNaps(store: LocalStore) async -> Int {
+        guard let pending = try? store.pendingNaps(), !pending.isEmpty else { return 0 }
+        var written = 0
+        for nap in pending {
+            let segs = [
+                SleepSegment(start: nap.start, end: nap.end, stage: .inBed),
+                SleepSegment(start: nap.start, end: nap.end, stage: .asleepCore),
+            ]
+            do {
+                try await write(sleep: segs)
+                try store.markNapWritten(start: nap.start)
+                written += 1
+            } catch { break }   // stop on first failure; unwritten naps retry next flush
+        }
+        return written
     }
 
     func requestAuthorization() async throws {

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -27,12 +27,15 @@ final class HealthKitWriter {
         case .restingHeartRate: id = .restingHeartRate
         case .hrvSDNN: id = .heartRateVariabilitySDNN
         case .spo2: id = .oxygenSaturation
-        // Skin temp is captured ONLY during the nightly sleep window (RingSession), so the
-        // sleeping-wrist type is the semantically correct destination — it's what Apple's own
-        // sleep apps and Bevel's wrist-temp baseline read. `.bodyTemperature` is a clinical
-        // oral/core type and would pollute that chart with skin values ~5°C low (#29). iOS 16+;
-        // deployment target is iOS 17. Units stay °C (see `unit(for:)`).
-        case .temperature: id = .appleSleepingWristTemperature
+        // Skin temp is captured ONLY during the nightly sleep window (RingSession), so a
+        // rest-oriented type is the right home — NOT clinical `.bodyTemperature`, whose chart a
+        // skin reading (~5 °C below oral/core) would pollute (#29). The ideal sleeping-wrist type
+        // (`.appleSleepingWristTemperature`) is Apple-COMPUTED and read-only for third parties:
+        // it can't be save()d, and putting it in the `toShare` set of `requestAuthorization`
+        // raises NSInvalidArgumentException, which would crash auth or — swallowed by the
+        // call-site `try?` — silently disable EVERY metric's writeback. So we use the writable,
+        // rest-scoped `.basalBodyTemperature` instead. Units stay °C (see `unit(for:)`).
+        case .temperature: id = .basalBodyTemperature
         case .respiratoryRate: id = .respiratoryRate
         case .steps: id = .stepCount
         case .activeEnergy: id = .activeEnergyBurned
@@ -138,7 +141,21 @@ final class HealthKitWriter {
         // Read sleepAnalysis so the iOS Sleep-schedule window (HealthKitSleepSchedule) works
         // the moment the HealthKit entitlement is enabled — no further auth change needed.
         // (No effect today: without the entitlement the request is a no-op, so it can't prompt.)
-        try await store.requestAuthorization(toShare: allTypes, read: [HKCategoryType(.sleepAnalysis)])
+        let read: Set<HKObjectType> = [HKCategoryType(.sleepAnalysis)]
+        // Every type in `allTypes` is deliberately third-party-WRITABLE (that's why `.temperature`
+        // maps to `.basalBodyTemperature`, not the read-only `.appleSleepingWristTemperature`) —
+        // an unshareable type here would poison the whole request. Defensive isolation: if the
+        // request still throws (a future/edge type the OS refuses to share), retry WITHOUT
+        // temperature so one bad type degrades to "temp not shared" instead of disabling share
+        // access for every metric. (A genuinely non-shareable Apple-computed type raises an Obj-C
+        // NSInvalidArgumentException this can't catch — which is exactly why we never list one.)
+        do {
+            try await store.requestAuthorization(toShare: allTypes, read: read)
+        } catch {
+            var writable = allTypes
+            if let temp = Self.quantityType(for: .temperature) { writable.remove(temp) }
+            try await store.requestAuthorization(toShare: writable, read: read)
+        }
     }
 
     /// Write scalar samples. Caller filters with SyncCursor first.

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -71,6 +71,9 @@ final class HealthKitWriter {
         }
         set.insert(HKQuantityType(.basalEnergyBurned))
         set.insert(HKCategoryType(.sleepAnalysis))
+        // Workout types (#75): HKWorkout + GPS route (workout sessions feature).
+        set.insert(HKWorkoutType.workoutType())
+        set.insert(HKSeriesType.workoutRoute())
         return set
     }
 

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -27,7 +27,12 @@ final class HealthKitWriter {
         case .restingHeartRate: id = .restingHeartRate
         case .hrvSDNN: id = .heartRateVariabilitySDNN
         case .spo2: id = .oxygenSaturation
-        case .temperature: id = .bodyTemperature
+        // Skin temp is captured ONLY during the nightly sleep window (RingSession), so the
+        // sleeping-wrist type is the semantically correct destination — it's what Apple's own
+        // sleep apps and Bevel's wrist-temp baseline read. `.bodyTemperature` is a clinical
+        // oral/core type and would pollute that chart with skin values ~5°C low (#29). iOS 16+;
+        // deployment target is iOS 17. Units stay °C (see `unit(for:)`).
+        case .temperature: id = .appleSleepingWristTemperature
         case .respiratoryRate: id = .respiratoryRate
         case .steps: id = .stepCount
         case .activeEnergy: id = .activeEnergyBurned
@@ -73,7 +78,12 @@ final class HealthKitWriter {
     /// was nothing pending or share access isn't granted.
     struct FlushResult: Equatable {
         var samples = 0, sleepSegments = 0, steps = 0
-        var wroteAnything: Bool { samples > 0 || sleepSegments > 0 || steps > 0 }
+        var restingDays = 0, passiveHours = 0
+        var activeKcal = 0.0
+        var wroteAnything: Bool {
+            samples > 0 || sleepSegments > 0 || steps > 0
+                || restingDays > 0 || passiveHours > 0 || activeKcal > 0
+        }
     }
 
     /// Mirror everything pending into Apple Health in one pass — scalar vitals, the night's
@@ -110,6 +120,17 @@ final class HealthKitWriter {
                 result.steps = delta
             } catch { /* leave the watermark; retry next flush */ }
         }
+        // Derived daily resting HR — one sample per finalized day (#18, #37). Idempotency is a
+        // UserDefaults day-watermark, NOT the store cursor: RHR isn't a stored sample, and the
+        // `hk:` cursor rows belong to the raw-sample mirror above.
+        result.restingDays = await flushRestingHR(local: store, sleepSegments: sleepSegments)
+
+        // Energy: passive (hourly BMR) + active (HR-derived Edwards TRIMP). Each carries its own
+        // UserDefaults watermark so repeated flushes never double-count (#37). Body inputs come
+        // from the shared profile defaults — the ring transmits none of them.
+        let profile = Self.storedUserProfile()
+        result.passiveHours = await flushPassiveCalories(profile: profile)
+        result.activeKcal = await flushActiveCalories(local: store, profile: profile)
         return result
     }
 
@@ -125,10 +146,25 @@ final class HealthKitWriter {
         let hkSamples: [HKQuantitySample] = samples.compactMap { s in
             guard let type = Self.quantityType(for: s.kind) else { return nil }
             let q = HKQuantity(unit: Self.unit(for: s.kind), doubleValue: s.value)
-            return HKQuantitySample(type: type, quantity: q, start: s.start, end: s.end)
+            return HKQuantitySample(type: type, quantity: q, start: s.start, end: s.end,
+                                    metadata: Self.metadata(for: s.kind))
         }
         guard !hkSamples.isEmpty else { return }
         try await store.save(hkSamples)
+    }
+
+    /// Metadata key on HRV samples flagging which statistic the value actually is.
+    static let hrvStatisticMetadataKey = "OpenRingConnHRVStatistic"
+
+    /// Per-kind sample metadata. The ring reports HRV as **RMSSD**, but HealthKit only offers
+    /// an **SDNN** field — so we store the RMSSD value in `.heartRateVariabilitySDNN` and tag it
+    /// honestly here rather than invent an RMSSD→SDNN conversion constant (the two are not a
+    /// fixed ratio; see docs/HEALTHKIT_MAPPING.md). Readers can distinguish via this key.
+    static func metadata(for kind: MetricKind) -> [String: Any]? {
+        switch kind {
+        case .hrvSDNN: return [hrvStatisticMetadataKey: "RMSSD"]
+        default: return nil
+        }
     }
 
     func writePassiveCalories(profile: UserProfile, date: Date) async throws {
@@ -163,6 +199,139 @@ final class HealthKitWriter {
         let maxHR = max(220 - profile.age, 1)
         let kcal = Calories.activeKcal(hrSamples: hrSamples, maxHR: maxHR)
         try await writeActiveCalories(kcal: kcal, date: date)
+    }
+
+    /// One derived resting-HR sample for a day (anchored at start-of-day; HealthKit buckets it
+    /// onto that calendar day). Value comes from `RestingHR` (sleep mean → low-activity floor).
+    func writeRestingHR(bpm: Double, day: Date) async throws {
+        let q = HKQuantity(unit: Self.unit(for: .restingHeartRate), doubleValue: bpm)
+        let sample = HKQuantitySample(type: HKQuantityType(.restingHeartRate),
+                                      quantity: q, start: day, end: day)
+        try await store.save(sample)
+    }
+
+    // MARK: Derived-write watermarks (UserDefaults — see flushToHealth)
+    //
+    // Resting HR and energy are DERIVED, not stored samples, so they can't ride the LocalStore
+    // `hk:` cursor (which gates the raw-sample mirror). Each keeps its own idempotency mark in
+    // UserDefaults — shared across the foreground + background `HealthKitWriter` instances, and
+    // only advanced after a confirmed write, so a failed/unauthorized flush backfills next time.
+    private static let rhrWatermarkKey = "hk.restingHR.lastDay"      // start-of-day last written
+    private static let basalWatermarkKey = "hk.basalEnergy.nextHour" // first hour not yet written
+    private static let activeDayKey = "hk.activeEnergy.day"          // start-of-day of the accumulator
+    private static let activeWrittenKey = "hk.activeEnergy.writtenKcal"
+    /// A day's resting HR is finalized once the day is ~half over, so a pre-dawn flush can't
+    /// freeze a partial-night value, yet last night's RHR still lands the same day (by midday).
+    private static let restingFinalizationDelay: TimeInterval = 12 * 3600
+
+    /// Write one resting-HR sample per finalized day not yet covered by the day-watermark.
+    /// Reads HR straight from the store (the dashboard's source) via its public accessor.
+    private func flushRestingHR(local: LocalStore, sleepSegments: [SleepSegment]) async -> Int {
+        let cal = Calendar.current
+        let now = Date()
+        let defaults = UserDefaults.standard
+        let lastWritten = Date(timeIntervalSince1970: defaults.double(forKey: Self.rhrWatermarkKey))
+        let cutoff = now.addingTimeInterval(-Self.restingFinalizationDelay)
+        // Bound the scan: never re-read already-written days, and look back at most a week so a
+        // first run backfills recent history without an unbounded query.
+        let lookback = cal.date(byAdding: .day, value: -7, to: cal.startOfDay(for: now))
+            ?? now.addingTimeInterval(-7 * 86_400)
+        let scanStart = max(lookback, lastWritten)
+        guard let stored = try? local.samples(kind: .heartRate, from: scanStart, to: now),
+              !stored.isEmpty else { return 0 }
+        let hr = stored.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        let days = RestingHR.dailyValues(hr: hr, sleep: sleepSegments, calendar: cal)
+
+        var written = 0
+        var newWatermark = lastWritten
+        for d in days where d.day > lastWritten && d.day <= cutoff {  // days ascend
+            do {
+                try await writeRestingHR(bpm: d.bpm, day: d.day)
+                written += 1
+                newWatermark = d.day
+            } catch { break }  // stop at the first failure; already-written days stay covered
+        }
+        if newWatermark > lastWritten {
+            defaults.set(newWatermark.timeIntervalSince1970, forKey: Self.rhrWatermarkKey)
+        }
+        return written
+    }
+
+    /// Write basal (passive) energy for each completed hour since the watermark, returning the
+    /// count. First run starts the meter at the current hour (no historical flood); a long gap
+    /// is clamped to the last ~24 hours.
+    private func flushPassiveCalories(profile: UserProfile) async -> Int {
+        let defaults = UserDefaults.standard
+        let now = Date()
+        let currentHour = Self.startOfHour(now)
+        let stored = defaults.double(forKey: Self.basalWatermarkKey)
+        var hour = stored == 0 ? currentHour : Date(timeIntervalSince1970: stored)
+        hour = max(hour, currentHour.addingTimeInterval(-24 * 3600))  // clamp a long gap
+
+        var written = 0
+        while hour < currentHour {
+            do {
+                try await writePassiveCalories(profile: profile, date: hour)
+                written += 1
+                hour = hour.addingTimeInterval(3600)
+            } catch { break }  // leave the watermark at the failed hour; retry next flush
+        }
+        // `hour` now points at the first hour still unwritten (currentHour when all succeeded).
+        if hour.timeIntervalSince1970 > stored {
+            defaults.set(hour.timeIntervalSince1970, forKey: Self.basalWatermarkKey)
+        }
+        return written
+    }
+
+    /// Write today's active-energy DELTA (today's HR-derived TRIMP kcal minus what's already
+    /// been written today), returning the kcal written. HealthKit SUMS activeEnergyBurned, so
+    /// writing the delta lands the running daily total without re-adding it each flush.
+    private func flushActiveCalories(local: LocalStore, profile: UserProfile) async -> Double {
+        let cal = Calendar.current
+        let now = Date()
+        let today = cal.startOfDay(for: now)
+        let defaults = UserDefaults.standard
+        let storedDay = Date(timeIntervalSince1970: defaults.double(forKey: Self.activeDayKey))
+        var written = defaults.double(forKey: Self.activeWrittenKey)
+        if cal.startOfDay(for: storedDay) != today { written = 0 }  // new day → reset accumulator
+
+        guard let stored = try? local.samples(kind: .heartRate, from: today, to: now),
+              !stored.isEmpty else {
+            defaults.set(today.timeIntervalSince1970, forKey: Self.activeDayKey)
+            defaults.set(written, forKey: Self.activeWrittenKey)
+            return 0
+        }
+        let hr = stored.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        let maxHR = max(220 - profile.age, 1)
+        let total = Calories.activeKcal(hrSamples: hr, maxHR: maxHR)
+        let delta = total - written
+        guard delta >= 1.0 else {  // ignore sub-kcal churn; still persist the (reset) day marker
+            defaults.set(today.timeIntervalSince1970, forKey: Self.activeDayKey)
+            defaults.set(written, forKey: Self.activeWrittenKey)
+            return 0
+        }
+        do {
+            try await writeActiveCalories(kcal: delta, date: today)
+            defaults.set(today.timeIntervalSince1970, forKey: Self.activeDayKey)
+            defaults.set(total, forKey: Self.activeWrittenKey)
+            return delta
+        } catch { return 0 }
+    }
+
+    /// The user's body profile, read from the shared `@AppStorage` keys (the same keys
+    /// `UserProfileSettingsView`/`CaloriesCardView` use — keep these defaults in sync). Feeds the
+    /// BMR/TRIMP energy estimates; the ring transmits none of these inputs.
+    static func storedUserProfile(_ defaults: UserDefaults = .standard) -> UserProfile {
+        let age = defaults.object(forKey: "userProfile.age") as? Int ?? 35
+        let weightKg = defaults.object(forKey: "userProfile.weightKg") as? Double ?? 70
+        let heightCm = defaults.object(forKey: "userProfile.heightCm") as? Double ?? 170
+        let sexRaw = defaults.string(forKey: "userProfile.sex") ?? BiologicalSex.male.rawValue
+        return UserProfile(age: age, weightKg: max(weightKg, 1), heightCm: max(heightCm, 1),
+                           sex: BiologicalSex(rawValue: sexRaw) ?? .male)
+    }
+
+    private static func startOfHour(_ date: Date, _ cal: Calendar = .current) -> Date {
+        cal.date(from: cal.dateComponents([.year, .month, .day, .hour], from: date)) ?? date
     }
 
     /// Write a night as contiguous sleepAnalysis category samples (mapping notes).

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -74,6 +74,10 @@ final class HealthKitWriter {
         // Workout types (#75): HKWorkout + GPS route (workout sessions feature).
         set.insert(HKWorkoutType.workoutType())
         set.insert(HKSeriesType.workoutRoute())
+        // Women's health (#78): user-logged period flow written to Health.
+        // NOTE: temperature is NOT added here — it already ships via the canonical
+        // `.basalBodyTemperature` path (MetricKind.temperature). No triple-write.
+        set.insert(HKCategoryType(.menstrualFlow))
         return set
     }
 
@@ -95,10 +99,11 @@ final class HealthKitWriter {
         var naps = 0
         var distanceM = 0.0         // estimated distance written (#81)
         var exerciseMinutes = 0.0   // estimated exercise minutes written (#82)
+        var menstrualFlowEntries = 0  // user-logged period entries written (#78)
         var wroteAnything: Bool {
             samples > 0 || sleepSegments > 0 || steps > 0
                 || restingDays > 0 || passiveHours > 0 || activeKcal > 0 || naps > 0
-                || distanceM > 0 || exerciseMinutes > 0
+                || distanceM > 0 || exerciseMinutes > 0 || menstrualFlowEntries > 0
         }
     }
 
@@ -127,6 +132,10 @@ final class HealthKitWriter {
         // Naps (#76): each carries its own `healthWritten` flag (NOT the night's `.sleep` cursor),
         // so a daytime nap and the overnight night write independently and never collide.
         result.naps = await flushNaps(store: store)
+
+        // Women's health (#78): write pending user-logged period flow entries to Health.
+        // Gated by each entry's own `healthWritten` flag — independent of all other writes.
+        result.menstrualFlowEntries = await flushMenstrualFlow(localStore: store)
 
         // Profile is used for distance stride + calorie TRIMP — resolved once here so all three
         // derived writes use the same snapshot. Body inputs come from the shared profile defaults;
@@ -188,6 +197,52 @@ final class HealthKitWriter {
             } catch { break }   // stop on first failure; unwritten naps retry next flush
         }
         return written
+    }
+
+    /// Write pending user-logged period flow entries to Apple Health as
+    /// `menstrualFlow` category samples, returning the count written.
+    /// Each entry is gated by its own `healthWritten` flag — independent of
+    /// all other HK writes. One HKCategorySample per period entry spanning
+    /// start…end (or start + 5 days when no end is logged yet).
+    /// `HKMetadataKeyMenstrualCycleStart: true` marks each as the first day
+    /// of a new cycle (period start = cycle start). (#78)
+    private func flushMenstrualFlow(localStore: LocalStore) async -> Int {
+        guard let pending = try? localStore.pendingPeriodEntries(), !pending.isEmpty else { return 0 }
+        var written = 0
+        for entry in pending {
+            do {
+                try await writeMenstrualFlow(entry: entry)
+                try localStore.markPeriodEntryWritten(start: entry.start)
+                written += 1
+            } catch { break }   // stop on first failure; unwritten entries retry next flush
+        }
+        return written
+    }
+
+    /// Write a single `menstrualFlow` category sample for a period entry.
+    private func writeMenstrualFlow(entry: StoredPeriodEntry) async throws {
+        let type = HKCategoryType(.menstrualFlow)
+        // Map app flow level to HKCategoryValueMenstrualFlow.
+        let flowValue: HKCategoryValueMenstrualFlow
+        switch entry.flowLevelRaw {
+        case 1: flowValue = .light
+        case 3: flowValue = .heavy
+        default: flowValue = .medium
+        }
+        // Use logged end date, or start + 5 days as a sensible stand-in when the
+        // user hasn't closed the period yet. HK only stores what the user logged.
+        let endDate = entry.end ?? entry.start.addingTimeInterval(5 * 86_400)
+        let sample = HKCategorySample(
+            type: type,
+            value: flowValue.rawValue,
+            start: entry.start,
+            end: endDate,
+            metadata: [
+                // Mark the first day of the period as the first day of the cycle.
+                HKMetadataKeyMenstrualCycleStart: true,
+            ]
+        )
+        try await store.save(sample)
     }
 
     func requestAuthorization() async throws {

--- a/ios/OpenRingConn/Health/HealthKitWriter.swift
+++ b/ios/OpenRingConn/Health/HealthKitWriter.swift
@@ -54,7 +54,10 @@ final class HealthKitWriter {
     }
 
     func requestAuthorization() async throws {
-        try await store.requestAuthorization(toShare: allTypes, read: [])
+        // Read sleepAnalysis so the iOS Sleep-schedule window (HealthKitSleepSchedule) works
+        // the moment the HealthKit entitlement is enabled — no further auth change needed.
+        // (No effect today: without the entitlement the request is a no-op, so it can't prompt.)
+        try await store.requestAuthorization(toShare: allTypes, read: [HKCategoryType(.sleepAnalysis)])
     }
 
     /// Write scalar samples. Caller filters with SyncCursor first.

--- a/ios/OpenRingConn/HealthNotificationCenter.swift
+++ b/ios/OpenRingConn/HealthNotificationCenter.swift
@@ -30,6 +30,12 @@ enum ReminderDefaults {
     /// Read by `evaluateReminders` to decide whether the user has been sedentary.
     static let lastActivityAt = "reminder.lastActivityAt"
 
+    /// UserDefaults key written by RingSession whenever ANY ring data frame arrives. DURABLE
+    /// (survives session teardown on background/disconnect), unlike the ephemeral
+    /// `session.lastFrameAt` which resets to nil on a cold launch. The wear reminder reads this
+    /// so it tracks actual "ring data went silent" rather than transient BLE-connection state.
+    static let lastRingDataAt = "reminder.lastRingDataAt"
+
     static func register(_ d: UserDefaults = .standard) {
         d.register(defaults: [
             sedentaryEnabled:    true,
@@ -157,19 +163,28 @@ struct HealthNotificationCenter {
         let thresholds = HealthAlertDefaults.thresholds()
         let instantSince = now.addingTimeInterval(-Self.instantLookback)
         let inactiveSince = now.addingTimeInterval(-Self.inactiveLookback)
+        let lastFired = store.lastFired()
+        // Only consider HR/SpO2 readings NEWER than the last time that notification fired, so a
+        // single morning spike alerts ONCE rather than re-firing every backoff window (the 2h
+        // backoff is shorter than the 12h lookback, so without this the worst reading in the
+        // window would keep being re-returned and re-announced for hours). (#73 fix)
+        let hrSince = max(instantSince, lastFired[.highHR] ?? .distantPast)
+        let spo2Since = max(instantSince, lastFired[.lowSpO2] ?? .distantPast)
 
         // Stored readings + the just-synced in-memory batch (so a fresh sync is reflected at once).
         var hr = ((try? localStore.recentSamples(kind: .heartRate, since: instantSince)) ?? [])
+            .filter { $0.start > hrSince }
             .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
         var spo2 = ((try? localStore.recentSamples(kind: .spo2, since: instantSince)) ?? [])
+            .filter { $0.start > spo2Since }
             .map { SpO2Reading(percent: Int(($0.value * 100).rounded()), time: $0.start) }
         let inactiveHR = ((try? localStore.recentSamples(kind: .heartRate, since: inactiveSince)) ?? [])
             .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
 
         if let synced = session?.historySamples {
-            hr += synced.filter { $0.kind == .heartRate && $0.value > 0 && $0.start >= instantSince }
+            hr += synced.filter { $0.kind == .heartRate && $0.value > 0 && $0.start > hrSince }
                 .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
-            spo2 += synced.filter { $0.kind == .spo2 && $0.value > 0 && $0.start >= instantSince }
+            spo2 += synced.filter { $0.kind == .spo2 && $0.value > 0 && $0.start > spo2Since }
                 .map { SpO2Reading(percent: Int(($0.value * 100).rounded()), time: $0.start) }
         }
 
@@ -186,7 +201,7 @@ struct HealthNotificationCenter {
 
         // --- Route survivors through the ONE shared gate (quiet hours + backoff) ---------------
         let quiet = HealthAlertDefaults.quietHours()
-        let fire = gate.filter(candidates, now: now, lastFired: store.lastFired(), quietHours: quiet)
+        let fire = gate.filter(candidates, now: now, lastFired: lastFired, quietHours: quiet)
         guard !fire.isEmpty, await ensureAuthorized() else { return }
         for n in fire { await post(n, hit: hitByNotif[n]) }
         store.markFired(fire, at: now)
@@ -257,7 +272,13 @@ struct HealthNotificationCenter {
             let r = WearReminder()
             // "ever connected" = a peripheral ID has been persisted by RingScanner.
             let hasSavedRing = d.string(forKey: "com.openringconn.ring.peripheralID") != nil
-            let lastData = session?.lastFrameAt
+            // Use the DURABLE last-frame timestamp (survives cold launch / session teardown), not
+            // the ephemeral session value — otherwise the reminder fires "Put your ring back on"
+            // on every cold foreground while the ring is actually worn and merely reconnecting.
+            // Take the most recent of the durable and (if present) live session timestamps.
+            let durableEpoch = d.double(forKey: ReminderDefaults.lastRingDataAt)
+            let durable: Date? = durableEpoch > 0 ? Date(timeIntervalSince1970: durableEpoch) : nil
+            let lastData = [durable, session?.lastFrameAt].compactMap { $0 }.max()
             if r.shouldFire(lastRingDataAt: lastData, now: now, everConnected: hasSavedRing) {
                 candidates.append(.wearReminder)
             }
@@ -309,11 +330,26 @@ struct HealthNotificationCenter {
         }
     }
 
+    /// Body-vital alerts carry the medical disclaimer; #84 lifestyle reminders and the #86
+    /// charging-complete banner do NOT (they aren't sensor-vital readings). This matches the
+    /// stated intent in `copy(for:)` ("no medical disclaimer appended — they're lifestyle
+    /// reminders"), which the previous unconditional append in `post` contradicted.
+    private static func appendsDisclaimer(_ n: HealthNotification) -> Bool {
+        switch n {
+        case .highHR, .lowSpO2, .elevatedHRInactive,
+             .skinTempRise, .skinTempDrop, .skinTempFluctuationRise, .skinTempFluctuationDrop,
+             .fever:
+            return true
+        case .sedentaryReminder, .wearReminder, .bedtimeReminder, .chargingComplete:
+            return false
+        }
+    }
+
     private func post(_ n: HealthNotification, hit: HealthAlertHit?) async {
         let content = UNMutableNotificationContent()
         let copy = Self.copy(for: n, hit: hit)
         content.title = copy.title
-        content.body = copy.body + "\n\n" + Self.disclaimer
+        content.body = Self.appendsDisclaimer(n) ? copy.body + "\n\n" + Self.disclaimer : copy.body
         content.sound = .default
         // One pending request per condition (stable id) — re-posting just refreshes it.
         let request = UNNotificationRequest(identifier: "alerts.health.\(n.rawValue)",

--- a/ios/OpenRingConn/HealthNotificationCenter.swift
+++ b/ios/OpenRingConn/HealthNotificationCenter.swift
@@ -1,0 +1,282 @@
+import Foundation
+import OpenRingKit
+import UserNotifications
+
+// THE shared local-notification service for health alerts (#73) and skin-temp/fever
+// notifications (#85). There is exactly ONE of these engines: a single quiet-hours/DND window,
+// a single anti-spam de-dupe namespace, lazy UNUserNotifications authorization. Both tickets
+// route their conditions through `post`. The PURE threshold/de-dupe/DND math lives in
+// OpenRingKit (HealthAlerts.swift); this file is the UserDefaults persistence + the
+// UNUserNotificationCenter glue + the data gathering from LocalStore.
+//
+// Separate from the observability alerts (ObservabilityStore.swift / LocalAlertCenter): those
+// warn about the TRACKER failing silently (not synced / Health-auth lost). These are BODY-vital
+// alerts the user opted into. They share the same app-wide notification authorization, but keep
+// their own settings, de-dupe lane, and copy (each carries the "not a medical device" disclaimer).
+
+// MARK: - Settings (shared by the engine and the settings UI)
+
+/// `@AppStorage`/`UserDefaults` keys + defaults for the health-alert thresholds and quiet hours.
+/// The settings UI writes these via `@AppStorage`; the engine reads the same keys here. Defaults
+/// are registered so `integer(forKey:)`/`bool(forKey:)` return the intended value before the user
+/// has ever opened settings (mirrors `SleepScheduleDefaults`).
+enum HealthAlertDefaults {
+    static let highHREnabled = "alerts.highHR.enabled"
+    static let highHRBpm = "alerts.highHR.bpm"
+    static let lowSpO2Enabled = "alerts.lowSpO2.enabled"
+    static let lowSpO2Percent = "alerts.lowSpO2.percent"
+    static let elevatedHREnabled = "alerts.elevatedHR.enabled"
+    static let elevatedHRBpm = "alerts.elevatedHR.bpm"
+    static let tempFeverEnabled = "alerts.tempFever.enabled"
+    static let quietEnabled = "alerts.quiet.enabled"
+    static let quietStartMinutes = "alerts.quiet.startMinutes"
+    static let quietEndMinutes = "alerts.quiet.endMinutes"
+
+    // Defaults mirror OpenRingKit's HealthAlertThresholds / QuietHours so the UI and the pure
+    // layer agree out of the box.
+    static let defaultHighHRBpm = 120
+    static let defaultLowSpO2Percent = 90
+    static let defaultElevatedHRBpm = 100
+    static let defaultQuietStart = 22 * 60
+    static let defaultQuietEnd = 7 * 60
+
+    static func register(_ defaults: UserDefaults = .standard) {
+        defaults.register(defaults: [
+            highHREnabled: true,
+            highHRBpm: defaultHighHRBpm,
+            lowSpO2Enabled: true,
+            lowSpO2Percent: defaultLowSpO2Percent,
+            elevatedHREnabled: true,
+            elevatedHRBpm: defaultElevatedHRBpm,
+            tempFeverEnabled: true,
+            quietEnabled: false,
+            quietStartMinutes: defaultQuietStart,
+            quietEndMinutes: defaultQuietEnd,
+        ])
+    }
+
+    static func thresholds(_ d: UserDefaults = .standard) -> HealthAlertThresholds {
+        register(d)
+        return HealthAlertThresholds(
+            highHREnabled: d.bool(forKey: highHREnabled),
+            highHRBpm: d.integer(forKey: highHRBpm),
+            lowSpO2Enabled: d.bool(forKey: lowSpO2Enabled),
+            lowSpO2Percent: d.integer(forKey: lowSpO2Percent),
+            elevatedHREnabled: d.bool(forKey: elevatedHREnabled),
+            elevatedHRBpm: d.integer(forKey: elevatedHRBpm))
+    }
+
+    static func quietHours(_ d: UserDefaults = .standard) -> QuietHours {
+        register(d)
+        return QuietHours(enabled: d.bool(forKey: quietEnabled),
+                          startMinutes: d.integer(forKey: quietStartMinutes),
+                          endMinutes: d.integer(forKey: quietEndMinutes))
+    }
+
+    static func tempFeverEnabledValue(_ d: UserDefaults = .standard) -> Bool {
+        register(d); return d.bool(forKey: tempFeverEnabled)
+    }
+}
+
+// MARK: - De-dupe persistence
+
+/// Persists when each `HealthNotification` last fired, so the pure `NotificationGate` can enforce
+/// the anti-spam backoff across launches. UserDefaults-backed (schema-free, thread-safe), like
+/// `ObservabilityStore`'s alert lane — kept separate so the two alert systems can't collide.
+struct HealthNotificationStore {
+    private let defaults: UserDefaults
+    init(_ defaults: UserDefaults = .standard) { self.defaults = defaults }
+    private static let key = "alerts.health.lastFired"   // [HealthNotification.rawValue: epoch]
+
+    func lastFired() -> [HealthNotification: Date] {
+        let raw = defaults.dictionary(forKey: Self.key) as? [String: Double] ?? [:]
+        var out: [HealthNotification: Date] = [:]
+        for (k, v) in raw where v > 0 {
+            if let n = HealthNotification(rawValue: k) { out[n] = Date(timeIntervalSince1970: v) }
+        }
+        return out
+    }
+
+    func markFired(_ notifs: [HealthNotification], at now: Date = Date()) {
+        guard !notifs.isEmpty else { return }
+        var raw = defaults.dictionary(forKey: Self.key) as? [String: Double] ?? [:]
+        for n in notifs { raw[n.rawValue] = now.timeIntervalSince1970 }
+        defaults.set(raw, forKey: Self.key)
+    }
+}
+
+// MARK: - The engine
+
+@MainActor
+struct HealthNotificationCenter {
+    var store = HealthNotificationStore()
+    var gate = NotificationGate()
+    private var center: UNUserNotificationCenter { .current() }
+
+    /// How far back instantaneous HR/SpO2 alerts (#73) look for a threshold crossing. Covers an
+    /// overnight sync that finishes in the morning; the de-dupe backoff stops it from re-nagging.
+    static let instantLookback: TimeInterval = 12 * 3600
+    /// Window for the sustained-elevated-HR-while-inactive rule.
+    static let inactiveLookback: TimeInterval = 24 * 3600
+
+    /// Evaluate ALL health-alert conditions (#73 + #85) from the store (+ optional live session),
+    /// then post a debounced notification for each survivor. Safe to call liberally — a no-op when
+    /// nothing crosses a threshold or everything is inside the backoff/quiet window.
+    func evaluate(store localStore: LocalStore, session: RingSession?, now: Date = Date()) async {
+        var candidates: [HealthNotification] = []
+        var hitByNotif: [HealthNotification: HealthAlertHit] = [:]
+
+        // --- #73: high HR / low SpO2 / elevated-HR-while-inactive --------------------------------
+        let thresholds = HealthAlertDefaults.thresholds()
+        let instantSince = now.addingTimeInterval(-Self.instantLookback)
+        let inactiveSince = now.addingTimeInterval(-Self.inactiveLookback)
+
+        // Stored readings + the just-synced in-memory batch (so a fresh sync is reflected at once).
+        var hr = ((try? localStore.recentSamples(kind: .heartRate, since: instantSince)) ?? [])
+            .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        var spo2 = ((try? localStore.recentSamples(kind: .spo2, since: instantSince)) ?? [])
+            .map { SpO2Reading(percent: Int(($0.value * 100).rounded()), time: $0.start) }
+        let inactiveHR = ((try? localStore.recentSamples(kind: .heartRate, since: inactiveSince)) ?? [])
+            .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+
+        if let synced = session?.historySamples {
+            hr += synced.filter { $0.kind == .heartRate && $0.value > 0 && $0.start >= instantSince }
+                .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+            spo2 += synced.filter { $0.kind == .spo2 && $0.value > 0 && $0.start >= instantSince }
+                .map { SpO2Reading(percent: Int(($0.value * 100).rounded()), time: $0.start) }
+        }
+
+        for hit in HealthAlertEvaluator.evaluate(hr: hr, spo2: spo2, inactiveHR: inactiveHR,
+                                                 thresholds: thresholds) {
+            candidates.append(hit.notification)
+            hitByNotif[hit.notification] = hit
+        }
+
+        // --- #85: skin-temp anomaly flags + suspected fever ------------------------------------
+        if HealthAlertDefaults.tempFeverEnabledValue() {
+            candidates += tempFeverCandidates(store: localStore)
+        }
+
+        // --- Route survivors through the ONE shared gate (quiet hours + backoff) ---------------
+        let quiet = HealthAlertDefaults.quietHours()
+        let fire = gate.filter(candidates, now: now, lastFired: store.lastFired(), quietHours: quiet)
+        guard !fire.isEmpty, await ensureAuthorized() else { return }
+        for n in fire { await post(n, hit: hitByNotif[n]) }
+        store.markFired(fire, at: now)
+    }
+
+    /// Compute the latest night's skin-temp anomaly flags (#69) + suspected fever (#72), then map
+    /// them to notifications (#85). Reuses the SAME canonical SkinTempBaseline offset the Sleep card
+    /// shows — temperature is not recomputed for fever.
+    private func tempFeverCandidates(store: LocalStore) -> [HealthNotification] {
+        guard let latest = try? store.latestSleepSummary(), latest.skinTempC > 0 else { return [] }
+        let nights = ((try? store.recentSleepSummaries(limit: 40)) ?? []).filter { $0.skinTempC > 0 }
+        let cal = Calendar.current
+        let tonightDay = cal.startOfDay(for: latest.night)
+        let prior = nights
+            .filter { cal.startOfDay(for: $0.night) != tonightDay }
+            .map { SkinTempBaseline.NightlyTemp(night: $0.night, celsius: $0.skinTempC) }
+        let previousNight = prior.max { $0.night < $1.night }?.celsius
+        let report = SkinTempBaseline.report(tonight: latest.skinTempC, priorNights: prior,
+                                             previousNight: previousNight)
+
+        // Fever: resting-HR baseline vs today + the canonical temp offset (#72 owns the logic).
+        let fever = suspectedFever(store: store, tempOffsetC: report.offsetC)
+        return TempFeverNotifications.notifications(flags: report.flags, feverSuspected: fever)
+    }
+
+    /// Resting-HR daily series → personal baseline, cross-referenced with the temp offset for the
+    /// fever flag. Returns false on insufficient history (never a false positive).
+    private func suspectedFever(store: LocalStore, tempOffsetC: Double?) -> Bool {
+        guard let tempOffsetC else { return false }
+        let since = Date().addingTimeInterval(-Double(VitalsBaseline.Config().maxBaselineDays + 2) * 86_400)
+        let hr = ((try? store.recentSamples(kind: .heartRate, since: since)) ?? [])
+            .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        let daily = RestingHR.dailyValues(hr: hr).sorted { $0.day < $1.day }
+        guard let today = daily.last?.bpm else { return false }
+        let prior = daily.dropLast().map(\.bpm)
+        return VitalsBaseline.suspectedFever(restingHRToday: today, restingHRPrior: Array(prior),
+                                             skinTempOffsetC: tempOffsetC)
+    }
+
+    /// Request notification authorization LAZILY — only the first time there's actually something
+    /// to post, so a user who never crosses a threshold is never prompted. These are alerts the
+    /// user opted into in Settings, so we request a standard (visible) authorization.
+    private func ensureAuthorized() async -> Bool {
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined:
+            return (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+        default:
+            return false
+        }
+    }
+
+    private func post(_ n: HealthNotification, hit: HealthAlertHit?) async {
+        let content = UNMutableNotificationContent()
+        let copy = Self.copy(for: n, hit: hit)
+        content.title = copy.title
+        content.body = copy.body + "\n\n" + Self.disclaimer
+        content.sound = .default
+        // One pending request per condition (stable id) — re-posting just refreshes it.
+        let request = UNNotificationRequest(identifier: "alerts.health.\(n.rawValue)",
+                                            content: content, trigger: nil)
+        try? await center.add(request)
+    }
+
+    // MARK: Copy
+
+    /// The medical-disclaimer line carried on EVERY health/fever notification, per the APK
+    /// (pp.txt:45929 / 46204): "Note: This product is not a medical device …".
+    static let disclaimer =
+        "Note: OpenRingConn is not a medical device. These reminders are based on ring sensor "
+        + "data only and are not a diagnosis. If you feel unwell, consult a qualified medical professional."
+
+    private static func timeString(_ date: Date?) -> String {
+        guard let date else { return "" }
+        let f = DateFormatter(); f.timeStyle = .short
+        return f.string(from: date)
+    }
+
+    static func copy(for n: HealthNotification, hit: HealthAlertHit?) -> (title: String, body: String) {
+        let at = timeString(hit?.time)
+        switch n {
+        case .highHR:
+            let bpm = hit.map { Int($0.value) }
+            return ("High heart rate",
+                    "High heart rate detected"
+                    + (bpm.map { " (\($0) bpm)" } ?? "")
+                    + (at.isEmpty ? "" : " at \(at)") + ".")
+        case .lowSpO2:
+            let pct = hit.map { Int($0.value) }
+            return ("Low blood oxygen",
+                    "Low blood oxygen detected"
+                    + (pct.map { " (\($0)%)" } ?? "")
+                    + (at.isEmpty ? "" : " at \(at)") + " (estimate).")
+        case .elevatedHRInactive:
+            let bpm = hit.map { Int($0.value) }
+            return ("Elevated heart rate while inactive",
+                    "Your heart rate stayed elevated"
+                    + (bpm.map { " (above \($0) bpm)" } ?? "")
+                    + " for over 10 minutes while you were inactive. This can indicate a change in how you feel.")
+        case .skinTempRise:
+            return ("Skin temperature elevated",
+                    "Your overnight skin temperature is well above your personal baseline (estimate).")
+        case .skinTempDrop:
+            return ("Skin temperature low",
+                    "Your overnight skin temperature is well below your personal baseline (estimate).")
+        case .skinTempFluctuationRise:
+            return ("Skin temperature jumped",
+                    "Your overnight skin temperature rose sharply versus the previous night (estimate).")
+        case .skinTempFluctuationDrop:
+            return ("Skin temperature dropped",
+                    "Your overnight skin temperature fell sharply versus the previous night (estimate).")
+        case .fever:
+            return ("Possible fever signs",
+                    "Your skin temperature and heart rate are both elevated above your baseline, "
+                    + "which can accompany suspected fever symptoms (estimate).")
+        }
+    }
+}

--- a/ios/OpenRingConn/HealthNotificationCenter.swift
+++ b/ios/OpenRingConn/HealthNotificationCenter.swift
@@ -14,6 +14,33 @@ import UserNotifications
 // alerts the user opted into. They share the same app-wide notification authorization, but keep
 // their own settings, de-dupe lane, and copy (each carries the "not a medical device" disclaimer).
 
+// MARK: - Reminder settings (#84)
+
+/// `@AppStorage`/`UserDefaults` keys + defaults for the three app-side reminders (#84).
+/// Registered so `bool(forKey:)`/`integer(forKey:)` return the intended value on first run,
+/// mirroring the pattern in `HealthAlertDefaults`.
+enum ReminderDefaults {
+    static let sedentaryEnabled    = "reminder.sedentary.enabled"
+    static let sedentaryIntervalMin = "reminder.sedentary.intervalMin"
+    static let wearEnabled          = "reminder.wear.enabled"
+    static let bedtimeEnabled       = "reminder.bedtime.enabled"
+    static let bedtimeMinutesBefore = "reminder.bedtime.minutesBefore"
+
+    /// UserDefaults key written by RingSession when a nonzero step delta arrives.
+    /// Read by `evaluateReminders` to decide whether the user has been sedentary.
+    static let lastActivityAt = "reminder.lastActivityAt"
+
+    static func register(_ d: UserDefaults = .standard) {
+        d.register(defaults: [
+            sedentaryEnabled:    true,
+            sedentaryIntervalMin: 50,
+            wearEnabled:         false,
+            bedtimeEnabled:      false,
+            bedtimeMinutesBefore: 30,
+        ])
+    }
+}
+
 // MARK: - Settings (shared by the engine and the settings UI)
 
 /// `@AppStorage`/`UserDefaults` keys + defaults for the health-alert thresholds and quiet hours.
@@ -199,6 +226,74 @@ struct HealthNotificationCenter {
                                              skinTempOffsetC: tempOffsetC)
     }
 
+    // MARK: - Reminders (#84)
+
+    /// Evaluate all three app-side reminders (sedentary / wear / bedtime) and fire any
+    /// survivors through the ONE shared gate (quiet hours + anti-spam backoff). Safe to
+    /// call liberally — a no-op when nothing crosses a threshold or everything is held by
+    /// the gate. Pass `sleepEnabled = true` and the configured bed/wake minutes to enable
+    /// the bedtime reminder; pass `sleepEnabled = false` to skip it.
+    func evaluateReminders(session: RingSession?,
+                           sleepBedMinutes: Int, sleepWakeMinutes: Int, sleepEnabled: Bool,
+                           now: Date = Date()) async {
+        ReminderDefaults.register()
+        let d = UserDefaults.standard
+        var candidates: [HealthNotification] = []
+
+        // Sedentary / move reminder
+        if d.bool(forKey: ReminderDefaults.sedentaryEnabled) {
+            let interval = TimeInterval(d.integer(forKey: ReminderDefaults.sedentaryIntervalMin)) * 60
+            let r = SedentaryReminder(interval: max(interval, 10 * 60))
+            let lastActivityEpoch = d.double(forKey: ReminderDefaults.lastActivityAt)
+            let lastActivityAt: Date? = lastActivityEpoch > 0
+                ? Date(timeIntervalSince1970: lastActivityEpoch) : nil
+            if r.shouldFire(lastActivityAt: lastActivityAt, now: now) {
+                candidates.append(.sedentaryReminder)
+            }
+        }
+
+        // Wear reminder
+        if d.bool(forKey: ReminderDefaults.wearEnabled) {
+            let r = WearReminder()
+            // "ever connected" = a peripheral ID has been persisted by RingScanner.
+            let hasSavedRing = d.string(forKey: "com.openringconn.ring.peripheralID") != nil
+            let lastData = session?.lastFrameAt
+            if r.shouldFire(lastRingDataAt: lastData, now: now, everConnected: hasSavedRing) {
+                candidates.append(.wearReminder)
+            }
+        }
+
+        // Bedtime reminder
+        if sleepEnabled, d.bool(forKey: ReminderDefaults.bedtimeEnabled) {
+            let minutesBefore = d.integer(forKey: ReminderDefaults.bedtimeMinutesBefore)
+            let r = BedtimeReminder(minutesBefore: max(minutesBefore, 5))
+            if r.shouldFire(now: now, bedMinutes: sleepBedMinutes, wakeMinutes: sleepWakeMinutes) {
+                candidates.append(.bedtimeReminder)
+            }
+        }
+
+        guard !candidates.isEmpty else { return }
+        let quiet = HealthAlertDefaults.quietHours()
+        let fire = gate.filter(candidates, now: now, lastFired: store.lastFired(), quietHours: quiet)
+        guard !fire.isEmpty, await ensureAuthorized() else { return }
+        for n in fire { await post(n, hit: nil) }
+        store.markFired(fire, at: now)
+    }
+
+    // MARK: - Charging complete (#86)
+
+    /// Post a "ring fully charged" notification, routed through the shared gate so it
+    /// respects quiet hours and the anti-spam backoff. Called by ContentView when
+    /// `BatteryTTE.justReachedFull` fires. (#86)
+    func postChargingComplete(store localStore: LocalStore) async {
+        let candidates: [HealthNotification] = [.chargingComplete]
+        let quiet = HealthAlertDefaults.quietHours()
+        let fire = gate.filter(candidates, now: Date(), lastFired: store.lastFired(), quietHours: quiet)
+        guard !fire.isEmpty, await ensureAuthorized() else { return }
+        for n in fire { await post(n, hit: nil) }
+        store.markFired(fire)
+    }
+
     /// Request notification authorization LAZILY — only the first time there's actually something
     /// to post, so a user who never crosses a threshold is never prompted. These are alerts the
     /// user opted into in Settings, so we request a standard (visible) authorization.
@@ -277,6 +372,20 @@ struct HealthNotificationCenter {
             return ("Possible fever signs",
                     "Your skin temperature and heart rate are both elevated above your baseline, "
                     + "which can accompany suspected fever symptoms (estimate).")
+        // #84 reminders — no medical disclaimer appended (they're lifestyle reminders)
+        case .sedentaryReminder:
+            return ("Move reminder",
+                    "You've been inactive for a while — time to move! (estimated)")
+        case .wearReminder:
+            return ("Ring not detected",
+                    "Put your ring back on to continue tracking.")
+        case .bedtimeReminder:
+            return ("Bedtime reminder",
+                    "Time to wind down for bed.")
+        // #86 battery
+        case .chargingComplete:
+            return ("Ring fully charged",
+                    "Your RingConn ring has reached 100% — disconnect the charger (estimated).")
         }
     }
 }

--- a/ios/OpenRingConn/Info.plist
+++ b/ios/OpenRingConn/Info.plist
@@ -29,6 +29,8 @@
 	<string>OpenRingConn reads health metrics from your RingConn ring to display them.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>OpenRingConn writes your ring's metrics into Apple Health.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>OpenRingConn uses your location to map outdoor workout routes (walking, running, cycling, hiking). Location is not used outside of an active workout.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>

--- a/ios/OpenRingConn/Info.plist
+++ b/ios/OpenRingConn/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.openringconn.app.bgrefresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -27,6 +31,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>
+		<string>fetch</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/ios/OpenRingConn/Info.plist
+++ b/ios/OpenRingConn/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>com.openringconn.app.bgrefresh</string>
+		<string>com.dreamality.openringconn.bgrefresh</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/ios/OpenRingConn/Info.plist
+++ b/ios/OpenRingConn/Info.plist
@@ -5,6 +5,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.dreamality.openringconn.bgrefresh</string>
+		<string>com.dreamality.openringconn.bgprocessing</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
@@ -32,6 +33,7 @@
 	<array>
 		<string>bluetooth-central</string>
 		<string>fetch</string>
+		<string>processing</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/ios/OpenRingConn/Observability/ActivityLogView.swift
+++ b/ios/OpenRingConn/Observability/ActivityLogView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import UIKit
+
+// User-reachable observability screen (#44): freshness timestamps, whether iOS is actually
+// running our background tasks, and a bounded log of recent sync outcomes — so a silent failure
+// (a throttled BGTask, a stalled ring) becomes visible instead of invisible.
+
+struct ActivityLogView: View {
+    private let store = ObservabilityStore()
+    @State private var records: [TaskRecord] = []
+    @State private var refreshStatus: UIBackgroundRefreshStatus = .available
+
+    var body: some View {
+        List {
+            Section("Freshness") {
+                timeRow("Last successful sync", store.lastSuccessfulSync)
+                timeRow("Last Health write", store.lastHealthWrite)
+            }
+
+            Section("Background tasks") {
+                timeRow("Last background run", store.bgLastRun)
+                timeRow("Last scheduled", store.bgLastScheduled)
+                LabeledContent("Background App Refresh", value: refreshStatusText)
+                if refreshStatus != .available {
+                    Text("iOS is limiting background activity. Turn on Settings ▸ General ▸ "
+                         + "Background App Refresh so the ring can sync while the app is closed.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                Text("Background heart-rate runs at iOS's discretion (usually overnight while "
+                     + "charging) and is best-effort — daytime background HR is not guaranteed.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+
+            Section("Recent activity") {
+                if records.isEmpty {
+                    Text("No background activity recorded yet.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(records.reversed()) { record in
+                        recordRow(record)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Background activity")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            records = store.records()
+            refreshStatus = UIApplication.shared.backgroundRefreshStatus
+        }
+    }
+
+    private func timeRow(_ label: String, _ date: Date?) -> some View {
+        LabeledContent(label) {
+            if let date {
+                Text(date, format: .relative(presentation: .named))
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("never").foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private func recordRow(_ record: TaskRecord) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: record.success ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(record.success ? .green : .orange)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(kindLabel(record.kind)).font(.subheadline.weight(.medium))
+                    Spacer()
+                    Text(record.date, format: .dateTime.month().day().hour().minute())
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+                if let detail = record.detail {
+                    Text(detail).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func kindLabel(_ kind: TaskRecord.Kind) -> String {
+        switch kind {
+        case .appRefresh: return "App refresh"
+        case .processing: return "Processing"
+        case .foreground: return "Foreground sync"
+        }
+    }
+
+    private var refreshStatusText: String {
+        switch refreshStatus {
+        case .available: return "On"
+        case .denied: return "Off"
+        case .restricted: return "Restricted"
+        @unknown default: return "Unknown"
+        }
+    }
+}

--- a/ios/OpenRingConn/Observability/ObservabilityStore.swift
+++ b/ios/OpenRingConn/Observability/ObservabilityStore.swift
@@ -1,0 +1,173 @@
+import Foundation
+import OpenRingKit
+import UserNotifications
+
+// Observability/alerting glue for the always-on tracker (#44). The PURE policy (thresholds +
+// debounce + ring-buffer trim) lives in OpenRingKit (`SyncObservability.swift`); this file is the
+// app-side persistence + notification plumbing. Deliberately UserDefaults-backed, NOT SwiftData:
+// a separate, schema-free store avoids a migration and a collision with the steps lane. Plain
+// `struct` over `UserDefaults` (itself thread-safe), so the foreground UI and the background task
+// can both record without an actor hop.
+
+/// One recorded sync/background-task outcome for the user-visible activity log.
+struct TaskRecord: Codable, Identifiable, Equatable {
+    enum Kind: String, Codable {
+        case appRefresh   // BGAppRefreshTask (short ~30 s window)
+        case processing   // BGProcessingTask (longer window — gives background HR a chance, #45)
+        case foreground   // a sync the user triggered / a foreground auto-refresh
+    }
+    var id = UUID()
+    var date: Date
+    var kind: Kind
+    var success: Bool
+    var detail: String?
+}
+
+/// Reads/writes the observability timestamps + bounded outcome log in UserDefaults.
+struct ObservabilityStore {
+    private let defaults: UserDefaults
+    init(_ defaults: UserDefaults = .standard) { self.defaults = defaults }
+
+    /// Keep the last N outcomes (newest survive — see `BoundedLog`). Small: this is a debug aid.
+    static let logLimit = 40
+
+    private enum Key {
+        static let lastSync = "obs.lastSuccessfulSync"
+        static let lastHealthWrite = "obs.lastHealthWrite"
+        static let bgLastRun = "obs.bgLastRun"
+        static let bgLastScheduled = "obs.bgLastScheduled"
+        static let log = "obs.taskLog"
+        static let alertFired = "obs.alertLastFired"        // [SyncAlert.rawValue: epoch]
+        static let healthEverAuthorized = "obs.healthEverAuthorized"
+    }
+
+    // MARK: Timestamps
+
+    var lastSuccessfulSync: Date? { date(Key.lastSync) }
+    var lastHealthWrite: Date? { date(Key.lastHealthWrite) }
+    var bgLastRun: Date? { date(Key.bgLastRun) }
+    var bgLastScheduled: Date? { date(Key.bgLastScheduled) }
+    var healthEverAuthorized: Bool { defaults.bool(forKey: Key.healthEverAuthorized) }
+
+    private func date(_ key: String) -> Date? {
+        let t = defaults.double(forKey: key)
+        return t > 0 ? Date(timeIntervalSince1970: t) : nil
+    }
+
+    /// Latch that Health share access was granted at least once, so a LATER revocation can be
+    /// distinguished from "never opted in" (gates the `healthAuthLost` alert).
+    func markHealthEverAuthorized() { defaults.set(true, forKey: Key.healthEverAuthorized) }
+
+    // MARK: Recording
+
+    /// Record a sync attempt's outcome. A success bumps "last successful sync"; any
+    /// background-originated run (not `.foreground`) bumps "last background run" so the user can
+    /// see whether iOS is actually waking the app. Appends to the bounded log either way.
+    func recordSyncOutcome(kind: TaskRecord.Kind, success: Bool, detail: String?, at now: Date = Date()) {
+        if kind != .foreground { defaults.set(now.timeIntervalSince1970, forKey: Key.bgLastRun) }
+        if success { defaults.set(now.timeIntervalSince1970, forKey: Key.lastSync) }
+        append(TaskRecord(date: now, kind: kind, success: success, detail: detail))
+    }
+
+    /// Record that we mirrored data into Apple Health (drives the "Last Health write" line).
+    func recordHealthWrite(at now: Date = Date()) {
+        defaults.set(now.timeIntervalSince1970, forKey: Key.lastHealthWrite)
+    }
+
+    /// Record that we (re)submitted a BGTask request — lets the UI show "scheduled vs. last run"
+    /// so a large gap reads as "iOS is throttling us", not "the app is broken".
+    func recordScheduled(at now: Date = Date()) {
+        defaults.set(now.timeIntervalSince1970, forKey: Key.bgLastScheduled)
+    }
+
+    // MARK: Bounded outcome log
+
+    func records() -> [TaskRecord] {
+        guard let data = defaults.data(forKey: Key.log),
+              let list = try? JSONDecoder().decode([TaskRecord].self, from: data) else { return [] }
+        return list
+    }
+
+    private func append(_ record: TaskRecord) {
+        let capped = BoundedLog.appendCapped(record, to: records(), limit: Self.logLimit)
+        if let data = try? JSONEncoder().encode(capped) { defaults.set(data, forKey: Key.log) }
+    }
+
+    // MARK: Alert debounce persistence (consumed by SyncAlertPolicy)
+
+    func alertLastFired() -> [SyncAlert: Date] {
+        let raw = defaults.dictionary(forKey: Key.alertFired) as? [String: Double] ?? [:]
+        var out: [SyncAlert: Date] = [:]
+        for (k, v) in raw where v > 0 {
+            if let alert = SyncAlert(rawValue: k) { out[alert] = Date(timeIntervalSince1970: v) }
+        }
+        return out
+    }
+
+    func markAlertsFired(_ alerts: [SyncAlert], at now: Date = Date()) {
+        var raw = defaults.dictionary(forKey: Key.alertFired) as? [String: Double] ?? [:]
+        for a in alerts { raw[a.rawValue] = now.timeIntervalSince1970 }
+        defaults.set(raw, forKey: Key.alertFired)
+    }
+}
+
+/// Posts the debounced silent-failure notifications (#44). One notification per condition per
+/// `SyncAlertPolicy.renotifyInterval`; never spams. Authorization is requested LAZILY and
+/// provisionally — the first time there's actually something to say — so a healthy user is never
+/// prompted on launch and quiet alerts land in Notification Center without an upfront dialog.
+struct LocalAlertCenter {
+    var store = ObservabilityStore()
+    var policy = SyncAlertPolicy()
+    // Computed (not a stored property) so the synthesized memberwise init stays internal — i.e.
+    // `LocalAlertCenter()` is callable from the other files that fire alerts.
+    private var center: UNUserNotificationCenter { .current() }
+
+    /// Evaluate the current state and post a debounced notification for each firing condition.
+    /// No-op when nothing's wrong. `batteryPercent == nil` (e.g. the background session is already
+    /// torn down) simply skips the low-battery check rather than firing falsely.
+    func evaluate(now: Date = Date(), batteryPercent: Int?, healthAuthorized: Bool) async {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: store.lastSuccessfulSync,
+            batteryPercent: batteryPercent,
+            healthAuthorized: healthAuthorized,
+            healthEverAuthorized: store.healthEverAuthorized,
+            lastFired: store.alertLastFired())
+        guard !fire.isEmpty, await ensureAuthorized() else { return }
+        for alert in fire { await post(alert) }
+        store.markAlertsFired(fire, at: now)
+    }
+
+    private func ensureAuthorized() async -> Bool {
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined:
+            // Provisional auth posts quietly (no upfront prompt) — appropriate for an alert the
+            // user hasn't asked for but would want when something silently breaks.
+            return (try? await center.requestAuthorization(options: [.alert, .sound, .provisional])) ?? false
+        default:
+            return false
+        }
+    }
+
+    private func post(_ alert: SyncAlert) async {
+        let content = UNMutableNotificationContent()
+        switch alert {
+        case .notSynced:
+            content.title = "Ring not synced"
+            content.body = "OpenRingConn hasn't synced your ring in a while. Open the app to refresh, and check Settings ▸ General ▸ Background App Refresh."
+        case .lowBattery:
+            content.title = "Ring battery low"
+            content.body = "Your RingConn battery is low — charge it soon to keep tracking."
+        case .healthAuthLost:
+            content.title = "Apple Health access off"
+            content.body = "OpenRingConn can no longer write to Apple Health. Re-enable it in Settings ▸ Health ▸ Data Access & Devices."
+        }
+        // One pending request per condition (stable id) — re-posting just refreshes it.
+        let request = UNNotificationRequest(identifier: "obs.alert.\(alert.rawValue)",
+                                            content: content, trigger: nil)
+        try? await center.add(request)
+    }
+}

--- a/ios/OpenRingConn/SleepCardView.swift
+++ b/ios/OpenRingConn/SleepCardView.swift
@@ -20,8 +20,13 @@ import OpenRingKit
 /// Stages (Deep/Light/REM/Awake) are an on-device ESTIMATE — the ring doesn't transmit a
 /// hypnogram (PROTOCOL.md §5.3) — so the card labels them "est.".
 struct SleepCardView: View {
-    /// Latest persisted night (capped at 1) — the offline source of truth.
+    @Environment(\.modelContext) private var modelContext
+    /// Trailing persisted nights (latest first) — the offline source of truth. The window is
+    /// wider than 1 so the rolling skin-temp baseline + the offset mini-chart (#69) have history;
+    /// `latest` (= `storedSleep.first`) still drives the headline night.
     @Query private var storedSleep: [StoredSleepSummary]
+    /// Today's auto-detected naps (#76), latest first.
+    @Query private var todayNaps: [StoredNap]
     /// Freshly staged segments from the just-finished sync (empty when none / after disconnect).
     /// Preferred over the store so a completed sync updates the card immediately.
     var liveSegments: [SleepSegment]
@@ -34,11 +39,20 @@ struct SleepCardView: View {
     /// Days of HR/HRV/SpO₂ history scanned before the precise night window is applied in memory.
     private static let vitalsWindowDays: TimeInterval = 3
 
+    /// Trailing nights queried for the baseline + temp chart (#69). 35 ≥ the 30-night baseline.
+    private static let historyNights = 35
+
     init(liveSegments: [SleepSegment] = []) {
         self.liveSegments = liveSegments
         var d = FetchDescriptor<StoredSleepSummary>(sortBy: [SortDescriptor(\.night, order: .reverse)])
-        d.fetchLimit = 1
+        d.fetchLimit = Self.historyNights
         _storedSleep = Query(d)
+
+        // Naps that started today (#76).
+        let dayStart = Calendar.current.startOfDay(for: Date())
+        _todayNaps = Query(FetchDescriptor<StoredNap>(
+            predicate: #Predicate { $0.start >= dayStart },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]))
 
         // Anchor the window to the start of the current hour so the descriptor stays stable across
         // rapid re-renders (re-fetching hourly or when data changes), not on every render.
@@ -67,6 +81,11 @@ struct SleepCardView: View {
         /// relative term, so a pre-midnight night isn't mislabeled "yesterday".
         let wakeKnown: Bool
     }
+
+    /// Latest persisted night — the source of the detail metrics (#69/#70/#71). Aligns with the
+    /// displayed `night`: a fresh sync upserts it before the card settles, and the store fallback
+    /// already reads from it.
+    private var latest: StoredSleepSummary? { storedSleep.first }
 
     /// The night to show: prefer this connection's freshly synced staging (instant), else the
     /// most recent persisted night (survives all day / offline). Only ever a real night (asleep > 0).
@@ -118,12 +137,14 @@ struct SleepCardView: View {
     private func content(_ night: Night) -> some View {
         let s = night.summary
         let m = s.minutes
-        // Headline: total time asleep.
+        // Headline: total time asleep + the composite Sleep Score badge (#70).
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             Text("\(m.asleep / 60)h \(m.asleep % 60)m")
                 .font(.system(size: 36, weight: .bold, design: .rounded))
                 .monospacedDigit().contentTransition(.numericText())
             Text("asleep").font(.subheadline.weight(.semibold)).foregroundStyle(.secondary)
+            Spacer()
+            if let score = latest?.sleepScore, score > 0 { scoreBadge(score) }
         }
         stageBar(m)
         stageLegend(m)
@@ -133,9 +154,252 @@ struct SleepCardView: View {
         if let avg = overnightAverages(night) {
             overnightVitals(avg)
         }
+        // Detail metrics (#69/#70/#71/#76), grouped so this builder stays under the ViewBuilder
+        // child limit. All read from the latest persisted summary, so they survive offline.
+        detailSection()
         // Footer: sleep window · efficiency · est. caveat.
         Text(footer(night).joined(separator: " · "))
             .font(.caption2).foregroundStyle(.tertiary)
+    }
+
+    /// The Wave-1 sleep-detail rows in one group: per-stage HR, overnight stress, skin-temp
+    /// baseline, movement chart, naps, and the subjective rating.
+    @ViewBuilder
+    private func detailSection() -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            perStageHR()       // #70 per-stage average HR
+            stressRow()        // #71 overnight stress
+            skinTempSection()  // #69 nightly skin-temp + baseline offset + mini chart
+            movementSection()  // #70 2.5-min / 3-level movement chart
+            napsRow()          // #76 daytime naps
+            feelRating()       // #70 subjective rating
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Sleep Score badge (#70)
+
+    /// Tier color for a 0–100 composite Sleep Score (≥85 / 70–84 / <70).
+    private func scoreColor(_ score: Int) -> Color {
+        switch SleepScore.Tier.of(score) {
+        case .excellent: return .green
+        case .good: return .teal
+        case .needsImprovement: return .orange
+        }
+    }
+
+    private func scoreBadge(_ score: Int) -> some View {
+        VStack(spacing: 0) {
+            Text("\(score)")
+                .font(.system(size: 22, weight: .bold, design: .rounded)).monospacedDigit()
+            Text("score").font(.system(size: 9)).foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 10).padding(.vertical, 4)
+        .background(RoundedRectangle(cornerRadius: 10).fill(scoreColor(score).opacity(0.18)))
+        .foregroundStyle(scoreColor(score))
+    }
+
+    // MARK: Per-stage HR (#70)
+
+    @ViewBuilder
+    private func perStageHR() -> some View {
+        let stages: [(name: String, bpm: Int)] = [
+            ("Deep", latest?.hrDeep ?? 0), ("Light", latest?.hrLight ?? 0),
+            ("REM", latest?.hrRem ?? 0), ("Awake", latest?.hrAwake ?? 0),
+        ].filter { $0.1 > 0 }
+        if !stages.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Avg HR by stage").font(.caption2).foregroundStyle(.secondary)
+                HStack(spacing: 16) {
+                    ForEach(stages, id: \.name) { stage in stat(stage.name, "\(stage.bpm)", "bpm") }
+                }
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    // MARK: Overnight stress (#71)
+
+    @ViewBuilder
+    private func stressRow() -> some View {
+        if let score = latest?.stressScore, score > 0 {
+            let band = SleepStress.Band.of(score)
+            HStack(spacing: 6) {
+                Image(systemName: "waveform.path.ecg").font(.caption2).foregroundStyle(stressColor(band))
+                Text("Overnight stress").font(.caption2).foregroundStyle(.secondary)
+                Text("\(score)").font(.caption.weight(.semibold)).monospacedDigit()
+                Text(band.label).font(.caption2).foregroundStyle(stressColor(band))
+                Text("· est.").font(.caption2).foregroundStyle(.tertiary)
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    private func stressColor(_ band: SleepStress.Band) -> Color {
+        switch band {
+        case .relaxed: return .green
+        case .normal: return .teal
+        case .medium: return .orange
+        case .high: return .red
+        }
+    }
+
+    // MARK: Skin-temperature baseline + nightly deviation (#69)
+
+    /// Build a `SkinTempBaseline.NightReport` for the latest night from the trailing stored nights.
+    private var tempReport: SkinTempBaseline.NightReport? {
+        guard let latest, latest.skinTempC > 0 else { return nil }
+        let priorNights = storedSleep
+            .filter { $0.skinTempC > 0 && $0.night != latest.night }
+            .map { SkinTempBaseline.NightlyTemp(night: $0.night, celsius: $0.skinTempC) }
+        return SkinTempBaseline.report(tonight: latest.skinTempC, priorNights: priorNights)
+    }
+
+    @ViewBuilder
+    private func skinTempSection() -> some View {
+        if let r = tempReport {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Image(systemName: "thermometer.medium").font(.caption2).foregroundStyle(.pink)
+                    Text("Skin temp").font(.caption2).foregroundStyle(.secondary)
+                    Text(String(format: "%.1f°C", r.nightlyC))
+                        .font(.caption.weight(.semibold)).monospacedDigit()
+                    if let off = r.offsetC {
+                        Text(String(format: "%+.1f°C vs baseline", off))
+                            .font(.caption2).foregroundStyle(tempColor(r.band))
+                    } else {
+                        Text("baseline building").font(.caption2).foregroundStyle(.tertiary)
+                    }
+                }
+                tempChart()
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    private func tempColor(_ band: SkinTempBaseline.DeviationBand?) -> Color {
+        switch band {
+        case .abnormalRise: return .red
+        case .abnormalDrop: return .blue
+        default: return .secondary
+        }
+    }
+
+    /// Bar color for a nightly offset: green within ±1 °C, red/blue when abnormal.
+    private func tempBarColor(_ off: Double) -> Color {
+        let band = SkinTempBaseline.deviationBand(offset: off)
+        return band == .normal ? .green : tempColor(band)
+    }
+
+    /// Compact baseline chart (#69): each recent night's offset from the rolling baseline as a
+    /// bar above (warmer) / below (cooler) a center baseline line.
+    @ViewBuilder
+    private func tempChart() -> some View {
+        let nights = storedSleep.filter { $0.skinTempC > 0 }
+        if nights.count >= SkinTempBaseline.minBaselineNights,
+           let baseline = SkinTempBaseline.baseline(
+                priorNights: nights.map { SkinTempBaseline.NightlyTemp(night: $0.night, celsius: $0.skinTempC) }) {
+            // Oldest→newest, last ~14 nights, as offsets from the baseline.
+            let points = nights.sorted { $0.night < $1.night }.suffix(14).map { $0.skinTempC - baseline }
+            let maxAbs = max(points.map { abs($0) }.max() ?? 0.5, 0.5)
+            GeometryReader { geo in
+                let halfH = geo.size.height / 2
+                HStack(alignment: .center, spacing: 2) {
+                    ForEach(Array(points.enumerated()), id: \.offset) { _, off in
+                        let frac = min(max(off / maxAbs, -1), 1)         // -1…1
+                        let barH = max(abs(frac) * halfH, 1)
+                        VStack(spacing: 0) {
+                            ZStack(alignment: .bottom) {
+                                Color.clear
+                                if frac >= 0 { Rectangle().fill(tempBarColor(off)).frame(height: barH) }
+                            }.frame(height: halfH)
+                            ZStack(alignment: .top) {
+                                Color.clear
+                                if frac < 0 { Rectangle().fill(tempBarColor(off)).frame(height: barH) }
+                            }.frame(height: halfH)
+                        }
+                    }
+                }
+                .overlay(alignment: .center) {
+                    Rectangle().fill(Color.secondary.opacity(0.4)).frame(height: 1)
+                }
+            }
+            .frame(height: 24)
+        }
+    }
+
+    // MARK: Body-movement chart (#70)
+
+    @ViewBuilder
+    private func movementSection() -> some View {
+        let levels = latest?.movementLevels ?? []
+        if !levels.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Movement").font(.caption2).foregroundStyle(.secondary)
+                GeometryReader { geo in
+                    HStack(spacing: 1) {
+                        ForEach(Array(levels.enumerated()), id: \.offset) { _, lvl in
+                            Rectangle().fill(movementColor(lvl))
+                                .frame(width: max(geo.size.width / CGFloat(levels.count) - 1, 0.5))
+                        }
+                    }
+                }
+                .frame(height: 16)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    private func movementColor(_ level: Int) -> Color {
+        switch level {
+        case 2: return .orange       // active
+        case 1: return .yellow       // light
+        default: return Color.secondary.opacity(0.25)   // still
+        }
+    }
+
+    // MARK: Naps (#76)
+
+    @ViewBuilder
+    private func napsRow() -> some View {
+        if !todayNaps.isEmpty {
+            let totalMin = todayNaps.reduce(0) { $0 + $1.durationMin }
+            HStack(spacing: 6) {
+                Image(systemName: "sun.max.fill").font(.caption2).foregroundStyle(.yellow)
+                Text("Naps today").font(.caption2).foregroundStyle(.secondary)
+                Text("\(todayNaps.count)").font(.caption.weight(.semibold)).monospacedDigit()
+                Text("· \(totalMin)m total").font(.caption2).foregroundStyle(.secondary)
+                Text("· est.").font(.caption2).foregroundStyle(.tertiary)
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    // MARK: Subjective rating (#70)
+
+    @ViewBuilder
+    private func feelRating() -> some View {
+        if let latest {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("How did you sleep?").font(.caption2).foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    ForEach(1...9, id: \.self) { n in
+                        Circle()
+                            .fill(n <= latest.feelScore ? Color.indigo : Color.secondary.opacity(0.18))
+                            .frame(width: 16, height: 16)
+                            .overlay(Text("\(n)").font(.system(size: 9))
+                                .foregroundStyle(n <= latest.feelScore ? .white : .secondary))
+                            .onTapGesture { setFeel(n, night: latest.night) }
+                    }
+                }
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    private func setFeel(_ score: Int, night: Date) {
+        try? LocalStore(modelContext).setFeelScore(score, night: night)
     }
 
     /// Mean HR (bpm) / HRV (ms) / SpO₂ (%) over the night's in-bed window, from the bounded

--- a/ios/OpenRingConn/SleepCardView.swift
+++ b/ios/OpenRingConn/SleepCardView.swift
@@ -21,6 +21,8 @@ import OpenRingKit
 /// hypnogram (PROTOCOL.md §5.3) — so the card labels them "est.".
 struct SleepCardView: View {
     @Environment(\.modelContext) private var modelContext
+    /// Temperature display unit (#83). Syncs with the Units section in UserProfileSettingsView.
+    @AppStorage("units.temperature") private var tempUnitRaw = TemperatureUnit.localeDefault.rawValue
     /// Trailing persisted nights (latest first) — the offline source of truth. The window is
     /// wider than 1 so the rolling skin-temp baseline + the offset mini-chart (#69) have history;
     /// `latest` (= `storedSleep.first`) still drives the headline night.
@@ -262,7 +264,7 @@ struct SleepCardView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "thermometer.medium").font(.caption2).foregroundStyle(.pink)
                     Text("Skin temp").font(.caption2).foregroundStyle(.secondary)
-                    Text(String(format: "%.1f°C", r.nightlyC))
+                    Text(skinTempString(r.nightlyC))
                         .font(.caption.weight(.semibold)).monospacedDigit()
                     if let off = r.offsetC {
                         Text(String(format: "%+.1f°C vs baseline", off))
@@ -275,6 +277,12 @@ struct SleepCardView: View {
             }
             .padding(.top, 2)
         }
+    }
+
+    /// Format a Celsius skin-temp value in the user's chosen unit (#83).
+    private func skinTempString(_ celsius: Double) -> String {
+        let unit = TemperatureUnit(rawValue: tempUnitRaw) ?? .celsius
+        return UnitsFormatter.temperature(celsius, unit: unit)
     }
 
     private func tempColor(_ band: SkinTempBaseline.DeviationBand?) -> Color {

--- a/ios/OpenRingConn/SleepCardView.swift
+++ b/ios/OpenRingConn/SleepCardView.swift
@@ -1,0 +1,282 @@
+import SwiftUI
+import SwiftData
+import OpenRingKit
+
+/// Dedicated, always-visible Sleep section (its own card, sits below Vitals).
+///
+/// The whole point of this view is PERSISTENCE: the most recent night's sleep stays on screen
+/// all day — across reconnects, foreground auto-refreshes, and manual "Sync from ring" taps —
+/// until a *newer* night replaces it. Earlier, sleep was only drawn from the live session's
+/// `stagedSegments` (and the sync card's just-synced batch), so a daytime sync that returned no
+/// new history cleared those and the morning's sleep vanished. Here the source of truth is the
+/// persisted `StoredSleepSummary` rollup (upserted by night in `LocalStore.saveSleepSummary`,
+/// untouched by sample-retention pruning), so it survives offline and across launches.
+///
+/// A just-finished sync is still reflected instantly: `liveSegments` (this connection's freshly
+/// staged night) is preferred over the store when present, mirroring the #67 rationale for the
+/// vitals rows. Once the link drops, `liveSegments` is empty and the @Query store fallback
+/// carries the same night forward.
+///
+/// Stages (Deep/Light/REM/Awake) are an on-device ESTIMATE — the ring doesn't transmit a
+/// hypnogram (PROTOCOL.md §5.3) — so the card labels them "est.".
+struct SleepCardView: View {
+    /// Latest persisted night (capped at 1) — the offline source of truth.
+    @Query private var storedSleep: [StoredSleepSummary]
+    /// Freshly staged segments from the just-finished sync (empty when none / after disconnect).
+    /// Preferred over the store so a completed sync updates the card immediately.
+    var liveSegments: [SleepSegment]
+    /// Sleep-vitals samples (HR / HRV / SpO₂) over the last few days — narrowed in memory to the
+    /// resolved night window for the "overnight average" row under the stage breakdown. Bounded
+    /// (value-positive + windowed) so it never scans all history (#32), mirroring
+    /// `VitalsTableView.recentTemp`. A night older than this window keeps its totals but omits the
+    /// averages (its raw samples have aged out of the query window).
+    @Query private var recentVitals: [StoredSample]
+    /// Days of HR/HRV/SpO₂ history scanned before the precise night window is applied in memory.
+    private static let vitalsWindowDays: TimeInterval = 3
+
+    init(liveSegments: [SleepSegment] = []) {
+        self.liveSegments = liveSegments
+        var d = FetchDescriptor<StoredSleepSummary>(sortBy: [SortDescriptor(\.night, order: .reverse)])
+        d.fetchLimit = 1
+        _storedSleep = Query(d)
+
+        // Anchor the window to the start of the current hour so the descriptor stays stable across
+        // rapid re-renders (re-fetching hourly or when data changes), not on every render.
+        let hourStart = Calendar.current.dateInterval(of: .hour, for: Date())?.start ?? Date()
+        let lookback = hourStart.addingTimeInterval(-Self.vitalsWindowDays * 86_400)
+        let hr = MetricKind.heartRate.rawValue
+        let hrv = MetricKind.hrvSDNN.rawValue
+        let spo2 = MetricKind.spo2.rawValue
+        _recentVitals = Query(FetchDescriptor<StoredSample>(
+            predicate: #Predicate {
+                ($0.kindRaw == hr || $0.kindRaw == hrv || $0.kindRaw == spo2)
+                    && $0.start > lookback && $0.value > 0
+            },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]))
+    }
+
+    /// One night resolved for display, from either the live staging or the persisted rollup.
+    private struct Night {
+        let summary: SleepStaging.Summary
+        let inBedStart: Date?
+        let inBedEnd: Date?
+        /// Reference time for the "last night / yesterday / date" label.
+        let when: Date
+        /// True when `when` is a real wake time. When false (a legacy rollup with no in-bed clock
+        /// times, where `when` is only the start-of-day key) the label shows the date instead of a
+        /// relative term, so a pre-midnight night isn't mislabeled "yesterday".
+        let wakeKnown: Bool
+    }
+
+    /// The night to show: prefer this connection's freshly synced staging (instant), else the
+    /// most recent persisted night (survives all day / offline). Only ever a real night (asleep > 0).
+    /// The live `liveSegments` are already gated to overnight sleep by RingSession (review #1), so a
+    /// daytime nap never reaches here as "last night".
+    private var night: Night? {
+        if !liveSegments.isEmpty {
+            let s = SleepStaging.summary(liveSegments)
+            if s.minutes.asleep > 0 {
+                let start = liveSegments.map(\.start).min()
+                let end = liveSegments.map(\.end).max()
+                return Night(summary: s, inBedStart: start, inBedEnd: end,
+                             when: end ?? start ?? Date(), wakeKnown: end != nil)
+            }
+        }
+        if let s = storedSleep.first, s.asleepMin > 0 {
+            let start = s.inBedStart > .distantPast ? s.inBedStart : nil
+            let end = (s.inBedEnd > s.inBedStart) ? s.inBedEnd : nil
+            return Night(summary: s.asSummary, inBedStart: start, inBedEnd: end,
+                         when: end ?? start ?? s.night, wakeKnown: end != nil)
+        }
+        return nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "moon.zzz.fill").foregroundStyle(.indigo)
+                Text("SLEEP").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                Spacer()
+                if let night {
+                    Text(Self.nightLabel(night.when, wakeKnown: night.wakeKnown))
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            if let night {
+                content(night)
+            } else {
+                emptyState
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16)
+            .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    @ViewBuilder
+    private func content(_ night: Night) -> some View {
+        let s = night.summary
+        let m = s.minutes
+        // Headline: total time asleep.
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text("\(m.asleep / 60)h \(m.asleep % 60)m")
+                .font(.system(size: 36, weight: .bold, design: .rounded))
+                .monospacedDigit().contentTransition(.numericText())
+            Text("asleep").font(.subheadline.weight(.semibold)).foregroundStyle(.secondary)
+        }
+        stageBar(m)
+        stageLegend(m)
+        // Overnight HR / HRV / SpO₂ averages for this night (moved out of the sync card, where
+        // they read as a current "latest" reading). Computed over the night window from stored
+        // samples, so they describe the same night the card is showing and persist with it.
+        if let avg = overnightAverages(night) {
+            overnightVitals(avg)
+        }
+        // Footer: sleep window · efficiency · est. caveat.
+        Text(footer(night).joined(separator: " · "))
+            .font(.caption2).foregroundStyle(.tertiary)
+    }
+
+    /// Mean HR (bpm) / HRV (ms) / SpO₂ (%) over the night's in-bed window, from the bounded
+    /// `recentVitals` query narrowed in memory. nil when the window is unknown (a legacy rollup
+    /// with no clock times) or no samples fall inside it (e.g. a night older than the query
+    /// window). SpO₂ is stored 0…1 and surfaced as a whole percent.
+    private func overnightAverages(_ night: Night) -> (hr: Int?, hrv: Int?, spo2: Int?)? {
+        guard let start = night.inBedStart, let end = night.inBedEnd, end > start else { return nil }
+        let hrKind = MetricKind.heartRate.rawValue
+        let hrvKind = MetricKind.hrvSDNN.rawValue
+        let spo2Kind = MetricKind.spo2.rawValue
+        var hrSum = 0.0, hrN = 0, hrvSum = 0.0, hrvN = 0, spo2Sum = 0.0, spo2N = 0
+        for s in recentVitals where s.start >= start && s.start <= end {
+            if s.kindRaw == hrKind { hrSum += s.value; hrN += 1 }
+            else if s.kindRaw == hrvKind { hrvSum += s.value; hrvN += 1 }
+            else if s.kindRaw == spo2Kind { spo2Sum += s.value; spo2N += 1 }
+        }
+        let hr = hrN > 0 ? Int((hrSum / Double(hrN)).rounded()) : nil
+        let hrv = hrvN > 0 ? Int((hrvSum / Double(hrvN)).rounded()) : nil
+        let spo2 = spo2N > 0 ? Int((spo2Sum / Double(spo2N) * 100).rounded()) : nil
+        return (hr == nil && hrv == nil && spo2 == nil) ? nil : (hr, hrv, spo2)
+    }
+
+    /// "Overnight average" mini-stat row (omits any metric with no samples that night).
+    @ViewBuilder
+    private func overnightVitals(_ avg: (hr: Int?, hrv: Int?, spo2: Int?)) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Overnight average").font(.caption2).foregroundStyle(.secondary)
+            HStack(spacing: 20) {
+                if let hr = avg.hr { stat("HR", "\(hr)", "bpm") }
+                if let hrv = avg.hrv { stat("HRV", "\(hrv)", "ms") }
+                if let spo2 = avg.spo2 { stat("SpO₂", "\(spo2)", "%") }
+            }
+        }
+        .padding(.top, 2)
+    }
+
+    /// Compact labeled stat for the overnight-average row.
+    private func stat(_ label: String, _ value: String, _ unit: String) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(label).font(.caption2).foregroundStyle(.secondary)
+            HStack(alignment: .firstTextBaseline, spacing: 2) {
+                Text(value).font(.subheadline.weight(.semibold)).monospacedDigit()
+                Text(unit).font(.caption2).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    /// Proportional Deep/Light/REM/Awake bar, driven by the night's stage minutes.
+    private func stageBar(_ m: (inBed: Int, awake: Int, light: Int, deep: Int, rem: Int, asleep: Int)) -> some View {
+        let total = Double(m.deep + m.light + m.rem + m.awake)
+        return GeometryReader { geo in
+            HStack(spacing: 1) {
+                ForEach(Self.stages, id: \.name) { stage in
+                    let mins = stage.minutes(m)
+                    Rectangle().fill(stage.color)
+                        .frame(width: total > 0 ? geo.size.width * Double(mins) / total : 0)
+                }
+            }
+        }
+        .frame(height: 12)
+        .clipShape(Capsule())
+    }
+
+    /// Color key with per-stage minutes (omits stages with no time).
+    private func stageLegend(_ m: (inBed: Int, awake: Int, light: Int, deep: Int, rem: Int, asleep: Int)) -> some View {
+        HStack(spacing: 12) {
+            ForEach(Self.stages, id: \.name) { stage in
+                let mins = stage.minutes(m)
+                if mins > 0 {
+                    HStack(spacing: 4) {
+                        Circle().fill(stage.color).frame(width: 7, height: 7)
+                        Text("\(stage.name) \(mins)m").font(.caption2).foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Footer parts: clock window (when known) + efficiency + the estimate caveat.
+    private func footer(_ night: Night) -> [String] {
+        var parts: [String] = []
+        if let start = night.inBedStart, let end = night.inBedEnd {
+            parts.append("\(start.formatted(date: .omitted, time: .shortened))–\(end.formatted(date: .omitted, time: .shortened))")
+        }
+        parts.append("\(Int((night.summary.efficiency * 100).rounded()))% efficiency")
+        parts.append("est.")
+        return parts
+    }
+
+    /// No-sleep state, scoped to SLEEP only. It deliberately does NOT claim HRV / Resting HR /
+    /// Respiratory Rate are unavailable: those are decoded independently and can already be present
+    /// (e.g. a daytime HR measurement gives a Resting HR) while no stageable sleep block exists, so
+    /// asserting otherwise here would contradict the populated vitals rows above. (Review #2, #58.)
+    private var emptyState: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "moon.zzz").font(.subheadline).foregroundStyle(.indigo)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Your sleep appears here after an overnight sync")
+                    .font(.subheadline.weight(.medium))
+                Text("Wear the ring to bed and connect in the morning. Once it syncs, last night's sleep stays here all day.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Stage table
+
+    private struct Stage {
+        let name: String
+        let color: Color
+        let minutes: (_ m: (inBed: Int, awake: Int, light: Int, deep: Int, rem: Int, asleep: Int)) -> Int
+    }
+    /// Display order + colors (match the prior sync-card stage bar): Deep, Light, REM, Awake.
+    private static let stages: [Stage] = [
+        Stage(name: "Deep", color: .indigo, minutes: { $0.deep }),
+        Stage(name: "Light", color: .teal, minutes: { $0.light }),
+        Stage(name: "REM", color: .purple, minutes: { $0.rem }),
+        Stage(name: "Awake", color: .orange, minutes: { $0.awake }),
+    ]
+
+    // MARK: Night label
+
+    private static let nightDate: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "MMM d"; return f
+    }()
+    /// "last night" when the sleep ended today, "yesterday" when it ended yesterday, else the date —
+    /// so a days-old persisted night isn't mistaken for this morning's. Falls back to the date when
+    /// the wake time is unknown (a legacy rollup with only a start-of-day key), since the relative
+    /// term can't be computed reliably from the start-of-day alone. (Review #3.)
+    private static func nightLabel(_ when: Date, wakeKnown: Bool) -> String {
+        guard wakeKnown else { return nightDate.string(from: when) }
+        let cal = Calendar.current
+        let days = cal.dateComponents([.day], from: cal.startOfDay(for: when),
+                                      to: cal.startOfDay(for: Date())).day ?? 0
+        switch days {
+        case ..<0: return nightDate.string(from: when)   // future (shouldn't happen) — show date
+        case 0: return "last night"
+        case 1: return "yesterday"
+        default: return nightDate.string(from: when)
+        }
+    }
+}

--- a/ios/OpenRingConn/SleepSchedule.swift
+++ b/ios/OpenRingConn/SleepSchedule.swift
@@ -1,0 +1,142 @@
+import Foundation
+import HealthKit
+import OpenRingKit
+
+// Sleep-schedule abstraction.
+//
+// The app needs to bound a "night window" (today: for the overnight skin-temp average;
+// later: to constrain on-device sleep detection). We get that window from the user's
+// sleep schedule behind ONE protocol with TWO implementations and ONE swap point:
+//
+//   • `ManualSleepSchedule`     — works TODAY with no entitlement; reads a user-set
+//                                 bedtime + wake (minutes-since-midnight, @AppStorage).
+//   • `HealthKitSleepSchedule`  — reads the REAL iOS Sleep schedule from HealthKit's
+//                                 `sleepAnalysis` samples. Compiles now, but returns nil
+//                                 when unauthorized / no entitlement (we ship without the
+//                                 HealthKit entitlement — see ios/project.yml).
+//   • `SleepSchedule.current`   — the swap point: prefer HealthKit when it returns data,
+//                                 else fall back to the manual schedule.
+//
+// "Flipping the switch" once a paid dev account is approved == enabling the HealthKit
+// entitlement (uncomment the `entitlements:` block in ios/project.yml, re-run
+// `xcodegen generate`) and granting read access. No change is needed in THIS file or its
+// callers: `HealthKitSleepSchedule` simply starts returning data and wins at the selector.
+
+/// Returns the user's sleep window (bedtime → wake) for the night around `date`.
+protocol SleepScheduleProviding {
+    func sleepWindow(forNightEndingNear date: Date) async -> DateInterval?
+}
+
+// MARK: - Persistence keys (shared by the provider and the settings UI)
+
+/// `@AppStorage`/`UserDefaults` keys for the manual schedule. The settings UI writes
+/// these via `@AppStorage`; `ManualSleepSchedule` reads the same keys from `UserDefaults`.
+enum SleepScheduleDefaults {
+    static let enabled = "sleepSchedule.enabled"
+    static let bedMinutes = "sleepSchedule.bedMinutes"
+    static let wakeMinutes = "sleepSchedule.wakeMinutes"
+
+    /// Defaults: disabled, bed 22:30, wake 06:30. Disabled-by-default means the manual
+    /// window does NOT override the existing stored-sleep span unless the user opts in.
+    static let defaultBedMinutes = 22 * 60 + 30   // 1350
+    static let defaultWakeMinutes = 6 * 60 + 30    // 390
+
+    /// Register defaults so `integer(forKey:)` returns the intended bed/wake (not 0)
+    /// before the user has ever opened settings.
+    static func register(_ defaults: UserDefaults = .standard) {
+        defaults.register(defaults: [
+            bedMinutes: defaultBedMinutes,
+            wakeMinutes: defaultWakeMinutes,
+        ])
+    }
+}
+
+// MARK: - Manual schedule (works today, no entitlement)
+
+/// Reads a user-set bedtime + wake time-of-day and builds the night's `DateInterval`
+/// via OpenRingKit's pure `SleepWindow` math (cross-midnight aware). Returns nil when the
+/// user hasn't enabled a manual schedule.
+struct ManualSleepSchedule: SleepScheduleProviding {
+    var enabled: Bool
+    var bedMinutes: Int
+    var wakeMinutes: Int
+
+    /// Build from `UserDefaults` (the same store the `@AppStorage` settings UI writes to).
+    static func fromDefaults(_ defaults: UserDefaults = .standard) -> ManualSleepSchedule {
+        SleepScheduleDefaults.register(defaults)
+        return ManualSleepSchedule(
+            enabled: defaults.bool(forKey: SleepScheduleDefaults.enabled),
+            bedMinutes: defaults.integer(forKey: SleepScheduleDefaults.bedMinutes),
+            wakeMinutes: defaults.integer(forKey: SleepScheduleDefaults.wakeMinutes)
+        )
+    }
+
+    func sleepWindow(forNightEndingNear date: Date) async -> DateInterval? {
+        guard enabled else { return nil }
+        return SleepWindow.interval(bedMinutes: bedMinutes,
+                                    wakeMinutes: wakeMinutes,
+                                    nightEndingNear: date)
+    }
+}
+
+// MARK: - HealthKit schedule (compiles now, no-ops without entitlement)
+
+/// Derives the night's window from recent `sleepAnalysis` samples (the iOS Sleep
+/// schedule / Sleep Focus writes `inBed`; watches/other apps write `asleep*`). Returns
+/// nil — never crashes — when HealthKit is unavailable, unauthorized, or has no entitlement.
+struct HealthKitSleepSchedule: SleepScheduleProviding {
+    private let store = HKHealthStore()
+    /// How far back from `date` to look for the night's samples.
+    var lookback: TimeInterval = 18 * 3600
+
+    func sleepWindow(forNightEndingNear date: Date) async -> DateInterval? {
+        // Guard 1: device/platform support (Simulator without Health, etc.).
+        guard HKHealthStore.isHealthDataAvailable() else { return nil }
+        let sleepType = HKCategoryType(.sleepAnalysis)
+
+        // Guard 2: authorization. We only SHARE today (see HealthKitWriter), so read of
+        // sleepAnalysis is not authorized and the query below returns empty/errors — which
+        // we treat as "no schedule" and fall back. Once the entitlement is enabled and the
+        // user grants read access, the query returns real samples and this wins. We do NOT
+        // request authorization here (avoids a permission prompt on a passive lookup).
+        let inBed = HKCategoryValueSleepAnalysis.inBed.rawValue
+        let asleepValues = HKCategoryValueSleepAnalysis.allAsleepValues.map(\.rawValue)
+
+        let start = date.addingTimeInterval(-lookback)
+        let end = date.addingTimeInterval(6 * 3600)   // allow an in-progress morning
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: end,
+                                                     options: .strictStartDate)
+
+        let samples: [HKCategorySample] = await withCheckedContinuation { cont in
+            let q = HKSampleQuery(sampleType: sleepType, predicate: predicate,
+                                  limit: HKObjectQueryNoLimit, sortDescriptors: nil) { _, result, _ in
+                cont.resume(returning: (result as? [HKCategorySample]) ?? [])
+            }
+            store.execute(q)
+        }
+        guard !samples.isEmpty else { return nil }
+
+        // Prefer explicit `inBed` spans (the iOS Sleep schedule); fall back to asleep spans.
+        let relevant = samples.filter { $0.value == inBed }
+        let pool = relevant.isEmpty ? samples.filter { asleepValues.contains($0.value) } : relevant
+        guard let earliest = pool.map(\.startDate).min(),
+              let latest = pool.map(\.endDate).max(),
+              latest > earliest else { return nil }
+        return DateInterval(start: earliest, end: latest)
+    }
+}
+
+// MARK: - Swap point
+
+/// The single place that decides which schedule wins. HealthKit (the real iOS Sleep
+/// schedule) is preferred when it returns data; otherwise the manual schedule. This is
+/// the one symbol whose behavior changes when the HealthKit entitlement is later enabled.
+enum SleepSchedule {
+    static func current(forNightEndingNear date: Date,
+                        healthKit: SleepScheduleProviding = HealthKitSleepSchedule(),
+                        manual: SleepScheduleProviding = ManualSleepSchedule.fromDefaults())
+        async -> DateInterval? {
+        if let hk = await healthKit.sleepWindow(forNightEndingNear: date) { return hk }
+        return await manual.sleepWindow(forNightEndingNear: date)
+    }
+}

--- a/ios/OpenRingConn/SleepSchedule.swift
+++ b/ios/OpenRingConn/SleepSchedule.swift
@@ -19,8 +19,10 @@ import OpenRingKit
 //
 // "Flipping the switch" once a paid dev account is approved == enabling the HealthKit
 // entitlement (uncomment the `entitlements:` block in ios/project.yml, re-run
-// `xcodegen generate`) and granting read access. No change is needed in THIS file or its
-// callers: `HealthKitSleepSchedule` simply starts returning data and wins at the selector.
+// `xcodegen generate`) and granting read access at the prompt. `HealthKitWriter.request-
+// Authorization` already requests `sleepAnalysis` READ, so no auth-code change is needed:
+// with the entitlement on, `HealthKitSleepSchedule` starts returning data and wins at the
+// selector — no change in THIS file or its callers.
 
 /// Returns the user's sleep window (bedtime → wake) for the night around `date`.
 protocol SleepScheduleProviding {

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -364,6 +364,17 @@ struct LocalStore {
         return try context.fetch(descriptor).compactMap(\.sample)
     }
 
+    /// Stored samples of one kind newer than `since`, oldest→newest. Bounded by the predicate so
+    /// it never scans all history — used by the health-alert engine (#73/#85) to evaluate recent
+    /// HR/SpO2 readings against the user's thresholds.
+    func recentSamples(kind: MetricKind, since: Date) throws -> [QuantitySample] {
+        let kindRaw = kind.rawValue
+        let descriptor = FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == kindRaw && $0.start >= since && $0.value > 0 },
+            sortBy: [SortDescriptor(\.start, order: .forward)])
+        return try context.fetch(descriptor).compactMap(\.sample)
+    }
+
     func latestSample(kind: MetricKind) throws -> QuantitySample? {
         let kindRaw = kind.rawValue
         var descriptor = FetchDescriptor<StoredSample>(

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -71,6 +71,77 @@ final class StoredCursor {
     }
 }
 
+/// Persisted nightly sleep summary (total asleep + estimated stage breakdown) so the
+/// dashboard shows the last night OFFLINE, after the ring disconnects. Keyed by `night`
+/// (start-of-day of the sleep window's start) and UPSERTED so re-syncing the same night
+/// replaces rather than duplicates. Stage minutes are an on-device ESTIMATE — the ring
+/// doesn't transmit stage labels (PROTOCOL.md §5.3).
+///
+/// Every non-optional attribute has a default so SwiftData lightweight migration can add
+/// this table to stores written before it existed without trapping at launch (cf. #21).
+@Model
+final class StoredSleepSummary {
+    @Attribute(.unique) var night: Date = Date.distantPast
+    var asleepMin: Int = 0
+    var deepMin: Int = 0
+    var lightMin: Int = 0
+    var remMin: Int = 0
+    var awakeMin: Int = 0
+    var efficiency: Double = 0
+    var updatedAt: Date = Date.distantPast
+
+    init(
+        night: Date,
+        asleepMin: Int = 0,
+        deepMin: Int = 0,
+        lightMin: Int = 0,
+        remMin: Int = 0,
+        awakeMin: Int = 0,
+        efficiency: Double = 0,
+        updatedAt: Date = Date()
+    ) {
+        self.night = night
+        self.asleepMin = asleepMin
+        self.deepMin = deepMin
+        self.lightMin = lightMin
+        self.remMin = remMin
+        self.awakeMin = awakeMin
+        self.efficiency = efficiency
+        self.updatedAt = updatedAt
+    }
+
+    /// Rebuild a `SleepStaging.Summary` for the dashboard. `inBed` is recovered from the
+    /// stored efficiency (asleep / efficiency) so the displayed % matches; the per-stage
+    /// minutes round-trip exactly since they're already whole minutes.
+    var asSummary: SleepStaging.Summary {
+        let light = Double(lightMin) * 60
+        let deep = Double(deepMin) * 60
+        let rem = Double(remMin) * 60
+        let awake = Double(awakeMin) * 60
+        let asleep = light + deep + rem
+        let inBed = efficiency > 0 ? asleep / efficiency : asleep + awake
+        return SleepStaging.Summary(inBed: inBed, awake: awake, light: light, deep: deep, rem: rem)
+    }
+}
+
+/// Per-day rollups for values that are NOT epoch samples and must NOT flow through the
+/// cumulative-counter `ingest` path (which computes HealthKit deltas). Currently the
+/// ring's onboard step count for the day. Keyed by `day` (start-of-day) and UPSERTED, so
+/// the dashboard can show "steps today" offline without disturbing `SyncCursor` /
+/// `cumulativeState` / Apple Health writes.
+@Model
+final class StoredDaily {
+    @Attribute(.unique) var day: Date = Date.distantPast
+    var steps: Int = 0
+    var updatedAt: Date = Date.distantPast
+
+    init(day: Date, steps: Int = 0, updatedAt: Date = Date()) {
+        self.day = day
+        self.steps = steps
+        self.updatedAt = updatedAt
+    }
+}
+
 @MainActor
 struct LocalStore {
     let context: ModelContext
@@ -163,6 +234,70 @@ struct LocalStore {
         )
         descriptor.fetchLimit = 1
         return try context.fetch(descriptor).first?.sample
+    }
+
+    // MARK: Sleep summary + daily steps (offline dashboard, separate from `ingest`)
+
+    /// Upsert the nightly sleep summary, keyed by start-of-day of `night`. Re-syncing the
+    /// same night overwrites the existing row rather than inserting a duplicate. Does NOT
+    /// touch the SyncCursor — gating sleep history for HealthKit stays in `ingestSleep`.
+    func saveSleepSummary(_ summary: SleepStaging.Summary, night: Date) throws {
+        let dayStart = Calendar.current.startOfDay(for: night)
+        let m = summary.minutes
+        let descriptor = FetchDescriptor<StoredSleepSummary>(
+            predicate: #Predicate { $0.night == dayStart })
+        if let existing = try? context.fetch(descriptor).first {
+            existing.asleepMin = m.asleep
+            existing.deepMin = m.deep
+            existing.lightMin = m.light
+            existing.remMin = m.rem
+            existing.awakeMin = m.awake
+            existing.efficiency = summary.efficiency
+            existing.updatedAt = Date()
+        } else {
+            context.insert(StoredSleepSummary(
+                night: dayStart,
+                asleepMin: m.asleep,
+                deepMin: m.deep,
+                lightMin: m.light,
+                remMin: m.rem,
+                awakeMin: m.awake,
+                efficiency: summary.efficiency
+            ))
+        }
+        try context.save()
+    }
+
+    /// Most recent stored sleep summary (latest night), or nil.
+    func latestSleepSummary() throws -> StoredSleepSummary? {
+        var descriptor = FetchDescriptor<StoredSleepSummary>(
+            sortBy: [SortDescriptor(\.night, order: .reverse)])
+        descriptor.fetchLimit = 1
+        return try context.fetch(descriptor).first
+    }
+
+    /// Upsert the day's step count, keyed by start-of-day. The ring's onboard count only
+    /// grows within a day, so keep the max for the day; a new day gets its own row.
+    func saveDailySteps(_ steps: Int, day: Date = Date()) throws {
+        guard steps > 0 else { return }
+        let dayStart = Calendar.current.startOfDay(for: day)
+        let descriptor = FetchDescriptor<StoredDaily>(
+            predicate: #Predicate { $0.day == dayStart })
+        if let existing = try? context.fetch(descriptor).first {
+            existing.steps = max(existing.steps, steps)
+            existing.updatedAt = Date()
+        } else {
+            context.insert(StoredDaily(day: dayStart, steps: steps))
+        }
+        try context.save()
+    }
+
+    /// Most recent stored daily rollup (latest day), or nil.
+    func latestDaily() throws -> StoredDaily? {
+        var descriptor = FetchDescriptor<StoredDaily>(
+            sortBy: [SortDescriptor(\.day, order: .reverse)])
+        descriptor.fetchLimit = 1
+        return try context.fetch(descriptor).first
     }
 
     private func upsertCursor(kind: String, last: Date) {

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -68,6 +68,21 @@ struct LocalStore {
         return fresh
     }
 
+    /// Gate a night's sleep segments on the `.sleep` cursor so re-syncs don't
+    /// duplicate. Returns the segments to write (empty if this night is already
+    /// synced), advancing the cursor to the latest segment end.
+    func ingestSleep(_ segments: [SleepSegment]) throws -> [SleepSegment] {
+        guard let latest = segments.map(\.end).max() else { return [] }
+        var cursor = try loadCursor()
+        guard cursor.isNew(.sleep, latest) else { return [] }
+        cursor.advance(.sleep, to: latest)
+        if let last = cursor.last(.sleep) {
+            upsertCursor(kind: MetricKind.sleep.rawValue, last: last)
+        }
+        try context.save()
+        return segments
+    }
+
     private func upsertCursor(kind: String, last: Date) {
         let descriptor = FetchDescriptor<StoredCursor>(
             predicate: #Predicate { $0.kindRaw == kind })

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -152,6 +152,16 @@ struct LocalStore {
         return segments
     }
 
+    func latestSample(kind: MetricKind) throws -> QuantitySample? {
+        let kindRaw = kind.rawValue
+        var descriptor = FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == kindRaw },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]
+        )
+        descriptor.fetchLimit = 1
+        return try context.fetch(descriptor).first?.sample
+    }
+
     private func upsertCursor(kind: String, last: Date) {
         let descriptor = FetchDescriptor<StoredCursor>(
             predicate: #Predicate { $0.kindRaw == kind })
@@ -196,5 +206,13 @@ struct LocalStore {
         }
 
         return CumulativeMetricState(previousRawValue: previousRaw)
+    }
+}
+
+struct LaunchSnapshot {
+    let lastHeartRate: QuantitySample?
+
+    static func load(from store: LocalStore) throws -> LaunchSnapshot {
+        LaunchSnapshot(lastHeartRate: try store.latestSample(kind: .heartRate))
     }
 }

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -94,6 +94,30 @@ final class StoredSleepSummary {
     var inBedEnd: Date = Date.distantPast
     var updatedAt: Date = Date.distantPast
 
+    // MARK: Wave-1 sleep analytics (#69/#70/#71). Every column is DEFAULTED so SwiftData
+    // lightweight migration can add it to stores written before it existed (cf. #21). A 0
+    // sentinel means "not computed" for the optional metrics (skin temp / scores), since a
+    // worn night's skin temp is always > 28 °C and the scores are 1…100.
+
+    /// Nightly MEAN sleeping skin temperature (°C), 0 = none. Baseline/offset are derived at
+    /// display time from the trailing nights' `skinTempC` (#69) — only the nightly value is stored.
+    var skinTempC: Double = 0
+    /// Composite 0–100 Sleep Score (#70), 0 = not computed.
+    var sleepScore: Int = 0
+    /// Overnight stress score 1–100 from sleep-window RMSSD (#71), 0 = not computed.
+    var stressScore: Int = 0
+    /// Subjective "how did you sleep?" rating 1–9 (#70), 0 = unrated. Set by the user; NEVER
+    /// overwritten by a re-sync.
+    var feelScore: Int = 0
+    /// Per-stage average HR (bpm), 0 = none (#70).
+    var hrDeep: Int = 0
+    var hrLight: Int = 0
+    var hrRem: Int = 0
+    var hrAwake: Int = 0
+    /// Per-epoch (2.5-min) movement levels 0/1/2 across the night (#70) — small enough to
+    /// persist so the movement chart redraws offline.
+    var movementLevels: [Int] = []
+
     init(
         night: Date,
         asleepMin: Int = 0,
@@ -104,7 +128,16 @@ final class StoredSleepSummary {
         efficiency: Double = 0,
         inBedStart: Date = Date.distantPast,
         inBedEnd: Date = Date.distantPast,
-        updatedAt: Date = Date()
+        updatedAt: Date = Date(),
+        skinTempC: Double = 0,
+        sleepScore: Int = 0,
+        stressScore: Int = 0,
+        feelScore: Int = 0,
+        hrDeep: Int = 0,
+        hrLight: Int = 0,
+        hrRem: Int = 0,
+        hrAwake: Int = 0,
+        movementLevels: [Int] = []
     ) {
         self.night = night
         self.asleepMin = asleepMin
@@ -116,6 +149,15 @@ final class StoredSleepSummary {
         self.inBedStart = inBedStart
         self.inBedEnd = inBedEnd
         self.updatedAt = updatedAt
+        self.skinTempC = skinTempC
+        self.sleepScore = sleepScore
+        self.stressScore = stressScore
+        self.feelScore = feelScore
+        self.hrDeep = hrDeep
+        self.hrLight = hrLight
+        self.hrRem = hrRem
+        self.hrAwake = hrAwake
+        self.movementLevels = movementLevels
     }
 
     /// Rebuild a `SleepStaging.Summary` for the dashboard. `inBed` is recovered from the
@@ -154,6 +196,33 @@ final class StoredDaily {
         self.updatedAt = updatedAt
         self.healthWrittenSteps = healthWrittenSteps
     }
+}
+
+/// One auto-detected daytime nap (#76) — daytime stillness ≥ 15 min OUTSIDE the main overnight
+/// sleep window. Kept separate from `StoredSleepSummary` so naps never double-count against the
+/// night. Keyed by `start` and UPSERTED, so re-syncing the same day replaces rather than
+/// duplicates. `healthWritten` gates the (separate) Apple Health sleep write so a nap is written
+/// once. Every column is defaulted for SwiftData lightweight migration (cf. #21).
+@Model
+final class StoredNap {
+    @Attribute(.unique) var start: Date = Date.distantPast
+    var end: Date = Date.distantPast
+    var asleepMin: Int = 0
+    var isLongNap: Bool = false
+    var healthWritten: Bool = false
+    var updatedAt: Date = Date.distantPast
+
+    init(start: Date, end: Date, asleepMin: Int = 0, isLongNap: Bool = false,
+         healthWritten: Bool = false, updatedAt: Date = Date()) {
+        self.start = start
+        self.end = end
+        self.asleepMin = asleepMin
+        self.isLongNap = isLongNap
+        self.healthWritten = healthWritten
+        self.updatedAt = updatedAt
+    }
+
+    var durationMin: Int { max(Int(end.timeIntervalSince(start) / 60), 0) }
 }
 
 @MainActor
@@ -388,8 +457,21 @@ struct LocalStore {
     /// same night overwrites the existing row rather than inserting a duplicate. Does NOT
     /// touch the SyncCursor — gating sleep history for HealthKit stays in the `.sleep`
     /// watermark (`pendingHealthSleep`/`markSleepWritten`).
+    /// The Wave-1 analytics computed for a night alongside the stage totals (#69/#70/#71). All
+    /// optional — a value left at its default means "not computed" and the upsert leaves any
+    /// existing value untouched isn't needed (these are recomputed each sync), but `feelScore`
+    /// IS preserved across re-syncs since it's user-entered, not derived.
+    struct SleepNightExtras {
+        var skinTempC: Double = 0
+        var sleepScore: Int = 0
+        var stressScore: Int = 0
+        var hrByStage: [SleepStage: Int] = [:]
+        var movementLevels: [Int] = []
+    }
+
     func saveSleepSummary(_ summary: SleepStaging.Summary, night: Date,
-                          inBedStart: Date, inBedEnd: Date) throws {
+                          inBedStart: Date, inBedEnd: Date,
+                          extras: SleepNightExtras = SleepNightExtras()) throws {
         let dayStart = Calendar.current.startOfDay(for: night)
         let m = summary.minutes
         let descriptor = FetchDescriptor<StoredSleepSummary>(
@@ -404,8 +486,9 @@ struct LocalStore {
             existing.inBedStart = inBedStart
             existing.inBedEnd = inBedEnd
             existing.updatedAt = Date()
+            applyExtras(extras, to: existing)   // feelScore deliberately preserved
         } else {
-            context.insert(StoredSleepSummary(
+            let row = StoredSleepSummary(
                 night: dayStart,
                 asleepMin: m.asleep,
                 deepMin: m.deep,
@@ -415,9 +498,24 @@ struct LocalStore {
                 efficiency: summary.efficiency,
                 inBedStart: inBedStart,
                 inBedEnd: inBedEnd
-            ))
+            )
+            applyExtras(extras, to: row)
+            context.insert(row)
         }
         try context.save()
+    }
+
+    private func applyExtras(_ extras: SleepNightExtras, to row: StoredSleepSummary) {
+        // 0 = "not computed this pass" — keep any previously stored value rather than wiping it
+        // (a quick daytime live-read might re-stage the night with no temp/HRV coverage).
+        if extras.skinTempC > 0 { row.skinTempC = extras.skinTempC }
+        if extras.sleepScore > 0 { row.sleepScore = extras.sleepScore }
+        if extras.stressScore > 0 { row.stressScore = extras.stressScore }
+        if let v = extras.hrByStage[.asleepDeep] { row.hrDeep = v }
+        if let v = extras.hrByStage[.asleepCore] { row.hrLight = v }
+        if let v = extras.hrByStage[.asleepREM] { row.hrRem = v }
+        if let v = extras.hrByStage[.awake] { row.hrAwake = v }
+        if !extras.movementLevels.isEmpty { row.movementLevels = extras.movementLevels }
     }
 
     /// Most recent stored sleep summary (latest night), or nil.
@@ -426,6 +524,71 @@ struct LocalStore {
             sortBy: [SortDescriptor(\.night, order: .reverse)])
         descriptor.fetchLimit = 1
         return try context.fetch(descriptor).first
+    }
+
+    /// Trailing sleep summaries (latest first), for the rolling skin-temp baseline (#69) and
+    /// any short-window trend. Bounded so it never scans the whole table.
+    func recentSleepSummaries(limit: Int = 40) throws -> [StoredSleepSummary] {
+        var descriptor = FetchDescriptor<StoredSleepSummary>(
+            sortBy: [SortDescriptor(\.night, order: .reverse)])
+        descriptor.fetchLimit = limit
+        return try context.fetch(descriptor)
+    }
+
+    /// Persist the user's subjective sleep rating (1–9, #70) onto an existing night. No-op if
+    /// the night isn't in the store yet (a rating only makes sense once a night exists).
+    func setFeelScore(_ score: Int, night: Date) throws {
+        let dayStart = Calendar.current.startOfDay(for: night)
+        let descriptor = FetchDescriptor<StoredSleepSummary>(
+            predicate: #Predicate { $0.night == dayStart })
+        guard let row = try? context.fetch(descriptor).first else { return }
+        row.feelScore = max(0, min(score, 9))
+        row.updatedAt = Date()
+        try context.save()
+    }
+
+    // MARK: Naps (#76) — separate from the night so they never double-count
+
+    /// Upsert one auto-detected nap, keyed by start. A re-detected nap with the same start
+    /// updates in place; a genuinely new nap inserts. Preserves `healthWritten` on update so a
+    /// nap already mirrored to Health isn't re-written.
+    func saveNap(start: Date, end: Date, asleepMin: Int, isLongNap: Bool) throws {
+        let descriptor = FetchDescriptor<StoredNap>(predicate: #Predicate { $0.start == start })
+        if let existing = try? context.fetch(descriptor).first {
+            existing.end = end
+            existing.asleepMin = asleepMin
+            existing.isLongNap = isLongNap
+            existing.updatedAt = Date()
+        } else {
+            context.insert(StoredNap(start: start, end: end, asleepMin: asleepMin, isLongNap: isLongNap))
+        }
+        try context.save()
+    }
+
+    /// Naps that started on `day` (start-of-day bucket), latest first.
+    func naps(on day: Date = Date()) throws -> [StoredNap] {
+        let dayStart = Calendar.current.startOfDay(for: day)
+        let dayEnd = Calendar.current.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
+        let descriptor = FetchDescriptor<StoredNap>(
+            predicate: #Predicate { $0.start >= dayStart && $0.start < dayEnd },
+            sortBy: [SortDescriptor(\.start, order: .reverse)])
+        return try context.fetch(descriptor)
+    }
+
+    /// Naps not yet mirrored to Apple Health (oldest first), for `HealthKitWriter.flushNaps`.
+    func pendingNaps() throws -> [StoredNap] {
+        let descriptor = FetchDescriptor<StoredNap>(
+            predicate: #Predicate { $0.healthWritten == false },
+            sortBy: [SortDescriptor(\.start, order: .forward)])
+        return try context.fetch(descriptor)
+    }
+
+    /// Mark a nap written to Apple Health so it isn't written again.
+    func markNapWritten(start: Date) throws {
+        let descriptor = FetchDescriptor<StoredNap>(predicate: #Predicate { $0.start == start })
+        guard let row = try? context.fetch(descriptor).first else { return }
+        row.healthWritten = true
+        try context.save()
     }
 
     /// Accumulate a step DELTA into the running total for `day`, UPSERTED by start-of-day. The

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -658,6 +658,15 @@ struct LocalStore {
         return try context.fetch(descriptor).first
     }
 
+    /// Trailing daily rollups (latest first), bounded by `limit`. Used by TrendsView (#74) to
+    /// build 7-day rolling aggregates for steps. Bounded so it never scans the whole table.
+    func recentDailies(limit: Int = 14) throws -> [StoredDaily] {
+        var descriptor = FetchDescriptor<StoredDaily>(
+            sortBy: [SortDescriptor(\.day, order: .reverse)])
+        descriptor.fetchLimit = limit
+        return try context.fetch(descriptor)
+    }
+
     private func upsertCursor(kind: String, last: Date) {
         let descriptor = FetchDescriptor<StoredCursor>(
             predicate: #Predicate { $0.kindRaw == kind })

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -303,18 +303,27 @@ struct LocalStore {
 
     /// Upsert the day's step count, keyed by start-of-day. The ring's onboard count only
     /// grows within a day, so keep the max for the day; a new day gets its own row.
-    func saveDailySteps(_ steps: Int, day: Date = Date()) throws {
-        guard steps > 0 else { return }
+    /// Accumulate a step DELTA into today's running total. The ring's onboard counter is a
+    /// since-handoff delta that RESETS (the official app sums the deltas in local memory), so
+    /// we sum observed deltas the same way rather than storing the raw counter. New day = new row.
+    func addDailySteps(_ delta: Int, day: Date = Date()) throws {
+        guard delta > 0 else { return }
         let dayStart = Calendar.current.startOfDay(for: day)
-        let descriptor = FetchDescriptor<StoredDaily>(
-            predicate: #Predicate { $0.day == dayStart })
+        let descriptor = FetchDescriptor<StoredDaily>(predicate: #Predicate { $0.day == dayStart })
         if let existing = try? context.fetch(descriptor).first {
-            existing.steps = max(existing.steps, steps)
+            existing.steps += delta
             existing.updatedAt = Date()
         } else {
-            context.insert(StoredDaily(day: dayStart, steps: steps))
+            context.insert(StoredDaily(day: dayStart, steps: delta))
         }
         try context.save()
+    }
+
+    /// Today's accumulated step total (0 if none yet).
+    func todaySteps(day: Date = Date()) throws -> Int {
+        let dayStart = Calendar.current.startOfDay(for: day)
+        let descriptor = FetchDescriptor<StoredDaily>(predicate: #Predicate { $0.day == dayStart })
+        return (try? context.fetch(descriptor).first)?.steps ?? 0
     }
 
     /// Most recent stored daily rollup (latest day), or nil.

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -226,6 +226,18 @@ struct LocalStore {
         return segments
     }
 
+    /// Stored samples of one kind within `[start, end)`, oldest→newest. Used by the
+    /// dashboard to average overnight skin-temperature samples (which only exist while the
+    /// ring was connected) over a night window.
+    func samples(kind: MetricKind, from start: Date, to end: Date) throws -> [QuantitySample] {
+        let kindRaw = kind.rawValue
+        let descriptor = FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == kindRaw && $0.start >= start && $0.start < end },
+            sortBy: [SortDescriptor(\.start, order: .forward)]
+        )
+        return try context.fetch(descriptor).compactMap(\.sample)
+    }
+
     func latestSample(kind: MetricKind) throws -> QuantitySample? {
         let kindRaw = kind.rawValue
         var descriptor = FetchDescriptor<StoredSample>(

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -428,11 +428,12 @@ struct LocalStore {
         return try context.fetch(descriptor).first
     }
 
-    /// Upsert the day's step count, keyed by start-of-day. The ring's onboard count only
-    /// grows within a day, so keep the max for the day; a new day gets its own row.
-    /// Accumulate a step DELTA into today's running total. The ring's onboard counter is a
-    /// since-handoff delta that RESETS (the official app sums the deltas in local memory), so
-    /// we sum observed deltas the same way rather than storing the raw counter. New day = new row.
+    /// Accumulate a step DELTA into the running total for `day`, UPSERTED by start-of-day. The
+    /// ring's onboard counter is a since-handoff delta that RESETS (the official app sums the
+    /// deltas in local memory), so we sum observed deltas the same way rather than storing the
+    /// raw counter — `StepAccumulator` (#34) computes the reset-aware delta. New day = new row.
+    /// `day` is the SAMPLE time of the reading (when the descriptor arrived), so a delta observed
+    /// just after midnight for late-night steps is stamped onto its own day, not the prior one.
     func addDailySteps(_ delta: Int, day: Date = Date()) throws {
         guard delta > 0 else { return }
         let dayStart = Calendar.current.startOfDay(for: day)

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -212,6 +212,7 @@ struct LocalStore {
 struct LaunchSnapshot {
     let lastHeartRate: QuantitySample?
 
+    @MainActor
     static func load(from store: LocalStore) throws -> LaunchSnapshot {
         LaunchSnapshot(lastHeartRate: try store.latestSample(kind: .heartRate))
     }

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -12,16 +12,43 @@ final class StoredSample {
     var start: Date
     var end: Date
     var value: Double
+    var rawValue: Double?
+    var isDelta: Bool
+    var dailyTotal: Double?
 
-    init(kindRaw: String, start: Date, end: Date, value: Double) {
+    init(
+        kindRaw: String,
+        start: Date,
+        end: Date,
+        value: Double,
+        rawValue: Double? = nil,
+        isDelta: Bool = false,
+        dailyTotal: Double? = nil
+    ) {
         self.kindRaw = kindRaw
         self.start = start
         self.end = end
         self.value = value
+        self.rawValue = rawValue
+        self.isDelta = isDelta
+        self.dailyTotal = dailyTotal
     }
 
-    convenience init(_ s: QuantitySample) {
-        self.init(kindRaw: s.kind.rawValue, start: s.start, end: s.end, value: s.value)
+    convenience init(
+        _ s: QuantitySample,
+        rawValue: Double? = nil,
+        isDelta: Bool = false,
+        dailyTotal: Double? = nil
+    ) {
+        self.init(
+            kindRaw: s.kind.rawValue,
+            start: s.start,
+            end: s.end,
+            value: s.value,
+            rawValue: rawValue,
+            isDelta: isDelta,
+            dailyTotal: dailyTotal
+        )
     }
 
     var sample: QuantitySample? {
@@ -59,13 +86,55 @@ struct LocalStore {
     func ingest(_ samples: [QuantitySample]) throws -> [QuantitySample] {
         var cursor = try loadCursor()
         let fresh = cursor.selectNew(samples)
-        for s in fresh { context.insert(StoredSample(s)) }
+        var cumulativeStates: [MetricKind: CumulativeMetricState] = [:]
+        var cumulativeStateDays: [MetricKind: Date] = [:]
+        var ingested: [QuantitySample] = []
+
+        for s in fresh {
+            guard s.kind.isCumulativeCounter else {
+                context.insert(StoredSample(s))
+                ingested.append(s)
+                continue
+            }
+
+            // The daily total resets at midnight. `fresh` is sorted oldest→newest, so a
+            // single batch can span a day boundary; when it does, carry the raw counter
+            // forward (so the delta stays correct) but reset the running total to 0 for the
+            // new day. The initial DB-backed state is already day-bounded by `cumulativeState`.
+            let dayStart = Calendar.current.startOfDay(for: s.start)
+            let state: CumulativeMetricState
+            if let existing = cumulativeStates[s.kind] {
+                state = cumulativeStateDays[s.kind] == dayStart
+                    ? existing
+                    : CumulativeMetricState(previousRawValue: existing.previousRawValue, dailyTotal: 0)
+            } else {
+                state = try cumulativeState(for: s.kind, before: s.start)
+            }
+
+            let result = CumulativeMetricAccumulator.accumulate(s, state: state)
+            let deltaSample = QuantitySample(kind: s.kind, start: s.start, end: s.end, value: result.deltaValue)
+            context.insert(StoredSample(
+                deltaSample,
+                rawValue: result.rawValue,
+                isDelta: true,
+                dailyTotal: result.dailyTotal
+            ))
+            cumulativeStates[s.kind] = CumulativeMetricState(
+                previousRawValue: result.rawValue,
+                dailyTotal: result.dailyTotal
+            )
+            cumulativeStateDays[s.kind] = dayStart
+            // Return the per-epoch DELTA, not the running total: HealthKit *sums* cumulative
+            // quantity types (stepCount / activeEnergyBurned), so writing the daily total on
+            // every epoch would massively overcount. Deltas sum back to the daily total in Health.
+            ingested.append(deltaSample)
+        }
         for kind in MetricKind.allCases {
             guard let last = cursor.last(kind) else { continue }
             upsertCursor(kind: kind.rawValue, last: last)
         }
         try context.save()
-        return fresh
+        return ingested
     }
 
     /// Gate a night's sleep segments on the `.sleep` cursor so re-syncs don't
@@ -91,5 +160,41 @@ struct LocalStore {
         } else {
             context.insert(StoredCursor(kindRaw: kind, last: last))
         }
+    }
+
+    private func cumulativeState(for kind: MetricKind, before date: Date) throws -> CumulativeMetricState {
+        let kindRaw = kind.rawValue
+        var previousDescriptor = FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == kindRaw && $0.start < date },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]
+        )
+        previousDescriptor.fetchLimit = 1
+        let previous = try context.fetch(previousDescriptor).first
+        let previousRaw = previous.map { $0.rawValue ?? $0.value }
+
+        let dayInterval = Calendar.current.dateInterval(of: .day, for: date)
+        let dayStart = dayInterval?.start ?? date
+        let nextDay = dayInterval?.end ?? date
+        var dayDescriptor = FetchDescriptor<StoredSample>(
+            predicate: #Predicate {
+                $0.kindRaw == kindRaw && $0.start >= dayStart && $0.start < nextDay && $0.start < date
+            },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]
+        )
+        dayDescriptor.fetchLimit = 1
+
+        if let latestToday = try context.fetch(dayDescriptor).first {
+            if let dailyTotal = latestToday.dailyTotal {
+                return CumulativeMetricState(previousRawValue: previousRaw, dailyTotal: dailyTotal)
+            }
+            if !latestToday.isDelta {
+                return CumulativeMetricState(
+                    previousRawValue: previousRaw,
+                    dailyTotal: latestToday.rawValue ?? latestToday.value
+                )
+            }
+        }
+
+        return CumulativeMetricState(previousRawValue: previousRaw)
     }
 }

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -142,11 +142,17 @@ final class StoredDaily {
     @Attribute(.unique) var day: Date = Date.distantPast
     var steps: Int = 0
     var updatedAt: Date = Date.distantPast
+    /// Running step total already written to Apple Health for this day. The next Health
+    /// write pushes only `steps - healthWrittenSteps` as a stepCount sample, so HealthKit
+    /// (which SUMS stepCount) lands on the daily total instead of overcounting on every
+    /// sync. Defaulted for lightweight migration of stores written before this column.
+    var healthWrittenSteps: Int = 0
 
-    init(day: Date, steps: Int = 0, updatedAt: Date = Date()) {
+    init(day: Date, steps: Int = 0, updatedAt: Date = Date(), healthWrittenSteps: Int = 0) {
         self.day = day
         self.steps = steps
         self.updatedAt = updatedAt
+        self.healthWrittenSteps = healthWrittenSteps
     }
 }
 
@@ -156,11 +162,13 @@ struct LocalStore {
 
     init(_ context: ModelContext) { self.context = context }
 
-    /// Rebuild the in-memory SyncCursor from persisted rows.
+    /// Rebuild the in-memory SyncCursor from persisted rows. Skips the `hk:`-prefixed
+    /// HealthKit-watermark rows (see `pendingHealthSamples`) — they live in the same table
+    /// but track a separate concern and must not pollute the store-ingest cursor.
     func loadCursor() throws -> SyncCursor {
         let rows = try context.fetch(FetchDescriptor<StoredCursor>())
         var map: [String: Date] = [:]
-        for r in rows { map[r.kindRaw] = r.last }
+        for r in rows where !r.kindRaw.hasPrefix(Self.healthCursorPrefix) { map[r.kindRaw] = r.last }
         return SyncCursor(lastByKind: map)
     }
 
@@ -219,21 +227,6 @@ struct LocalStore {
         return ingested
     }
 
-    /// Gate a night's sleep segments on the `.sleep` cursor so re-syncs don't
-    /// duplicate. Returns the segments to write (empty if this night is already
-    /// synced), advancing the cursor to the latest segment end.
-    func ingestSleep(_ segments: [SleepSegment]) throws -> [SleepSegment] {
-        guard let latest = segments.map(\.end).max() else { return [] }
-        var cursor = try loadCursor()
-        guard cursor.isNew(.sleep, latest) else { return [] }
-        cursor.advance(.sleep, to: latest)
-        if let last = cursor.last(.sleep) {
-            upsertCursor(kind: MetricKind.sleep.rawValue, last: last)
-        }
-        try context.save()
-        return segments
-    }
-
     /// Stored samples of one kind within `[start, end)`, oldest→newest. Used by the
     /// dashboard to average overnight skin-temperature samples (which only exist while the
     /// ring was connected) over a night window.
@@ -256,11 +249,89 @@ struct LocalStore {
         return try context.fetch(descriptor).first?.sample
     }
 
+    // MARK: HealthKit write watermark (decoupled from the store-ingest cursor)
+    //
+    // The store-ingest cursor (`ingest`) dedupes ROWS in the local store so the dashboard
+    // never double-counts a re-synced night. Apple Health needs its OWN high-water mark:
+    // previously both shared one cursor, so the dashboard's auto-persist advanced it before
+    // the Health write could claim the samples — HR/HRV/SpO2/respiratory/temperature were
+    // persisted for the dashboard but NEVER reached Apple Health. This watermark reads from
+    // the store (the single source of truth the auto-persist fills) and only advances after
+    // a confirmed write, so an un-authorized or failed write safely backfills next time.
+
+    /// Non-cumulative scalar metrics mirrored into Apple Health straight from the store.
+    /// (Sleep uses `pendingHealthSleep`/`markSleepWritten`; cumulative step/energy counters
+    /// take their own paths.)
+    static let healthMirroredKinds: [MetricKind] = [.heartRate, .hrvSDNN, .spo2, .respiratoryRate, .temperature]
+    private static let healthCursorPrefix = "hk:"
+
+    /// Stored samples of the Health-mirrored kinds newer than the Health watermark,
+    /// oldest→newest — everything synced to the store but not yet written to Apple Health.
+    /// Does NOT advance the watermark (call `markHealthWritten` after a successful write).
+    func pendingHealthSamples() throws -> [QuantitySample] {
+        let cursor = try loadHealthCursor()
+        var out: [QuantitySample] = []
+        for kind in Self.healthMirroredKinds {
+            let kindRaw = kind.rawValue
+            let last = cursor.last(kind) ?? .distantPast
+            let descriptor = FetchDescriptor<StoredSample>(
+                predicate: #Predicate { $0.kindRaw == kindRaw && $0.start > last && $0.value > 0 },
+                sortBy: [SortDescriptor(\.start, order: .forward)])
+            out += try context.fetch(descriptor).compactMap(\.sample)
+        }
+        return out.sorted { $0.start < $1.start }
+    }
+
+    /// Sleep segments for a night not yet mirrored to Apple Health, gated on the `.sleep`
+    /// cursor — WITHOUT advancing it (call `markSleepWritten` only after a confirmed write,
+    /// so a failed save backfills next time instead of losing the night). Returns `[]` when
+    /// this night is already in Health.
+    func pendingHealthSleep(_ segments: [SleepSegment]) throws -> [SleepSegment] {
+        guard let latest = segments.map(\.end).max() else { return [] }
+        let cursor = try loadCursor()
+        return cursor.isNew(.sleep, latest) ? segments : []
+    }
+
+    /// Advance the `.sleep` cursor past the night just written to Apple Health.
+    func markSleepWritten(_ segments: [SleepSegment]) throws {
+        guard let latest = segments.map(\.end).max() else { return }
+        var cursor = try loadCursor()
+        guard cursor.isNew(.sleep, latest) else { return }
+        cursor.advance(.sleep, to: latest)
+        if let last = cursor.last(.sleep) {
+            upsertCursor(kind: MetricKind.sleep.rawValue, last: last)
+        }
+        try context.save()
+    }
+
+    /// Advance the Health watermark past the newest written sample per kind.
+    func markHealthWritten(_ samples: [QuantitySample]) throws {
+        guard !samples.isEmpty else { return }
+        var cursor = try loadHealthCursor()
+        _ = cursor.selectNew(samples)   // advances per kind to the newest start
+        for kind in Self.healthMirroredKinds {
+            guard let last = cursor.last(kind) else { continue }
+            upsertCursor(kind: Self.healthCursorPrefix + kind.rawValue, last: last)
+        }
+        try context.save()
+    }
+
+    /// Health watermark, read from the `hk:`-prefixed cursor rows (keyed by bare kind).
+    private func loadHealthCursor() throws -> SyncCursor {
+        let rows = try context.fetch(FetchDescriptor<StoredCursor>())
+        var map: [String: Date] = [:]
+        for r in rows where r.kindRaw.hasPrefix(Self.healthCursorPrefix) {
+            map[String(r.kindRaw.dropFirst(Self.healthCursorPrefix.count))] = r.last
+        }
+        return SyncCursor(lastByKind: map)
+    }
+
     // MARK: Sleep summary + daily steps (offline dashboard, separate from `ingest`)
 
     /// Upsert the nightly sleep summary, keyed by start-of-day of `night`. Re-syncing the
     /// same night overwrites the existing row rather than inserting a duplicate. Does NOT
-    /// touch the SyncCursor — gating sleep history for HealthKit stays in `ingestSleep`.
+    /// touch the SyncCursor — gating sleep history for HealthKit stays in the `.sleep`
+    /// watermark (`pendingHealthSleep`/`markSleepWritten`).
     func saveSleepSummary(_ summary: SleepStaging.Summary, night: Date,
                           inBedStart: Date, inBedEnd: Date) throws {
         let dayStart = Calendar.current.startOfDay(for: night)
@@ -324,6 +395,28 @@ struct LocalStore {
         let dayStart = Calendar.current.startOfDay(for: day)
         let descriptor = FetchDescriptor<StoredDaily>(predicate: #Predicate { $0.day == dayStart })
         return (try? context.fetch(descriptor).first)?.steps ?? 0
+    }
+
+    /// Steps accumulated today but not yet written to Apple Health (0 if none/caught up).
+    /// Pairs with `advanceStepsWritten` so the day's stepCount reaches Health as deltas that
+    /// sum to the daily total, never the full total re-added on every sync.
+    func pendingStepDelta(day: Date = Date()) throws -> Int {
+        let dayStart = Calendar.current.startOfDay(for: day)
+        let descriptor = FetchDescriptor<StoredDaily>(predicate: #Predicate { $0.day == dayStart })
+        guard let row = try? context.fetch(descriptor).first else { return 0 }
+        return max(row.steps - row.healthWrittenSteps, 0)
+    }
+
+    /// Record that `delta` more of today's steps are now reflected in Apple Health. Advancing
+    /// by the delta just written (rather than to an external total) keeps the watermark exactly
+    /// in step with what was pushed, so the next `pendingStepDelta` is correct.
+    func advanceStepsWritten(by delta: Int, day: Date = Date()) throws {
+        guard delta > 0 else { return }
+        let dayStart = Calendar.current.startOfDay(for: day)
+        let descriptor = FetchDescriptor<StoredDaily>(predicate: #Predicate { $0.day == dayStart })
+        guard let row = try? context.fetch(descriptor).first else { return }
+        row.healthWrittenSteps = min(row.healthWrittenSteps + delta, row.steps)
+        try context.save()
     }
 
     /// Most recent stored daily rollup (latest day), or nil.

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -88,6 +88,10 @@ final class StoredSleepSummary {
     var remMin: Int = 0
     var awakeMin: Int = 0
     var efficiency: Double = 0
+    /// Actual sleep-window clock times (first segment start … last segment end), NOT
+    /// start-of-day — so a night-temp window aligns to real sleep onset/wake, not midnight.
+    var inBedStart: Date = Date.distantPast
+    var inBedEnd: Date = Date.distantPast
     var updatedAt: Date = Date.distantPast
 
     init(
@@ -98,6 +102,8 @@ final class StoredSleepSummary {
         remMin: Int = 0,
         awakeMin: Int = 0,
         efficiency: Double = 0,
+        inBedStart: Date = Date.distantPast,
+        inBedEnd: Date = Date.distantPast,
         updatedAt: Date = Date()
     ) {
         self.night = night
@@ -107,6 +113,8 @@ final class StoredSleepSummary {
         self.remMin = remMin
         self.awakeMin = awakeMin
         self.efficiency = efficiency
+        self.inBedStart = inBedStart
+        self.inBedEnd = inBedEnd
         self.updatedAt = updatedAt
     }
 
@@ -253,7 +261,8 @@ struct LocalStore {
     /// Upsert the nightly sleep summary, keyed by start-of-day of `night`. Re-syncing the
     /// same night overwrites the existing row rather than inserting a duplicate. Does NOT
     /// touch the SyncCursor — gating sleep history for HealthKit stays in `ingestSleep`.
-    func saveSleepSummary(_ summary: SleepStaging.Summary, night: Date) throws {
+    func saveSleepSummary(_ summary: SleepStaging.Summary, night: Date,
+                          inBedStart: Date, inBedEnd: Date) throws {
         let dayStart = Calendar.current.startOfDay(for: night)
         let m = summary.minutes
         let descriptor = FetchDescriptor<StoredSleepSummary>(
@@ -265,6 +274,8 @@ struct LocalStore {
             existing.remMin = m.rem
             existing.awakeMin = m.awake
             existing.efficiency = summary.efficiency
+            existing.inBedStart = inBedStart
+            existing.inBedEnd = inBedEnd
             existing.updatedAt = Date()
         } else {
             context.insert(StoredSleepSummary(
@@ -274,7 +285,9 @@ struct LocalStore {
                 lightMin: m.light,
                 remMin: m.rem,
                 awakeMin: m.awake,
-                efficiency: summary.efficiency
+                efficiency: summary.efficiency,
+                inBedStart: inBedStart,
+                inBedEnd: inBedEnd
             ))
         }
         try context.save()

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -162,20 +162,40 @@ struct LocalStore {
 
     init(_ context: ModelContext) { self.context = context }
 
-    /// Rebuild the in-memory SyncCursor from persisted rows. Skips the `hk:`-prefixed
-    /// HealthKit-watermark rows (see `pendingHealthSamples`) — they live in the same table
-    /// but track a separate concern and must not pollute the store-ingest cursor.
+    /// The store-ingest cursor rows (live `@Model` objects, so mutating `.last` updates the
+    /// context). Skips the `hk:`-prefixed HealthKit-watermark rows (see `pendingHealthSamples`)
+    /// — they live in the same table but track a separate concern and must not pollute the
+    /// store-ingest cursor.
+    private func storeCursorRows() throws -> [StoredCursor] {
+        try context.fetch(FetchDescriptor<StoredCursor>())
+            .filter { !$0.kindRaw.hasPrefix(Self.healthCursorPrefix) }
+    }
+
+    /// Rebuild the in-memory SyncCursor from persisted rows.
     func loadCursor() throws -> SyncCursor {
-        let rows = try context.fetch(FetchDescriptor<StoredCursor>())
         var map: [String: Date] = [:]
-        for r in rows where !r.kindRaw.hasPrefix(Self.healthCursorPrefix) { map[r.kindRaw] = r.last }
+        for r in try storeCursorRows() { map[r.kindRaw] = r.last }
         return SyncCursor(lastByKind: map)
     }
 
     /// Persist new samples and advance the cursor in one step.
+    ///
+    /// Ordering matters (#22): the cursor advance is STAGED in memory and only the rows that
+    /// actually moved are written, then samples + cursor commit together in a single
+    /// `context.save()`. On a save failure we roll back, so the persisted cursor never moves
+    /// ahead of un-stored samples — they're retried on the next ingest instead of being lost.
     func ingest(_ samples: [QuantitySample]) throws -> [QuantitySample] {
-        var cursor = try loadCursor()
-        let fresh = cursor.selectNew(samples)
+        // Fetch the cursor rows ONCE and reuse them for both the in-memory cursor and the
+        // post-insert upsert — no per-`MetricKind` fetch loop (#33).
+        let rows = try storeCursorRows()
+        var rowByKind: [String: StoredCursor] = [:]
+        for r in rows { rowByKind[r.kindRaw] = r }
+        let cursor = SyncCursor(lastByKind: rowByKind.mapValues(\.last))
+
+        // Stage the advance — don't touch the persisted cursor until the save commits (#22).
+        let (fresh, advanced) = cursor.selectNewStaged(samples)
+        guard !fresh.isEmpty else { return [] }
+
         var cumulativeStates: [MetricKind: CumulativeMetricState] = [:]
         var cumulativeStateDays: [MetricKind: Date] = [:]
         var ingested: [QuantitySample] = []
@@ -198,6 +218,9 @@ struct LocalStore {
                     ? existing
                     : CumulativeMetricState(previousRawValue: existing.previousRawValue, dailyTotal: 0)
             } else {
+                // First sample of this kind in the batch: the ONLY DB hit for cumulative state.
+                // Subsequent samples of the same kind reuse the in-memory `cumulativeStates`
+                // cache above, so no further per-sample lookups occur this ingest (#33).
                 state = try cumulativeState(for: s.kind, before: s.start)
             }
 
@@ -219,12 +242,45 @@ struct LocalStore {
             // every epoch would massively overcount. Deltas sum back to the daily total in Health.
             ingested.append(deltaSample)
         }
-        for kind in MetricKind.allCases {
-            guard let last = cursor.last(kind) else { continue }
-            upsertCursor(kind: kind.rawValue, last: last)
+        // Persist ONLY the kinds whose cursor actually advanced, reusing the rows already
+        // fetched above — no fetch-per-`MetricKind.allCases` loop (#33).
+        for kind in advanced.advancedKinds(since: cursor) {
+            guard let last = advanced.last(kind) else { continue }
+            if let existing = rowByKind[kind.rawValue] {
+                existing.last = last
+            } else {
+                context.insert(StoredCursor(kindRaw: kind.rawValue, last: last))
+            }
         }
-        try context.save()
+        do {
+            // Samples + cursor advance commit atomically. On failure, roll back the staged
+            // inserts and cursor moves so the next ingest re-stores the same samples (#22).
+            try context.save()
+        } catch {
+            context.rollback()
+            throw error
+        }
         return ingested
+    }
+
+    // MARK: Retention (#32)
+    //
+    // Days of raw `StoredSample` history kept on-device. Older epochs are pruned — the data
+    // already lives in Apple Health — while the rollup tables (`StoredSleepSummary` /
+    // `StoredDaily`) are kept long-term so the offline dashboard still shows past nights/days.
+    static let sampleRetentionDays = 30
+
+    /// Delete raw samples older than the retention window; rollup tables are untouched. Meant to
+    /// run occasionally (e.g. once at launch), NOT per write: with no column index a predicate
+    /// delete scans `start`, so running it on every live sample would reintroduce the unbounded
+    /// scan #32 is removing. The cumulative-counter day chain is unaffected (it only reaches back
+    /// to the current day, far inside the window).
+    func pruneExpiredSamples(olderThan days: Int = LocalStore.sampleRetentionDays,
+                             now: Date = Date()) throws {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: now) ?? now
+        try context.delete(model: StoredSample.self,
+                           where: #Predicate { $0.start < cutoff })
+        try context.save()
     }
 
     /// Stored samples of one kind within `[start, end)`, oldest→newest. Used by the

--- a/ios/OpenRingConn/Store/LocalStore.swift
+++ b/ios/OpenRingConn/Store/LocalStore.swift
@@ -13,7 +13,10 @@ final class StoredSample {
     var end: Date
     var value: Double
     var rawValue: Double?
-    var isDelta: Bool
+    // Default required so SwiftData can auto-migrate stores written before these
+    // cumulative-counter columns existed (#21) — a new non-optional attribute with no
+    // default fails lightweight migration and traps at ModelContainer init on launch.
+    var isDelta: Bool = false
     var dailyTotal: Double?
 
     init(

--- a/ios/OpenRingConn/TrendsView.swift
+++ b/ios/OpenRingConn/TrendsView.swift
@@ -1,0 +1,266 @@
+// 7-day rolling trends for available decoded metrics (#74).
+//
+// SCOPE — AVAILABLE DATA ONLY.
+// Shows trends for: sleep-window HR / HRV / SpO₂ / RR, steps, nightly skin temp,
+// sleep score, overnight stress score.
+//
+// ⚠️ Daytime/waking HR, HRV, SpO₂ aggregates are NOT shown — they need the
+// undecoded activity-epoch [15:22] payload (#93). When that decode lands, those
+// aggregates extend this view. Do NOT add daytime vitals charts here yet.
+//
+// Data loading: synchronous on-main-thread fetch from SwiftData (no background
+// context needed; ModelContext is already main-actor). Computed in `.task` on
+// first appearance and cached in @State.
+
+import SwiftUI
+import SwiftData
+import Charts
+import OpenRingKit
+
+struct TrendsView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var points: [TrendsEngine.DailyPoint] = []
+    @State private var loading = true
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                if loading {
+                    ProgressView("Computing trends…")
+                        .padding(.top, 40)
+                } else if points.isEmpty {
+                    emptyState
+                } else {
+                    availableMetricsNote
+                    let avgs = TrendsEngine.rollingAverages(points)
+                    sleepSection(avgs: avgs)
+                    activitySection(avgs: avgs)
+                }
+            }
+            .padding()
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle("7-Day Trends")
+        .task { loadData() }
+    }
+
+    // MARK: - Sections
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "chart.line.uptrend.xyaxis")
+                .font(.system(size: 44))
+                .foregroundStyle(.secondary)
+            Text("No trend data yet")
+                .font(.headline)
+            Text("Sync from the ring a few times to build your history.")
+                .font(.subheadline).foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.top, 40)
+    }
+
+    private var availableMetricsNote: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "info.circle").foregroundStyle(.secondary)
+            Text("Showing sleep-window vitals only. Daytime HR/HRV/SpO₂ trends follow the ring activity-payload decode (#93).")
+                .font(.caption2).foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private func sleepSection(avgs: TrendsEngine.RollingAverages) -> some View {
+        VStack(spacing: 12) {
+            sectionHeader("Sleep")
+
+            chartCard(title: "Sleep Score", unit: "/100",
+                      color: .purple,
+                      data: points.compactMap { p in p.sleepScore.map { (p.date, Double($0)) } },
+                      avg: avgs.sleepScore,
+                      formatAvg: { "\(Int($0.rounded()))" })
+
+            chartCard(title: "Overnight Stress", unit: "/100",
+                      color: .red,
+                      data: points.compactMap { p in p.stressScore.map { (p.date, Double($0)) } },
+                      avg: avgs.stressScore,
+                      formatAvg: { "\(Int($0.rounded()))" })
+
+            chartCard(title: "Sleep Duration", unit: "h",
+                      color: .blue,
+                      data: points.compactMap { p in
+                          p.sleepMinutes.map { (p.date, Double($0) / 60.0) }
+                      },
+                      avg: avgs.sleepMinutes.map { $0 / 60.0 },
+                      formatAvg: { String(format: "%.1f", $0) })
+
+            if avgs.skinTempC != nil {
+                chartCard(title: "Skin Temp (nightly)", unit: "°C",
+                          color: .orange,
+                          data: points.compactMap { p in
+                              p.skinTempC.flatMap { t in t > 0 ? (p.date, t) : nil }
+                          },
+                          avg: avgs.skinTempC,
+                          formatAvg: { String(format: "%.1f", $0) })
+            }
+
+            chartCard(title: "Sleep-Window HR", unit: "bpm",
+                      color: .red,
+                      data: points.compactMap { p in
+                          p.sleepHRAvg.flatMap { hr in hr > TrendsEngine.minValidHR ? (p.date, hr) : nil }
+                      },
+                      avg: avgs.sleepHRAvg,
+                      formatAvg: { "\(Int($0.rounded()))" })
+
+            chartCard(title: "Sleep-Window HRV (RMSSD est.)", unit: "ms",
+                      color: .green,
+                      data: points.compactMap { p in p.sleepHRVAvg.map { (p.date, $0) } },
+                      avg: avgs.sleepHRVAvg,
+                      formatAvg: { "\(Int($0.rounded()))" })
+
+            chartCard(title: "Sleep-Window SpO₂", unit: "%",
+                      color: .cyan,
+                      data: points.compactMap { p in p.sleepSpO2Avg.map { (p.date, $0 * 100) } },
+                      avg: avgs.sleepSpO2Avg.map { $0 * 100 },
+                      formatAvg: { String(format: "%.1f", $0) })
+
+            chartCard(title: "Sleep-Window RR", unit: "brpm",
+                      color: .teal,
+                      data: points.compactMap { p in p.sleepRRAvg.map { (p.date, $0) } },
+                      avg: avgs.sleepRRAvg,
+                      formatAvg: { String(format: "%.1f", $0) })
+        }
+    }
+
+    private func activitySection(avgs: TrendsEngine.RollingAverages) -> some View {
+        VStack(spacing: 12) {
+            sectionHeader("Activity")
+            chartCard(title: "Daily Steps", unit: "",
+                      color: .green,
+                      data: points.compactMap { p in p.steps.map { (p.date, Double($0)) } },
+                      avg: avgs.steps,
+                      formatAvg: { "\(Int($0.rounded()).formatted())" })
+        }
+    }
+
+    // MARK: - Chart card
+
+    private func chartCard(
+        title: String,
+        unit: String,
+        color: Color,
+        data: [(Date, Double)],
+        avg: Double?,
+        formatAvg: (Double) -> String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(title.uppercased())
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if let a = avg {
+                    VStack(alignment: .trailing, spacing: 0) {
+                        Text("7d avg")
+                            .font(.caption2).foregroundStyle(.tertiary)
+                        Text("\(formatAvg(a))\(unit.isEmpty ? "" : " \(unit)")")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(color)
+                    }
+                }
+            }
+            if data.isEmpty {
+                Text("No data in last 7 days")
+                    .font(.caption).foregroundStyle(.tertiary)
+                    .frame(height: 70, alignment: .center)
+                    .frame(maxWidth: .infinity)
+            } else {
+                Chart(data, id: \.0) { (date, value) in
+                    BarMark(
+                        x: .value("Day", date, unit: .day),
+                        y: .value(title, value)
+                    )
+                    .foregroundStyle(color.gradient)
+                    .cornerRadius(3)
+                }
+                .frame(height: 80)
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { v in
+                        AxisValueLabel(format: .dateTime.weekday(.narrow))
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { _ in
+                        AxisGridLine()
+                        AxisValueLabel()
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16)
+            .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.headline)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Data loading
+
+    @MainActor
+    private func loadData() {
+        let store = LocalStore(modelContext)
+        let lookbackDays = 14
+        let cal = Calendar.current
+        let now = Date()
+        let lookbackStart = cal.date(byAdding: .day, value: -lookbackDays, to: now) ?? now
+
+        // Fetch sleep summaries (latest first → reverse for oldest-first points)
+        let summaries = (try? store.recentSleepSummaries(limit: lookbackDays)) ?? []
+
+        // Fetch daily step rollups (latest first)
+        let dailies = (try? store.recentDailies(limit: lookbackDays)) ?? []
+        var stepsByDay: [Date: Int] = [:]
+        for d in dailies { stepsByDay[cal.startOfDay(for: d.day)] = d.steps }
+
+        // Pre-fetch all sleep-window vitals samples from the lookback window (one query per kind)
+        // then filter per-night in memory — avoids N×4 queries.
+        let hrSamples   = (try? store.samples(kind: .heartRate,       from: lookbackStart, to: now)) ?? []
+        let hrvSamples  = (try? store.samples(kind: .hrvSDNN,         from: lookbackStart, to: now)) ?? []
+        let spo2Samples = (try? store.samples(kind: .spo2,            from: lookbackStart, to: now)) ?? []
+        let rrSamples   = (try? store.samples(kind: .respiratoryRate, from: lookbackStart, to: now)) ?? []
+
+        // Build daily points from summaries (oldest→newest)
+        points = summaries.reversed().map { s in
+            let night = s.night
+            let window = s.inBedStart > Date.distantPast
+                ? DateInterval(start: s.inBedStart, end: s.inBedEnd) : nil
+
+            func avg(_ samples: [QuantitySample], minVal: Double = 0) -> Double? {
+                guard let w = window else { return nil }
+                let vals = samples
+                    .filter { w.contains($0.start) && $0.value > minVal }
+                    .map(\.value)
+                guard !vals.isEmpty else { return nil }
+                return vals.reduce(0, +) / Double(vals.count)
+            }
+
+            return TrendsEngine.DailyPoint(
+                date:          night,
+                steps:         stepsByDay[night],
+                sleepMinutes:  s.asleepMin > 0 ? s.asleepMin : nil,
+                sleepScore:    s.sleepScore > 0 ? s.sleepScore : nil,
+                stressScore:   s.stressScore > 0 ? s.stressScore : nil,
+                skinTempC:     s.skinTempC > 0 ? s.skinTempC : nil,
+                sleepHRAvg:    avg(hrSamples, minVal: TrendsEngine.minValidHR),
+                sleepHRVAvg:   avg(hrvSamples),
+                sleepSpO2Avg:  avg(spo2Samples),
+                sleepRRAvg:    avg(rrSamples)
+            )
+        }
+
+        loading = false
+    }
+}

--- a/ios/OpenRingConn/TrendsView.swift
+++ b/ios/OpenRingConn/TrendsView.swift
@@ -225,6 +225,10 @@ struct TrendsView: View {
         var stepsByDay: [Date: Int] = [:]
         for d in dailies { stepsByDay[cal.startOfDay(for: d.day)] = d.steps }
 
+        // Index summaries by start-of-day night.
+        var summaryByNight: [Date: StoredSleepSummary] = [:]
+        for s in summaries { summaryByNight[cal.startOfDay(for: s.night)] = s }
+
         // Pre-fetch all sleep-window vitals samples from the lookback window (one query per kind)
         // then filter per-night in memory — avoids N×4 queries.
         let hrSamples   = (try? store.samples(kind: .heartRate,       from: lookbackStart, to: now)) ?? []
@@ -232,11 +236,15 @@ struct TrendsView: View {
         let spo2Samples = (try? store.samples(kind: .spo2,            from: lookbackStart, to: now)) ?? []
         let rrSamples   = (try? store.samples(kind: .respiratoryRate, from: lookbackStart, to: now)) ?? []
 
-        // Build daily points from summaries (oldest→newest)
-        points = summaries.reversed().map { s in
-            let night = s.night
-            let window = s.inBedStart > Date.distantPast
-                ? DateInterval(start: s.inBedStart, end: s.inBedEnd) : nil
+        // Build one point per day across the UNION of sleep-summary nights and daily-step days,
+        // so the Activity/Steps chart renders from step history even on days with no overnight
+        // sleep summary (e.g. the user wore the ring by day but not to bed). Both keys are
+        // start-of-day, so they align.
+        let allDays = Set(summaryByNight.keys).union(stepsByDay.keys).sorted()
+        points = allDays.map { day in
+            let s = summaryByNight[day]
+            let window = (s?.inBedStart ?? .distantPast) > Date.distantPast
+                ? DateInterval(start: s!.inBedStart, end: s!.inBedEnd) : nil
 
             func avg(_ samples: [QuantitySample], minVal: Double = 0) -> Double? {
                 guard let w = window else { return nil }
@@ -248,12 +256,12 @@ struct TrendsView: View {
             }
 
             return TrendsEngine.DailyPoint(
-                date:          night,
-                steps:         stepsByDay[night],
-                sleepMinutes:  s.asleepMin > 0 ? s.asleepMin : nil,
-                sleepScore:    s.sleepScore > 0 ? s.sleepScore : nil,
-                stressScore:   s.stressScore > 0 ? s.stressScore : nil,
-                skinTempC:     s.skinTempC > 0 ? s.skinTempC : nil,
+                date:          day,
+                steps:         stepsByDay[day],
+                sleepMinutes:  (s?.asleepMin ?? 0) > 0 ? s?.asleepMin : nil,
+                sleepScore:    (s?.sleepScore ?? 0) > 0 ? s?.sleepScore : nil,
+                stressScore:   (s?.stressScore ?? 0) > 0 ? s?.stressScore : nil,
+                skinTempC:     (s?.skinTempC ?? 0) > 0 ? s?.skinTempC : nil,
                 sleepHRAvg:    avg(hrSamples, minVal: TrendsEngine.minValidHR),
                 sleepHRVAvg:   avg(hrvSamples),
                 sleepSpO2Avg:  avg(spo2Samples),

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import OpenRingKit
+
+@MainActor
+struct UserProfileSettingsView: View {
+    @AppStorage("userProfile.age") private var age = 35
+    @AppStorage("userProfile.weightKg") private var weightKg = 70.0
+    @AppStorage("userProfile.heightCm") private var heightCm = 170.0
+    @AppStorage("userProfile.sex") private var sexRaw = BiologicalSex.male.rawValue
+
+    var body: some View {
+        Form {
+            Section("Profile") {
+                Stepper(value: $age, in: 13...120) {
+                    LabeledContent("Age", value: "\(age)")
+                }
+                LabeledContent("Weight") {
+                    TextField("kg", value: $weightKg, format: .number.precision(.fractionLength(1)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                }
+                LabeledContent("Height") {
+                    TextField("cm", value: $heightCm, format: .number.precision(.fractionLength(1)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                }
+                Picker("Sex", selection: $sexRaw) {
+                    ForEach(BiologicalSex.allCases, id: \.rawValue) { sex in
+                        Text(sex.rawValue.capitalized).tag(sex.rawValue)
+                    }
+                }
+            }
+
+            Section("Calories") {
+                LabeledContent("BMR", value: "\(Int(Calories.bmrKcalPerDay(profile: profile).rounded())) kcal/day")
+                LabeledContent("Passive", value: "\(Calories.bmrKcalPerHour(profile: profile), specifier: "%.1f") kcal/hour")
+                LabeledContent("Max HR", value: "\(maxHR) bpm")
+            }
+        }
+        .navigationTitle("User Profile")
+    }
+
+    private var profile: UserProfile {
+        UserProfile(
+            age: age,
+            weightKg: max(weightKg, 1.0),
+            heightCm: max(heightCm, 1.0),
+            sex: BiologicalSex(rawValue: sexRaw) ?? .male
+        )
+    }
+
+    private var maxHR: Int {
+        max(220 - age, 1)
+    }
+}

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -21,6 +21,19 @@ struct UserProfileSettingsView: View {
     @AppStorage(SleepScheduleDefaults.wakeMinutes)
     private var wakeMinutes = SleepScheduleDefaults.defaultWakeMinutes
 
+    // Health-alert thresholds (#73) + skin-temp/fever toggle (#85) + the shared quiet-hours (DND)
+    // window. Keys/defaults shared with the notification engine via `HealthAlertDefaults`.
+    @AppStorage(HealthAlertDefaults.highHREnabled) private var highHREnabled = true
+    @AppStorage(HealthAlertDefaults.highHRBpm) private var highHRBpm = HealthAlertDefaults.defaultHighHRBpm
+    @AppStorage(HealthAlertDefaults.lowSpO2Enabled) private var lowSpO2Enabled = true
+    @AppStorage(HealthAlertDefaults.lowSpO2Percent) private var lowSpO2Percent = HealthAlertDefaults.defaultLowSpO2Percent
+    @AppStorage(HealthAlertDefaults.elevatedHREnabled) private var elevatedHREnabled = true
+    @AppStorage(HealthAlertDefaults.elevatedHRBpm) private var elevatedHRBpm = HealthAlertDefaults.defaultElevatedHRBpm
+    @AppStorage(HealthAlertDefaults.tempFeverEnabled) private var tempFeverEnabled = true
+    @AppStorage(HealthAlertDefaults.quietEnabled) private var quietEnabled = false
+    @AppStorage(HealthAlertDefaults.quietStartMinutes) private var quietStart = HealthAlertDefaults.defaultQuietStart
+    @AppStorage(HealthAlertDefaults.quietEndMinutes) private var quietEnd = HealthAlertDefaults.defaultQuietEnd
+
     var body: some View {
         Form {
             Section("Profile") {
@@ -74,6 +87,48 @@ struct UserProfileSettingsView: View {
                 }
                 Text("Bounds the overnight skin-temp window. When Apple Health is "
                      + "authorized, your iOS Sleep schedule is used instead.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            Section("Health alerts") {
+                Toggle("High heart rate", isOn: $highHREnabled)
+                if highHREnabled {
+                    Stepper(value: $highHRBpm, in: 80...200, step: 5) {
+                        LabeledContent("Notify above", value: "\(highHRBpm) bpm")
+                    }
+                }
+                Toggle("Low blood oxygen", isOn: $lowSpO2Enabled)
+                if lowSpO2Enabled {
+                    Stepper(value: $lowSpO2Percent, in: 80...99) {
+                        LabeledContent("Notify below", value: "\(lowSpO2Percent)%")
+                    }
+                }
+                Toggle("Elevated HR while inactive", isOn: $elevatedHREnabled)
+                if elevatedHREnabled {
+                    Stepper(value: $elevatedHRBpm, in: 80...160, step: 5) {
+                        LabeledContent("Sustained above", value: "\(elevatedHRBpm) bpm")
+                    }
+                    Text("Notifies if heart rate stays above this for 10 minutes while inactive. "
+                         + "Sharpens once activity detection lands.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                Toggle("Skin-temp & fever alerts", isOn: $tempFeverEnabled)
+                Text("Note: OpenRingConn is not a medical device. These reminders are based on ring "
+                     + "sensor data only and are not a diagnosis. If you feel unwell, consult a "
+                     + "qualified medical professional.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+
+            Section("Quiet hours") {
+                Toggle("Mute alerts overnight", isOn: $quietEnabled)
+                if quietEnabled {
+                    DatePicker("From", selection: timeBinding($quietStart),
+                               displayedComponents: .hourAndMinute)
+                    DatePicker("To", selection: timeBinding($quietEnd),
+                               displayedComponents: .hourAndMinute)
+                }
+                Text("Health alerts are held during this window (delivered once it ends if still "
+                     + "relevant).")
                     .font(.caption).foregroundStyle(.secondary)
             }
 

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -21,6 +21,14 @@ struct UserProfileSettingsView: View {
     @AppStorage(SleepScheduleDefaults.wakeMinutes)
     private var wakeMinutes = SleepScheduleDefaults.defaultWakeMinutes
 
+    // Daily goals (#77). Keys/defaults shared with GoalsCardView via `GoalDefaults`.
+    @AppStorage(GoalDefaults.workdaySteps)    private var workdaySteps    = GoalDefaults.defaultWorkdaySteps
+    @AppStorage(GoalDefaults.weekendSteps)    private var weekendSteps    = GoalDefaults.defaultWeekendSteps
+    @AppStorage(GoalDefaults.activeKcal)      private var activeKcalGoal  = GoalDefaults.defaultActiveKcal
+    @AppStorage(GoalDefaults.activityMinutes) private var actMinGoal      = GoalDefaults.defaultActivityMinutes
+    @AppStorage(GoalDefaults.workdaySleepMin) private var workdaySleepMin = GoalDefaults.defaultWorkdaySleepMin
+    @AppStorage(GoalDefaults.weekendSleepMin) private var weekendSleepMin = GoalDefaults.defaultWeekendSleepMin
+
     // Health-alert thresholds (#73) + skin-temp/fever toggle (#85) + the shared quiet-hours (DND)
     // window. Keys/defaults shared with the notification engine via `HealthAlertDefaults`.
     @AppStorage(HealthAlertDefaults.highHREnabled) private var highHREnabled = true
@@ -90,6 +98,29 @@ struct UserProfileSettingsView: View {
                     .font(.caption).foregroundStyle(.secondary)
             }
 
+            Section("Daily goals") {
+                Stepper(value: $workdaySteps, in: 1_000...30_000, step: 500) {
+                    LabeledContent("Weekday steps", value: workdaySteps.formatted())
+                }
+                Stepper(value: $weekendSteps, in: 1_000...30_000, step: 500) {
+                    LabeledContent("Weekend steps", value: weekendSteps.formatted())
+                }
+                Stepper(value: $activeKcalGoal, in: 50...1_500, step: 25) {
+                    LabeledContent("Active calories", value: "\(Int(activeKcalGoal)) kcal")
+                }
+                Stepper(value: $actMinGoal, in: 5...180, step: 5) {
+                    LabeledContent("Activity minutes", value: "\(Int(actMinGoal)) min")
+                }
+                Stepper(value: $workdaySleepMin, in: 240...600, step: 15) {
+                    LabeledContent("Weekday sleep", value: formatGoalSleep(workdaySleepMin))
+                }
+                Stepper(value: $weekendSleepMin, in: 240...600, step: 15) {
+                    LabeledContent("Weekend sleep", value: formatGoalSleep(weekendSleepMin))
+                }
+                Text("Progress rings on the dashboard show today's goal vs. actual. Activity minutes = elevated-HR minutes (basic threshold estimate).")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
             Section("Health alerts") {
                 Toggle("High heart rate", isOn: $highHREnabled)
                 if highHREnabled {
@@ -134,6 +165,13 @@ struct UserProfileSettingsView: View {
 
         }
         .navigationTitle("User Profile")
+    }
+
+    // MARK: Goal helpers
+
+    private func formatGoalSleep(_ minutes: Int) -> String {
+        let h = minutes / 60, m = minutes % 60
+        return m > 0 ? "\(h)h \(m)m" : "\(h)h"
     }
 
     // MARK: Imperial display over metric storage

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -33,6 +33,17 @@ struct UserProfileSettingsView: View {
     // never see the cycle calendar card on the dashboard. Shared key with ContentView.
     @AppStorage("userProfile.womensHealthEnabled") private var womensHealthEnabled = false
 
+    // Unit preferences (#83). Default to locale-appropriate units out of the box.
+    @AppStorage("units.temperature") private var tempUnitRaw = TemperatureUnit.localeDefault.rawValue
+    @AppStorage("units.distance")    private var distUnitRaw = DistanceUnit.localeDefault.rawValue
+
+    // App-side reminder settings (#84). Keys/defaults shared with ReminderDefaults.
+    @AppStorage(ReminderDefaults.sedentaryEnabled)     private var sedentaryEnabled    = true
+    @AppStorage(ReminderDefaults.sedentaryIntervalMin) private var sedentaryIntervalMin = 50
+    @AppStorage(ReminderDefaults.wearEnabled)          private var wearEnabled          = false
+    @AppStorage(ReminderDefaults.bedtimeEnabled)       private var bedtimeEnabled       = false
+    @AppStorage(ReminderDefaults.bedtimeMinutesBefore) private var bedtimeMinutesBefore = 30
+
     // Health-alert thresholds (#73) + skin-temp/fever toggle (#85) + the shared quiet-hours (DND)
     // window. Keys/defaults shared with the notification engine via `HealthAlertDefaults`.
     @AppStorage(HealthAlertDefaults.highHREnabled) private var highHREnabled = true
@@ -173,6 +184,52 @@ struct UserProfileSettingsView: View {
                 }
                 Text("Health alerts are held during this window (delivered once it ends if still "
                      + "relevant).")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            // MARK: Reminders (#84)
+            Section("Reminders") {
+                Toggle("Sedentary / move reminder", isOn: $sedentaryEnabled)
+                if sedentaryEnabled {
+                    Stepper(value: $sedentaryIntervalMin, in: 30...120, step: 10) {
+                        LabeledContent("Remind after", value: "\(sedentaryIntervalMin) min inactive")
+                    }
+                }
+                Toggle("Wear reminder", isOn: $wearEnabled)
+                Toggle("Bedtime reminder", isOn: $bedtimeEnabled)
+                if bedtimeEnabled {
+                    Stepper(value: $bedtimeMinutesBefore, in: 15...60, step: 15) {
+                        LabeledContent("Warn before bed", value: "\(bedtimeMinutesBefore) min")
+                    }
+                }
+                Text("Reminder quiet hours and backoff use the same settings as health alerts above.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            // MARK: Units (#83)
+            Section("Units") {
+                Picker("Temperature", selection: $tempUnitRaw) {
+                    Text("°C").tag(TemperatureUnit.celsius.rawValue)
+                    Text("°F").tag(TemperatureUnit.fahrenheit.rawValue)
+                }
+                Picker("Distance", selection: $distUnitRaw) {
+                    Text("km").tag(DistanceUnit.metric.rawValue)
+                    Text("mi").tag(DistanceUnit.imperial.rawValue)
+                }
+                Text("Affects how temperature and distance values are shown throughout the app. "
+                     + "Values are always stored in metric internally.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            // MARK: Data export (#80)
+            Section("Data export") {
+                NavigationLink {
+                    ExportView()
+                } label: {
+                    Label("Export health data", systemImage: "square.and.arrow.up")
+                }
+                Text("Export all stored ring data (HR, SpO₂, sleep, steps) as CSV or JSON "
+                     + "for your own analysis. Data stays on your device unless you share it.")
                     .font(.caption).foregroundStyle(.secondary)
             }
 

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -25,14 +25,26 @@ struct UserProfileSettingsView: View {
                     LabeledContent("Age", value: "\(age)")
                 }
                 LabeledContent("Weight") {
-                    TextField("kg", value: $weightKg, format: .number.precision(.fractionLength(1)))
-                        .keyboardType(.decimalPad)
-                        .multilineTextAlignment(.trailing)
+                    HStack(spacing: 4) {
+                        TextField("lb", value: weightLb, format: .number.precision(.fractionLength(0)))
+                            .keyboardType(.decimalPad)
+                            .multilineTextAlignment(.trailing)
+                        Text("lb").foregroundStyle(.secondary)
+                    }
                 }
                 LabeledContent("Height") {
-                    TextField("cm", value: $heightCm, format: .number.precision(.fractionLength(1)))
-                        .keyboardType(.decimalPad)
-                        .multilineTextAlignment(.trailing)
+                    HStack(spacing: 4) {
+                        TextField("ft", value: heightFeet, format: .number)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                            .frame(maxWidth: 36)
+                        Text("ft").foregroundStyle(.secondary)
+                        TextField("in", value: heightInches, format: .number)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                            .frame(maxWidth: 36)
+                        Text("in").foregroundStyle(.secondary)
+                    }
                 }
                 Picker("Sex", selection: $sexRaw) {
                     ForEach(BiologicalSex.allCases, id: \.rawValue) { sex in
@@ -54,26 +66,39 @@ struct UserProfileSettingsView: View {
                     .font(.caption).foregroundStyle(.secondary)
             }
 
-            Section("Calories") {
-                LabeledContent("BMR", value: "\(Int(Calories.bmrKcalPerDay(profile: profile).rounded())) kcal/day")
-                LabeledContent("Passive", value: "\(String(format: "%.1f", Calories.bmrKcalPerHour(profile: profile))) kcal/hour")
-                LabeledContent("Max HR", value: "\(maxHR) bpm")
-            }
         }
         .navigationTitle("User Profile")
     }
 
-    private var profile: UserProfile {
-        UserProfile(
-            age: age,
-            weightKg: max(weightKg, 1.0),
-            heightCm: max(heightCm, 1.0),
-            sex: BiologicalSex(rawValue: sexRaw) ?? .male
-        )
+    // MARK: Imperial display over metric storage
+    // Storage stays kg/cm (OpenRingKit's BMR math expects metric); these bindings present
+    // and edit it in lb / ft+in, converting on the way through.
+
+    private static let lbPerKg = 2.2046226218
+    private static let cmPerIn = 2.54
+
+    private var weightLb: Binding<Double> {
+        Binding(get: { weightKg * Self.lbPerKg },
+                set: { weightKg = max($0, 0) / Self.lbPerKg })
     }
 
-    private var maxHR: Int {
-        max(220 - age, 1)
+    /// Total height in whole inches (rounded), the basis for the ft/in split.
+    private var totalInches: Int { Int((heightCm / Self.cmPerIn).rounded()) }
+
+    private var heightFeet: Binding<Int> {
+        Binding(get: { totalInches / 12 },
+                set: { newFeet in
+                    let inches = totalInches % 12
+                    heightCm = Double(max(newFeet, 0) * 12 + inches) * Self.cmPerIn
+                })
+    }
+
+    private var heightInches: Binding<Int> {
+        Binding(get: { totalInches % 12 },
+                set: { newInches in
+                    let feet = totalInches / 12
+                    heightCm = Double(feet * 12 + min(max(newInches, 0), 11)) * Self.cmPerIn
+                })
     }
 
     // MARK: Sleep-schedule bindings (minutes-since-midnight <-> Date for DatePicker)

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -8,6 +8,16 @@ struct UserProfileSettingsView: View {
     @AppStorage("userProfile.heightCm") private var heightCm = 170.0
     @AppStorage("userProfile.sex") private var sexRaw = BiologicalSex.male.rawValue
 
+    // Sleep schedule (manual). Persisted as minutes-since-midnight so it's timezone-free
+    // and feeds OpenRingKit's `SleepWindow` math directly. Keys/defaults are shared with
+    // `ManualSleepSchedule` via `SleepScheduleDefaults`. Disabled by default: until the
+    // user opts in, the night-temp window keeps using the detected sleep span.
+    @AppStorage(SleepScheduleDefaults.enabled) private var sleepEnabled = false
+    @AppStorage(SleepScheduleDefaults.bedMinutes)
+    private var bedMinutes = SleepScheduleDefaults.defaultBedMinutes
+    @AppStorage(SleepScheduleDefaults.wakeMinutes)
+    private var wakeMinutes = SleepScheduleDefaults.defaultWakeMinutes
+
     var body: some View {
         Form {
             Section("Profile") {
@@ -31,6 +41,19 @@ struct UserProfileSettingsView: View {
                 }
             }
 
+            Section("Sleep schedule") {
+                Toggle("Use manual sleep schedule", isOn: $sleepEnabled)
+                if sleepEnabled {
+                    DatePicker("Bedtime", selection: bedTimeBinding,
+                               displayedComponents: .hourAndMinute)
+                    DatePicker("Wake", selection: wakeTimeBinding,
+                               displayedComponents: .hourAndMinute)
+                }
+                Text("Bounds the overnight skin-temp window. When Apple Health is "
+                     + "authorized, your iOS Sleep schedule is used instead.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
             Section("Calories") {
                 LabeledContent("BMR", value: "\(Int(Calories.bmrKcalPerDay(profile: profile).rounded())) kcal/day")
                 LabeledContent("Passive", value: "\(String(format: "%.1f", Calories.bmrKcalPerHour(profile: profile))) kcal/hour")
@@ -51,5 +74,26 @@ struct UserProfileSettingsView: View {
 
     private var maxHR: Int {
         max(220 - age, 1)
+    }
+
+    // MARK: Sleep-schedule bindings (minutes-since-midnight <-> Date for DatePicker)
+
+    private var bedTimeBinding: Binding<Date> { timeBinding($bedMinutes) }
+    private var wakeTimeBinding: Binding<Date> { timeBinding($wakeMinutes) }
+
+    /// Bridges an `Int` minutes-since-midnight store to a `Date` an `.hourAndMinute`
+    /// `DatePicker` can edit (anchored to today; only the time component is used).
+    private func timeBinding(_ minutes: Binding<Int>) -> Binding<Date> {
+        let cal = Calendar.current
+        return Binding(
+            get: {
+                cal.startOfDay(for: Date())
+                    .addingTimeInterval(TimeInterval(minutes.wrappedValue * 60))
+            },
+            set: { newValue in
+                let c = cal.dateComponents([.hour, .minute], from: newValue)
+                minutes.wrappedValue = SleepWindow.minutes(hour: c.hour ?? 0, minute: c.minute ?? 0)
+            }
+        )
     }
 }

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -7,6 +7,9 @@ struct UserProfileSettingsView: View {
     @AppStorage("userProfile.weightKg") private var weightKg = 70.0
     @AppStorage("userProfile.heightCm") private var heightCm = 170.0
     @AppStorage("userProfile.sex") private var sexRaw = BiologicalSex.male.rawValue
+    // Periodic auto-measure toggle — same UserDefaults key RingSession reads. Default true
+    // (the user opted into periodic measuring); flip off to save ring battery.
+    @AppStorage(RingSession.autoMeasureEnabledKey) private var autoMeasureEnabled = true
 
     // Sleep schedule (manual). Persisted as minutes-since-midnight so it's timezone-free
     // and feeds OpenRingKit's `SleepWindow` math directly. Keys/defaults are shared with
@@ -51,6 +54,14 @@ struct UserProfileSettingsView: View {
                         Text(sex.rawValue.capitalized).tag(sex.rawValue)
                     }
                 }
+            }
+
+            Section("Tracking") {
+                Toggle("Auto-measure HR & SpO₂", isOn: $autoMeasureEnabled)
+                Text("While connected, the ring re-measures heart rate (~every 10 min) and "
+                     + "blood oxygen on its own, so the dashboard stays fresh — like the "
+                     + "official app. Uses more ring battery; turn off to measure only on tap.")
+                    .font(.caption).foregroundStyle(.secondary)
             }
 
             Section("Sleep schedule") {

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -29,6 +29,10 @@ struct UserProfileSettingsView: View {
     @AppStorage(GoalDefaults.workdaySleepMin) private var workdaySleepMin = GoalDefaults.defaultWorkdaySleepMin
     @AppStorage(GoalDefaults.weekendSleepMin) private var weekendSleepMin = GoalDefaults.defaultWeekendSleepMin
 
+    // Women's health toggle (#78). Off by default — users who don't want this feature
+    // never see the cycle calendar card on the dashboard. Shared key with ContentView.
+    @AppStorage("userProfile.womensHealthEnabled") private var womensHealthEnabled = false
+
     // Health-alert thresholds (#73) + skin-temp/fever toggle (#85) + the shared quiet-hours (DND)
     // window. Keys/defaults shared with the notification engine via `HealthAlertDefaults`.
     @AppStorage(HealthAlertDefaults.highHREnabled) private var highHREnabled = true
@@ -148,6 +152,15 @@ struct UserProfileSettingsView: View {
                      + "sensor data only and are not a diagnosis. If you feel unwell, consult a "
                      + "qualified medical professional.")
                     .font(.caption2).foregroundStyle(.secondary)
+            }
+
+            Section("Women's health") {
+                Toggle("Show cycle calendar", isOn: $womensHealthEnabled)
+                Text("Enables period logging, cycle predictions, and a menstrual-flow "
+                     + "write to Apple Health. The feature is hidden by default — only "
+                     + "turn it on if you want it. Predictions are estimates only and "
+                     + "are not a contraception tool or medical advice.")
+                    .font(.caption).foregroundStyle(.secondary)
             }
 
             Section("Quiet hours") {

--- a/ios/OpenRingConn/UserProfile.swift
+++ b/ios/OpenRingConn/UserProfile.swift
@@ -33,7 +33,7 @@ struct UserProfileSettingsView: View {
 
             Section("Calories") {
                 LabeledContent("BMR", value: "\(Int(Calories.bmrKcalPerDay(profile: profile).rounded())) kcal/day")
-                LabeledContent("Passive", value: "\(Calories.bmrKcalPerHour(profile: profile), specifier: "%.1f") kcal/hour")
+                LabeledContent("Passive", value: "\(String(format: "%.1f", Calories.bmrKcalPerHour(profile: profile))) kcal/hour")
                 LabeledContent("Max HR", value: "\(maxHR) bpm")
             }
         }

--- a/ios/OpenRingConn/VitalsStatusCardView.swift
+++ b/ios/OpenRingConn/VitalsStatusCardView.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+import SwiftData
+import OpenRingKit
+
+/// Vitals Status panel (#72). Compares the latest day's resting HR, overnight SpO₂, overnight HRV
+/// and skin temperature to the user's PERSONAL 7–30 day baseline and shows a normal / watch /
+/// anomaly status with the contributing signals — including the HR+temp suspected-fever flag.
+///
+/// Everything is derived from already-decoded data and judged against the user's OWN history (no
+/// hardcoded "healthy" ranges, no fabricated values). It's an on-device estimate, labeled as such,
+/// and carries the medical disclaimer. Empty until enough nights/days of history accrue.
+struct VitalsStatusCardView: View {
+    /// ~32 days of readings — enough to fill the 30-day baseline window plus today.
+    @Query private var hrSamples: [StoredSample]
+    @Query private var spo2Samples: [StoredSample]
+    @Query private var hrvSamples: [StoredSample]
+    /// Trailing nights for the canonical skin-temp baseline/offset (#69).
+    @Query private var sleepNights: [StoredSleepSummary]
+
+    private static let historyDays = 32
+
+    init() {
+        let since = Calendar.current.startOfDay(for: Date())
+            .addingTimeInterval(-Double(Self.historyDays) * 86_400)
+        let hr = MetricKind.heartRate.rawValue
+        let spo2 = MetricKind.spo2.rawValue
+        let hrv = MetricKind.hrvSDNN.rawValue
+        _hrSamples = Query(FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == hr && $0.start >= since && $0.value > 0 },
+            sortBy: [SortDescriptor(\.start, order: .forward)]))
+        _spo2Samples = Query(FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == spo2 && $0.start >= since && $0.value > 0 },
+            sortBy: [SortDescriptor(\.start, order: .forward)]))
+        _hrvSamples = Query(FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == hrv && $0.start >= since && $0.value > 0 },
+            sortBy: [SortDescriptor(\.start, order: .forward)]))
+        var nights = FetchDescriptor<StoredSleepSummary>(sortBy: [SortDescriptor(\.night, order: .reverse)])
+        nights.fetchLimit = 40
+        _sleepNights = Query(nights)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "waveform.path.ecg").foregroundStyle(statusColor)
+                Text("VITALS STATUS").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                Spacer()
+                if let report { statusBadge(report.status) }
+            }
+
+            if let report {
+                if report.feverSuspected {
+                    signalRow(icon: "thermometer.medium", color: .red, title: "Possible fever signs",
+                              detail: "Skin temperature and heart rate are both elevated above baseline.")
+                }
+                ForEach(Array(report.signals.enumerated()), id: \.offset) { _, signal in
+                    signalRow(icon: icon(for: signal), color: color(for: signal.severity),
+                              title: title(for: signal), detail: detail(for: signal))
+                }
+                if report.status == .normal && !report.feverSuspected {
+                    Text("All tracked vitals are within your personal baseline.")
+                        .font(.subheadline).foregroundStyle(.secondary)
+                }
+                Text("Compared to your personal 7–30 day baseline. On-device estimate — not a medical device.")
+                    .font(.caption2).foregroundStyle(.tertiary)
+            } else {
+                Text("Building your baseline")
+                    .font(.subheadline.weight(.medium))
+                Text("Wear the ring overnight for about a week so OpenRingConn can learn your personal "
+                     + "resting HR, SpO₂, HRV and skin-temperature ranges, then flag unusual days.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    // MARK: Report
+
+    /// The Vitals Status report for the latest day, or nil until at least one vital has enough
+    /// baseline history. Pure logic lives in OpenRingKit.VitalsBaseline; this assembles its inputs.
+    private var report: VitalsBaseline.Report? {
+        var inputs: [VitalsBaseline.VitalInput] = []
+        if let i = vitalInput(.restingHR, dailySeries(restingHRDaily())) { inputs.append(i) }
+        if let i = vitalInput(.overnightSpO2, dailySeries(dailyMeans(spo2Samples, scale: 100))) { inputs.append(i) }
+        if let i = vitalInput(.overnightHRV, dailySeries(dailyMeans(hrvSamples, scale: 1))) { inputs.append(i) }
+        let offset = skinTempOffset()
+        guard !inputs.isEmpty || offset != nil else { return nil }
+        return VitalsBaseline.report(inputs, skinTempOffsetC: offset)
+    }
+
+    /// Build a VitalInput from a chronological (today-last) series, requiring enough prior days.
+    private func vitalInput(_ vital: VitalsBaseline.Vital,
+                            _ series: [Double]) -> VitalsBaseline.VitalInput? {
+        guard let today = series.last else { return nil }
+        let prior = Array(series.dropLast())
+        guard prior.count >= VitalsBaseline.Config().minBaselineDays else { return nil }
+        return VitalsBaseline.VitalInput(vital: vital, today: today, prior: prior)
+    }
+
+    /// Chronological list of daily values (oldest→newest).
+    private func dailySeries(_ days: [(day: Date, value: Double)]) -> [Double] {
+        days.sorted { $0.day < $1.day }.map(\.value)
+    }
+
+    /// Resting HR per day = the day's sleep/low-activity HR estimate (RestingHR analytics).
+    private func restingHRDaily() -> [(day: Date, value: Double)] {
+        let samples = hrSamples.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        return RestingHR.dailyValues(hr: samples).map { (day: $0.day, value: $0.bpm) }
+    }
+
+    /// Per-calendar-day mean of a sample kind (SpO₂ fraction → percent via `scale`).
+    private func dailyMeans(_ samples: [StoredSample], scale: Double) -> [(day: Date, value: Double)] {
+        let byDay = Dictionary(grouping: samples) { Calendar.current.startOfDay(for: $0.start) }
+        return byDay.map { (day, rows) in
+            (day: day, value: rows.reduce(0.0) { $0 + $1.value * scale } / Double(rows.count))
+        }
+    }
+
+    /// Latest night's signed skin-temp offset from the rolling baseline (#69), or nil.
+    private func skinTempOffset() -> Double? {
+        let valid = sleepNights.filter { $0.skinTempC > 0 }
+        guard let latest = valid.max(by: { $0.night < $1.night }) else { return nil }
+        let cal = Calendar.current
+        let tonightDay = cal.startOfDay(for: latest.night)
+        let prior = valid
+            .filter { cal.startOfDay(for: $0.night) != tonightDay }
+            .map { SkinTempBaseline.NightlyTemp(night: $0.night, celsius: $0.skinTempC) }
+        guard let baseline = SkinTempBaseline.baseline(priorNights: prior) else { return nil }
+        return latest.skinTempC - baseline
+    }
+
+    // MARK: Presentation
+
+    private var statusColor: Color {
+        guard let status = report?.status else { return .green }
+        switch status {
+        case .anomaly: return .red
+        case .watch: return .orange
+        case .normal: return .green
+        }
+    }
+
+    @ViewBuilder private func statusBadge(_ status: VitalsBaseline.Status) -> some View {
+        let (label, color): (String, Color) = {
+            switch status {
+            case .normal: return ("Normal", .green)
+            case .watch: return ("Watch", .orange)
+            case .anomaly: return ("Anomaly", .red)
+            }
+        }()
+        Text(label.uppercased())
+            .font(.caption2.weight(.bold))
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(Capsule().fill(color.opacity(0.15)))
+            .foregroundStyle(color)
+    }
+
+    private func signalRow(icon: String, color: Color, title: String, detail: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: icon).foregroundStyle(color).frame(width: 20)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title).font(.subheadline.weight(.medium))
+                Text(detail).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func color(for severity: VitalsBaseline.Severity) -> Color {
+        severity == .significant ? .red : .orange
+    }
+
+    private func icon(for signal: VitalsBaseline.Signal) -> String {
+        if signal.isTemperature { return "thermometer.medium" }
+        switch signal.vital {
+        case .restingHR: return "heart.fill"
+        case .overnightSpO2: return "lungs.fill"
+        case .overnightHRV: return "waveform.path.ecg"
+        case .none: return "exclamationmark.circle"
+        }
+    }
+
+    private func title(for signal: VitalsBaseline.Signal) -> String {
+        let dir = signal.direction == .rise ? "elevated" : "low"
+        let sev = signal.severity == .significant ? "Significant" : "Minor"
+        if signal.isTemperature {
+            return "\(sev) skin-temperature change (\(signal.direction == .rise ? "rise" : "drop"))"
+        }
+        switch signal.vital {
+        case .restingHR: return "\(sev) resting heart rate (\(dir))"
+        case .overnightSpO2: return "\(sev) overnight SpO₂ (\(dir))"
+        case .overnightHRV: return "\(sev) overnight HRV (\(dir))"
+        case .none: return "\(sev) deviation"
+        }
+    }
+
+    private func detail(for signal: VitalsBaseline.Signal) -> String {
+        if signal.isTemperature {
+            // Skin temp is shown in °F app-wide; a °C delta scales to °F by 9/5.
+            return String(format: "%+.1f °F vs your baseline.", signal.delta * 9 / 5)
+        }
+        guard let base = signal.baselineMean else { return "Outside your usual range." }
+        switch signal.vital {
+        case .restingHR: return String(format: "%+.0f bpm vs your ~%.0f bpm baseline.", signal.delta, base)
+        case .overnightSpO2: return String(format: "%+.0f%% vs your ~%.0f%% baseline.", signal.delta, base)
+        case .overnightHRV: return String(format: "%+.0f ms vs your ~%.0f ms baseline.", signal.delta, base)
+        case .none: return "Outside your usual range."
+        }
+    }
+}

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -21,15 +21,14 @@ struct VitalsTableView: View {
     /// Temperature samples over the last few days — narrowed in memory to the precise night
     /// window for the overnight average (the exact window depends on async @State).
     @Query private var recentTemp: [StoredSample]
-    /// Latest persisted sleep summary (capped at 1) — the offline fallback for `sleep`.
+    /// Latest persisted sleep summary (capped at 1). The sleep BREAKDOWN now lives in the
+    /// dedicated SleepCardView; this query is retained only to bound the skin-temp night window
+    /// (`nightWindow`) to the most recent night's actual onset/wake span.
     @Query private var storedSleep: [StoredSleepSummary]
     /// Latest persisted daily rollup (capped at 1) — the offline fallback for live steps.
     @Query private var storedDaily: [StoredDaily]
     /// Live session (optional) — its readings override stored ones while connected.
     var session: RingSession?
-    /// LIVE sleep summary for the most recent night (total asleep + estimated stage
-    /// breakdown). When nil (no live session), `effectiveSleep` falls back to the store.
-    var sleep: SleepStaging.Summary?
 
     /// The user's sleep window (from the manual schedule, or the iOS Sleep schedule once
     /// HealthKit is authorized) — the preferred bound for the night-temp window. Resolved
@@ -45,9 +44,8 @@ struct VitalsTableView: View {
     /// versus all history.
     private static let tempWindowDays: TimeInterval = 3
 
-    init(session: RingSession? = nil, sleep: SleepStaging.Summary? = nil) {
+    init(session: RingSession? = nil) {
         self.session = session
-        self.sleep = sleep
 
         // Anchor the time windows to the start of the current hour so the @Query descriptors stay
         // stable across rapid SwiftUI re-renders (only re-fetching hourly or when data changes),
@@ -91,13 +89,6 @@ struct VitalsTableView: View {
             sortBy: [SortDescriptor(\.start, order: .reverse)])
         d.fetchLimit = 1
         return d
-    }
-
-    /// Prefer the live session summary; fall back to the latest stored night offline.
-    private var effectiveSleep: SleepStaging.Summary? {
-        if let sleep { return sleep }
-        guard let s = storedSleep.first, s.asleepMin > 0 else { return nil }
-        return s.asSummary
     }
 
     /// Prefer the ring's live onboard count; fall back to the stored count ONLY if it's
@@ -164,21 +155,6 @@ struct VitalsTableView: View {
         return lows.min().map { Int($0) }
     }
 
-    // MARK: First-run empty-state (#58)
-
-    /// True once at least one genuinely sleep-derived sample has been persisted (HRV, RR, or a
-    /// stored sleep summary). Resting HR is deliberately EXCLUDED: it's the min of ANY heart-rate
-    /// sample in the last 24 h, and an on-demand "Measure HR" tap persists a `.heartRate` sample on
-    /// disconnect (RingSession.swift) — so a single daytime reading would otherwise flip this true
-    /// before any overnight sync, suppressing `overnightSyncHint` and reverting the Sleep row to a
-    /// bare "—" WHILE HRV/RR still show "after overnight sync" (a contradictory first-run UI). The
-    /// four overnight rows (HRV, Resting HR, Respiratory Rate, Sleep) reflect this data; when false
-    /// they show the first-run empty state rather than reading as genuinely missing today's value.
-    /// (#58)
-    private var hasSleepVitals: Bool {
-        latestReading(.hrvSDNN) != nil || latestReading(.respiratoryRate) != nil || storedSleep.first != nil
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             measurableRow("Heart Rate", value: hrText, mode: .hr, active: hrActive,
@@ -192,7 +168,7 @@ struct VitalsTableView: View {
             divider
             // Sleep-derived rows: caption "after overnight sync" on each bare "—" row so the
             // user understands WHY they're empty, rather than seeing a bare dash with no context.
-            // The overnightSyncHint in the sleep section below gives the full explanation. (#58)
+            // The full explanation lives in the dedicated Sleep card's empty state below. (#58)
             row("HRV", value: valueText(.hrvSDNN) { "\(Int($0)) ms" },
                 time: nightlyWhen(.hrvSDNN) ?? "after overnight sync")
             divider
@@ -203,8 +179,6 @@ struct VitalsTableView: View {
             divider
             row("Respiratory Rate", value: valueText(.respiratoryRate) { String(format: "%.1f /min", $0) },
                 time: nightlyWhen(.respiratoryRate) ?? "after overnight sync")
-            divider
-            sleepSection
         }
         .padding(.vertical, 4)
         // Resolve the (async) sleep-schedule window once the view appears. The selector
@@ -212,54 +186,6 @@ struct VitalsTableView: View {
         .task(id: "\(sleepEnabled)-\(bedMinutes)-\(wakeMinutes)") {
             scheduleWindow = await SleepSchedule.current(forNightEndingNear: Date())
         }
-    }
-
-    /// Sleep: total asleep + estimated Deep/Light/REM/Awake breakdown (stages are an
-    /// on-device estimate — the ring doesn't send stage labels).
-    @ViewBuilder private var sleepSection: some View {
-        if let s = effectiveSleep, s.minutes.asleep > 0 {
-            VStack(alignment: .leading, spacing: 3) {
-                HStack {
-                    Text("Sleep").font(.subheadline)
-                    Spacer()
-                    Text("\(s.minutes.asleep / 60)h \(s.minutes.asleep % 60)m")
-                        .font(.subheadline.weight(.semibold)).monospacedDigit()
-                }
-                Text("Deep \(s.minutes.deep)m · Light \(s.minutes.light)m · REM \(s.minutes.rem)m · Awake \(s.minutes.awake)m")
-                    .font(.caption2).foregroundStyle(.secondary)
-                Text("est.\(sleepWhen.map { " · \($0)" } ?? "") · \(Int((s.efficiency * 100).rounded()))% efficiency")
-                    .font(.caption2).foregroundStyle(.tertiary)
-            }
-            .padding(.vertical, 8)
-        } else if hasSleepVitals {
-            // Syncs have run but no sleep detected for the most recent night.
-            row("Sleep", value: "—", time: nil)
-        } else {
-            // No overnight sync has completed yet — show an informative empty state that groups
-            // the explanation for all four sleep-derived rows. Distinct from `activationHint`
-            // (orange warning, connection-level) — this is informational, data-level. (#58)
-            overnightSyncHint
-        }
-    }
-
-    /// Empty-state shown in the sleep section when no overnight sync has completed. Groups the
-    /// explanation for HRV, Resting HR, Respiratory Rate, and Sleep in one place so the user
-    /// sees a clear message rather than four bare "—" rows with no context. (#58)
-    @ViewBuilder private var overnightSyncHint: some View {
-        HStack(alignment: .top, spacing: 10) {
-            Image(systemName: "moon.zzz")
-                .font(.subheadline)
-                .foregroundStyle(.indigo)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("HRV · Resting HR · Respiratory Rate · Sleep")
-                    .font(.subheadline.weight(.medium))
-                Text("Available after your first overnight sync. Wear the ring to bed and connect in the morning.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 8)
     }
 
     /// SpO₂ row with estimate caveat: live SpO₂ is a single-window measurement (🟡),
@@ -457,14 +383,6 @@ struct VitalsTableView: View {
         let today = Calendar.current.startOfDay(for: Date())
         guard let d = storedDaily.first, d.day == today, d.steps > 0 else { return nil }
         return Self.rel.localizedString(for: d.updatedAt, relativeTo: Date())
-    }
-
-    /// For a STORED (not live) sleep summary, the night it covers, so a days-old summary
-    /// isn't shown as if it were last night. nil when the value is live.
-    private var sleepWhen: String? {
-        guard sleep == nil, let s = storedSleep.first else { return nil }
-        let f = DateFormatter(); f.dateFormat = "MMM d"
-        return f.string(from: s.night)
     }
 
     private func tempString(_ celsius: Double) -> String {

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -13,7 +13,7 @@ struct VitalsTableView: View {
     /// Latest stored sample per displayed kind (newest first, capped at 1 each).
     @Query private var latestHR: [StoredSample]
     @Query private var latestSpO2: [StoredSample]
-    @Query private var latestTemp: [StoredSample]
+    @Query private var latestTempSample: [StoredSample]
     @Query private var latestHRV: [StoredSample]
     @Query private var latestRR: [StoredSample]
     /// Heart-rate samples over the last 24 h — the window resting HR (the sleep low) scans.
@@ -64,7 +64,7 @@ struct VitalsTableView: View {
 
         _latestHR = Query(Self.latestDescriptor(hr))
         _latestSpO2 = Query(Self.latestDescriptor(spo2))
-        _latestTemp = Query(Self.latestDescriptor(temp))
+        _latestTempSample = Query(Self.latestDescriptor(temp))
         _latestHRV = Query(Self.latestDescriptor(hrv))
         _latestRR = Query(Self.latestDescriptor(rr))
         _recentHR = Query(FetchDescriptor<StoredSample>(
@@ -115,7 +115,7 @@ struct VitalsTableView: View {
         var out: [MetricKind: StoredSample] = [:]
         out[.heartRate] = latestHR.first
         out[.spo2] = latestSpO2.first
-        out[.temperature] = latestTemp.first
+        out[.temperature] = latestTempSample.first
         out[.hrvSDNN] = latestHRV.first
         out[.respiratoryRate] = latestRR.first
         return out

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -135,17 +135,18 @@ struct VitalsTableView: View {
         if let s = session?.liveSpO2 { return "\(s) %" }
         return valueText(.spo2) { "\(Int(($0 * 100).rounded())) %" }
     }
-    // MARK: Skin temp (overnight headline; daytime live value is noisy, shown only as "now")
+    // MARK: Skin temp (headline = latest reading; overnight average shown as context)
 
-    /// Skin Temp row. The headline is the OVERNIGHT average (skin temp is noisy during the
-    /// day from ambient/activity), never the live daytime value. When connected we still
-    /// show the live reading as a small secondary line, clearly labeled "now".
+    /// Skin Temp row. The headline always shows the LATEST reading — the live value when
+    /// connected, else the most recent stored sample. The ring only polls skin temp overnight
+    /// (unless it sends one unsolicited), so the latest reading is normally last night's, which
+    /// is what we want on top during the day. The overnight average rides the secondary caption.
     private var skinTempRow: some View {
         HStack {
             Text("Skin Temp").font(.subheadline).foregroundStyle(.primary)
             Spacer()
             VStack(alignment: .trailing, spacing: 1) {
-                Text(nightTemp.map(tempString) ?? "—")
+                Text(latestTemp.map(tempString) ?? "—")
                     .font(.subheadline.weight(.semibold)).monospacedDigit()
                 if let secondary = skinTempSecondary {
                     Text(secondary).font(.caption2).foregroundStyle(.secondary)
@@ -155,20 +156,30 @@ struct VitalsTableView: View {
         .padding(.vertical, 8)
     }
 
-    /// Secondary caption under the Skin Temp headline: "overnight" when we have a night
-    /// average, plus the live value as "now …" when actively connected.
+    /// Latest skin-temp reading for the headline: the live value when connected, else the most
+    /// recent stored sample (ignoring zero/invalid placeholders), or nil if we have none.
+    private var latestTemp: Double? {
+        if let live = session?.liveTemperature { return live }
+        return latest[.temperature].map(\.value).flatMap { $0 > 0 ? $0 : nil }
+    }
+
+    /// Secondary caption under the Skin Temp headline: how fresh the headline reading is
+    /// ("live" when connected, else relative time) and the overnight average for context.
     private var skinTempSecondary: String? {
-        let now = session?.liveTemperature.map { "now \(tempString($0))" }
-        switch (nightTemp != nil, now) {
-        case (true, let now?):  return "overnight · \(now)"
-        case (true, nil):       return "overnight"
-        case (false, let now?): return now
-        case (false, nil):      return nil
+        var parts: [String] = []
+        if session?.liveTemperature != nil {
+            parts.append("live")
+        } else if latestTemp != nil, let s = latest[.temperature] {
+            parts.append(Self.rel.localizedString(for: s.start, relativeTo: Date()))
         }
+        if let night = nightTemp {
+            parts.append("overnight \(tempString(night))")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 
     /// Average skin temp (°C) over the most recent NIGHT window, or nil if that window has
-    /// no temperature samples (then the headline shows "—", never the noisy daytime value).
+    /// no temperature samples (then the secondary caption simply omits the overnight figure).
     /// Window: the latest stored sleep summary's span (night..night+inBed) when available,
     /// else local 00:00–06:00 of the most recent date that has temperature samples.
     private var nightTemp: Double? {

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -7,10 +7,27 @@ import OpenRingKit
 struct VitalsTableView: View {
     /// Most-recent samples first; we reduce to the latest per kind in `latest`.
     @Query(sort: \StoredSample.start, order: .reverse) private var samples: [StoredSample]
+    /// Persisted sleep summaries (latest night first) — the offline fallback for `sleep`.
+    @Query(sort: \StoredSleepSummary.night, order: .reverse) private var storedSleep: [StoredSleepSummary]
+    /// Persisted daily rollups (latest day first) — the offline fallback for live steps.
+    @Query(sort: \StoredDaily.day, order: .reverse) private var storedDaily: [StoredDaily]
     /// Live session (optional) — its readings override stored ones while connected.
     var session: RingSession?
-    /// Sleep summary for the most recent night (total asleep + estimated stage breakdown).
+    /// LIVE sleep summary for the most recent night (total asleep + estimated stage
+    /// breakdown). When nil (no live session), `effectiveSleep` falls back to the store.
     var sleep: SleepStaging.Summary?
+
+    /// Prefer the live session summary; fall back to the latest stored night offline.
+    private var effectiveSleep: SleepStaging.Summary? {
+        if let sleep { return sleep }
+        guard let s = storedSleep.first, s.asleepMin > 0 else { return nil }
+        return s.asSummary
+    }
+
+    /// Prefer the ring's live onboard count; fall back to today's stored count offline.
+    private var effectiveSteps: Int? {
+        session?.steps ?? storedDaily.first?.steps
+    }
 
     private var latest: [MetricKind: StoredSample] {
         var out: [MetricKind: StoredSample] = [:]
@@ -42,7 +59,7 @@ struct VitalsTableView: View {
             divider
             row("Resting HR", value: restingHR.map { "\($0) bpm" } ?? "—", time: nil)
             divider
-            row("Steps (today)", value: stepsText, time: session?.steps != nil ? "live" : nil)
+            row("Steps (today)", value: stepsText, time: stepsTime)
             divider
             row("Respiratory Rate", value: "— (todo)", time: nil)
             divider
@@ -54,7 +71,7 @@ struct VitalsTableView: View {
     /// Sleep: total asleep + estimated Deep/Light/REM/Awake breakdown (stages are an
     /// on-device estimate — the ring doesn't send stage labels).
     @ViewBuilder private var sleepSection: some View {
-        if let s = sleep, s.minutes.asleep > 0 {
+        if let s = effectiveSleep, s.minutes.asleep > 0 {
             VStack(alignment: .leading, spacing: 3) {
                 HStack {
                     Text("Sleep").font(.subheadline)
@@ -106,8 +123,14 @@ struct VitalsTableView: View {
     /// Ring's onboard step count — live while connected (the descriptor streams it). It's
     /// the ring's own count, which can differ from the official app's cloud daily total.
     private var stepsText: String {
-        guard let s = session?.steps else { return "—" }
+        guard let s = effectiveSteps else { return "—" }
         return "\(s)"
+    }
+    /// "live" while connected; else the relative time of the stored day's last update.
+    private var stepsTime: String? {
+        if session?.steps != nil { return "live" }
+        guard let d = storedDaily.first, d.steps > 0 else { return nil }
+        return Self.rel.localizedString(for: d.updatedAt, relativeTo: Date())
     }
 
     private func tempString(_ celsius: Double) -> String {

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -239,7 +239,9 @@ struct VitalsTableView: View {
                     .symbolEffect(.pulse, isActive: active)
             }
             .buttonStyle(.plain)
-            .disabled(session?.syncing == true)
+            // Disable while a sync holds the link, OR when the ring isn't streaming (#54) — a
+            // measure would only spin until timeout; the activation hint tells the user what to do.
+            .disabled(session?.syncing == true || session?.notStreaming == true)
         }
     }
 

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -24,9 +24,12 @@ struct VitalsTableView: View {
         return s.asSummary
     }
 
-    /// Prefer the ring's live onboard count; fall back to today's stored count offline.
+    /// Prefer the ring's live onboard count; fall back to the stored count ONLY if it's
+    /// today's (the row is labeled "today", so a prior day's total must not appear).
     private var effectiveSteps: Int? {
-        session?.steps ?? storedDaily.first?.steps
+        if let s = session?.steps { return s }
+        let today = Calendar.current.startOfDay(for: Date())
+        return storedDaily.first.flatMap { $0.day == today ? $0.steps : nil }
     }
 
     private var latest: [MetricKind: StoredSample] {
@@ -81,7 +84,7 @@ struct VitalsTableView: View {
                 }
                 Text("Deep \(s.minutes.deep)m · Light \(s.minutes.light)m · REM \(s.minutes.rem)m · Awake \(s.minutes.awake)m")
                     .font(.caption2).foregroundStyle(.secondary)
-                Text("est. · \(Int((s.efficiency * 100).rounded()))% efficiency")
+                Text("est.\(sleepWhen.map { " · \($0)" } ?? "") · \(Int((s.efficiency * 100).rounded()))% efficiency")
                     .font(.caption2).foregroundStyle(.tertiary)
             }
             .padding(.vertical, 8)
@@ -126,11 +129,21 @@ struct VitalsTableView: View {
         guard let s = effectiveSteps else { return "—" }
         return "\(s)"
     }
-    /// "live" while connected; else the relative time of the stored day's last update.
+    /// "live" while connected; else the relative time of today's stored count (nil if the
+    /// only stored count is from a prior day — `effectiveSteps` shows "—" then).
     private var stepsTime: String? {
         if session?.steps != nil { return "live" }
-        guard let d = storedDaily.first, d.steps > 0 else { return nil }
+        let today = Calendar.current.startOfDay(for: Date())
+        guard let d = storedDaily.first, d.day == today, d.steps > 0 else { return nil }
         return Self.rel.localizedString(for: d.updatedAt, relativeTo: Date())
+    }
+
+    /// For a STORED (not live) sleep summary, the night it covers, so a days-old summary
+    /// isn't shown as if it were last night. nil when the value is live.
+    private var sleepWhen: String? {
+        guard sleep == nil, let s = storedSleep.first else { return nil }
+        let f = DateFormatter(); f.dateFormat = "MMM d"
+        return f.string(from: s.night)
     }
 
     private func tempString(_ celsius: Double) -> String {

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -64,7 +64,8 @@ struct VitalsTableView: View {
             divider
             row("Steps (today)", value: stepsText, time: stepsTime)
             divider
-            row("Respiratory Rate", value: "— (todo)", time: nil)
+            row("Respiratory Rate", value: valueText(.respiratoryRate) { String(format: "%.1f /min", $0) },
+                time: timeFor(.respiratoryRate))
             divider
             sleepSection
         }

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import SwiftData
+import OpenRingKit
+
+/// Persistent vitals dashboard. Reads the latest stored sample per metric (so values
+/// are always visible offline) and prefers the live session reading when connected.
+struct VitalsTableView: View {
+    /// Most-recent samples first; we reduce to the latest per kind in `latest`.
+    @Query(sort: \StoredSample.start, order: .reverse) private var samples: [StoredSample]
+    /// Live session (optional) — its readings override stored ones while connected.
+    var session: RingSession?
+    /// Total sleep for the most recent night, minutes (from the last sync's segments).
+    var sleepMinutes: Int?
+
+    private var latest: [MetricKind: StoredSample] {
+        var out: [MetricKind: StoredSample] = [:]
+        for s in samples {
+            guard let k = MetricKind(rawValue: s.kindRaw), out[k] == nil else { continue }
+            out[k] = s
+        }
+        return out
+    }
+
+    /// Resting HR ≈ the lowest HR over the last 24 h (sleep low), derived from stored HR.
+    private var restingHR: Int? {
+        let dayAgo = Date().addingTimeInterval(-86_400)
+        let hrs = samples
+            .filter { $0.kindRaw == MetricKind.heartRate.rawValue && $0.start > dayAgo && $0.value > 0 }
+            .map { $0.value }
+        return hrs.min().map { Int($0) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            row("Heart Rate", value: hrText, time: timeFor(.heartRate, live: session?.liveHR != nil))
+            divider
+            row("SpO₂", value: spo2Text, time: timeFor(.spo2, live: session?.liveSpO2 != nil))
+            divider
+            row("Skin Temp", value: tempText, time: timeFor(.temperature, live: session?.liveTemperature != nil))
+            divider
+            row("HRV", value: valueText(.hrvSDNN) { "\(Int($0)) ms" }, time: timeFor(.hrvSDNN))
+            divider
+            row("Resting HR", value: restingHR.map { "\($0) bpm" } ?? "—", time: nil)
+            divider
+            row("Respiratory Rate", value: "— (todo)", time: nil)
+            divider
+            row("Sleep", value: sleepText, time: nil)
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: rows
+
+    private func row(_ label: String, value: String, time: String?) -> some View {
+        HStack {
+            Text(label).font(.subheadline).foregroundStyle(.primary)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(value).font(.subheadline.weight(.semibold)).monospacedDigit()
+                if let time { Text(time).font(.caption2).foregroundStyle(.secondary) }
+            }
+        }
+        .padding(.vertical, 8)
+    }
+
+    private var divider: some View { Divider().opacity(0.4) }
+
+    // MARK: value formatting (live overrides stored)
+
+    private var hrText: String {
+        if let hr = session?.liveHR { return "\(hr) bpm" }
+        return valueText(.heartRate) { "\(Int($0)) bpm" }
+    }
+    private var spo2Text: String {
+        if let s = session?.liveSpO2 { return "\(s) %" }
+        return valueText(.spo2) { "\(Int(($0 * 100).rounded())) %" }
+    }
+    private var tempText: String {
+        if let c = session?.liveTemperature { return tempString(c) }
+        return valueText(.temperature) { tempString($0) }
+    }
+    private var sleepText: String {
+        guard let m = sleepMinutes, m > 0 else { return "—" }
+        return "\(m / 60)h \(m % 60)m"
+    }
+
+    private func tempString(_ celsius: Double) -> String {
+        String(format: "%.1f °C  (%.1f °F)", celsius, celsius * 9 / 5 + 32)
+    }
+
+    /// Latest stored value for `kind`, formatted, or "—" if none.
+    private func valueText(_ kind: MetricKind, _ fmt: (Double) -> String) -> String {
+        latest[kind].map { fmt($0.value) } ?? "—"
+    }
+
+    private static let rel: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter(); f.unitsStyle = .abbreviated; return f
+    }()
+    private func timeFor(_ kind: MetricKind, live: Bool = false) -> String? {
+        if live { return "live" }
+        guard let s = latest[kind] else { return nil }
+        return Self.rel.localizedString(for: s.start, relativeTo: Date())
+    }
+}

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -127,6 +127,17 @@ struct VitalsTableView: View {
         recentHR.map(\.value).min().map { Int($0) }
     }
 
+    // MARK: First-run empty-state (#58)
+
+    /// True once at least one sleep-vitals sample has been persisted (HRV, RR, sleep summary,
+    /// or a resting-HR window). All four overnight rows (HRV, Resting HR, Respiratory Rate,
+    /// Sleep) depend on this data; when false the rows are in a first-run empty state rather
+    /// than genuinely missing today's reading. (#58)
+    private var hasSleepVitals: Bool {
+        latestHRV.first != nil || latestRR.first != nil
+            || storedSleep.first != nil || restingHR != nil
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             measurableRow("Heart Rate", value: hrText, mode: .hr, active: hrActive,
@@ -139,14 +150,19 @@ struct VitalsTableView: View {
             divider
             skinTempRow
             divider
-            row("HRV", value: valueText(.hrvSDNN) { "\(Int($0)) ms" }, time: nightlyWhen(.hrvSDNN))
+            // Sleep-derived rows: caption "after overnight sync" on each bare "—" row so the
+            // user understands WHY they're empty, rather than seeing a bare dash with no context.
+            // The overnightSyncHint in the sleep section below gives the full explanation. (#58)
+            row("HRV", value: valueText(.hrvSDNN) { "\(Int($0)) ms" },
+                time: latestHRV.isEmpty ? "after overnight sync" : nightlyWhen(.hrvSDNN))
             divider
-            row("Resting HR", value: restingHR.map { "\($0) bpm" } ?? "—", time: nil)
+            row("Resting HR", value: restingHR.map { "\($0) bpm" } ?? "—",
+                time: restingHR == nil ? "after overnight sync" : nil)
             divider
             row("Steps (today)", value: stepsText, time: stepsTime)
             divider
             row("Respiratory Rate", value: valueText(.respiratoryRate) { String(format: "%.1f /min", $0) },
-                time: nightlyWhen(.respiratoryRate))
+                time: latestRR.isEmpty ? "after overnight sync" : nightlyWhen(.respiratoryRate))
             divider
             sleepSection
         }
@@ -175,9 +191,35 @@ struct VitalsTableView: View {
                     .font(.caption2).foregroundStyle(.tertiary)
             }
             .padding(.vertical, 8)
-        } else {
+        } else if hasSleepVitals {
+            // Syncs have run but no sleep detected for the most recent night.
             row("Sleep", value: "—", time: nil)
+        } else {
+            // No overnight sync has completed yet — show an informative empty state that groups
+            // the explanation for all four sleep-derived rows. Distinct from `activationHint`
+            // (orange warning, connection-level) — this is informational, data-level. (#58)
+            overnightSyncHint
         }
+    }
+
+    /// Empty-state shown in the sleep section when no overnight sync has completed. Groups the
+    /// explanation for HRV, Resting HR, Respiratory Rate, and Sleep in one place so the user
+    /// sees a clear message rather than four bare "—" rows with no context. (#58)
+    @ViewBuilder private var overnightSyncHint: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "moon.zzz")
+                .font(.subheadline)
+                .foregroundStyle(.indigo)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("HRV · Resting HR · Respiratory Rate · Sleep")
+                    .font(.subheadline.weight(.medium))
+                Text("Available after your first overnight sync. Wear the ring to bed and connect in the morning.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 8)
     }
 
     // MARK: rows

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -74,9 +74,6 @@ struct VitalsTableView: View {
             divider
             row("Steps (today)", value: stepsText, time: stepsTime)
             divider
-            row("Battery", value: session?.batteryPercent.map { "\($0)%" } ?? "—",
-                time: session?.batteryPercent != nil ? "live" : nil)
-            divider
             row("Respiratory Rate", value: valueText(.respiratoryRate) { String(format: "%.1f /min", $0) },
                 time: timeFor(.respiratoryRate))
             divider

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -131,11 +131,11 @@ struct VitalsTableView: View {
         VStack(alignment: .leading, spacing: 0) {
             measurableRow("Heart Rate", value: hrText, mode: .hr, active: hrActive,
                           time: hrActive && session?.liveHR == nil
-                              ? "measuring…" : timeFor(.heartRate, live: session?.liveHR != nil))
+                              ? "measuring…" : timeFor(.heartRate, live: hrLive))
             divider
             measurableRow("SpO₂", value: spo2Text, mode: .spo2, active: spo2Active,
                           time: spo2Active && session?.liveSpO2 == nil
-                              ? "measuring…" : timeFor(.spo2, live: session?.liveSpO2 != nil))
+                              ? "measuring…" : timeFor(.spo2, live: spo2Live))
             divider
             skinTempRow
             divider
@@ -199,6 +199,11 @@ struct VitalsTableView: View {
     private var hrActive: Bool { session?.monitoring == true && session?.liveMode == .hr }
     private var spo2Active: Bool { session?.monitoring == true && session?.liveMode == .spo2 }
 
+    /// True when the link has gone quiet so a lingering live value must NOT read as "live" (#36).
+    /// A silently-dropped link keeps its last HR/SpO₂/steps/temp until CoreBluetooth fires
+    /// `didDisconnect`; staleness lets us show "Xm ago" instead of a minutes-old value as current.
+    private var liveStale: Bool { session?.liveReadingsStale == true }
+
     /// A vitals row carrying an inline start/stop measure control for an on-demand metric.
     private func measurableRow(_ label: String, value: String, mode: RingSession.LiveMode,
                                active: Bool, time: String?) -> some View {
@@ -242,12 +247,18 @@ struct VitalsTableView: View {
 
     // MARK: value formatting (live overrides stored)
 
+    /// HR/SpO₂ count as "live" only while we're actively measuring that metric AND frames are
+    /// still arriving. A leftover value after monitoring stops, or a silently-dropped link, falls
+    /// back to the stored sample's timestamp instead of a false "live" caption (#36).
+    private var hrLive: Bool { hrActive && session?.liveHR != nil && !liveStale }
+    private var spo2Live: Bool { spo2Active && session?.liveSpO2 != nil && !liveStale }
+
     private var hrText: String {
-        if let hr = session?.liveHR { return "\(hr) bpm" }
+        if hrLive, let hr = session?.liveHR { return "\(hr) bpm" }
         return valueText(.heartRate) { "\(Int($0)) bpm" }
     }
     private var spo2Text: String {
-        if let s = session?.liveSpO2 { return "\(s) %" }
+        if spo2Live, let s = session?.liveSpO2 { return "\(s) %" }
         return valueText(.spo2) { "\(Int(($0 * 100).rounded())) %" }
     }
     // MARK: Skin temp (headline = latest reading; overnight average shown as context)
@@ -282,7 +293,7 @@ struct VitalsTableView: View {
     /// ("live" when connected, else relative time) and the overnight average for context.
     private var skinTempSecondary: String? {
         var parts: [String] = []
-        if session?.liveTemperature != nil {
+        if session?.liveTemperature != nil, !liveStale {
             parts.append("live")
         } else if latestTemp != nil, let s = latest[.temperature] {
             parts.append(Self.rel.localizedString(for: s.start, relativeTo: Date()))
@@ -333,10 +344,11 @@ struct VitalsTableView: View {
         guard let s = effectiveSteps else { return "—" }
         return "\(s)"
     }
-    /// "live" while connected; else the relative time of today's stored count (nil if the
-    /// only stored count is from a prior day — `effectiveSteps` shows "—" then).
+    /// "live" while the descriptor is fresh; else the relative time of today's stored count (nil
+    /// if the only stored count is from a prior day — `effectiveSteps` shows "—" then). A quiet
+    /// link no longer reads as "live" (#36) — it shows when the count was last updated instead.
     private var stepsTime: String? {
-        if session?.steps != nil { return "live" }
+        if session?.steps != nil, !liveStale { return "live" }
         let today = Calendar.current.startOfDay(for: Date())
         guard let d = storedDaily.first, d.day == today, d.steps > 0 else { return nil }
         return Self.rel.localizedString(for: d.updatedAt, relativeTo: Date())

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -38,6 +38,8 @@ struct VitalsTableView: View {
     @AppStorage(SleepScheduleDefaults.enabled) private var sleepEnabled = false
     @AppStorage(SleepScheduleDefaults.bedMinutes) private var bedMinutes = SleepScheduleDefaults.defaultBedMinutes
     @AppStorage(SleepScheduleDefaults.wakeMinutes) private var wakeMinutes = SleepScheduleDefaults.defaultWakeMinutes
+    /// Temperature display unit (#83). Syncs with the Units section in UserProfileSettingsView.
+    @AppStorage("units.temperature") private var tempUnitRaw = TemperatureUnit.localeDefault.rawValue
 
     /// Days of temperature history the night-temp window query scans before the precise night
     /// window is applied in memory — generous enough to cover the most recent night, still tiny
@@ -385,8 +387,10 @@ struct VitalsTableView: View {
         return Self.rel.localizedString(for: d.updatedAt, relativeTo: Date())
     }
 
+    /// Format a Celsius value in the user's chosen unit (#83).
     private func tempString(_ celsius: Double) -> String {
-        String(format: "%.1f °F", celsius * 9 / 5 + 32)
+        let unit = TemperatureUnit(rawValue: tempUnitRaw) ?? .celsius
+        return UnitsFormatter.temperature(celsius, unit: unit)
     }
 
     /// Latest stored value for `kind`, formatted, or "—" if none.

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -5,6 +5,7 @@ import OpenRingKit
 /// Persistent vitals dashboard. Reads the latest stored sample per metric (so values
 /// are always visible offline) and prefers the live session reading when connected.
 struct VitalsTableView: View {
+    @Environment(\.modelContext) private var modelContext
     /// Most-recent samples first; we reduce to the latest per kind in `latest`.
     @Query(sort: \StoredSample.start, order: .reverse) private var samples: [StoredSample]
     /// Persisted sleep summaries (latest night first) — the offline fallback for `sleep`.
@@ -56,7 +57,7 @@ struct VitalsTableView: View {
             divider
             row("SpO₂", value: spo2Text, time: timeFor(.spo2, live: session?.liveSpO2 != nil))
             divider
-            row("Skin Temp", value: tempText, time: timeFor(.temperature, live: session?.liveTemperature != nil))
+            skinTempRow
             divider
             row("HRV", value: valueText(.hrvSDNN) { "\(Int($0)) ms" }, time: timeFor(.hrvSDNN))
             divider
@@ -120,9 +121,60 @@ struct VitalsTableView: View {
         if let s = session?.liveSpO2 { return "\(s) %" }
         return valueText(.spo2) { "\(Int(($0 * 100).rounded())) %" }
     }
-    private var tempText: String {
-        if let c = session?.liveTemperature { return tempString(c) }
-        return valueText(.temperature) { tempString($0) }
+    // MARK: Skin temp (overnight headline; daytime live value is noisy, shown only as "now")
+
+    /// Skin Temp row. The headline is the OVERNIGHT average (skin temp is noisy during the
+    /// day from ambient/activity), never the live daytime value. When connected we still
+    /// show the live reading as a small secondary line, clearly labeled "now".
+    private var skinTempRow: some View {
+        HStack {
+            Text("Skin Temp").font(.subheadline).foregroundStyle(.primary)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(nightTemp.map(tempString) ?? "—")
+                    .font(.subheadline.weight(.semibold)).monospacedDigit()
+                if let secondary = skinTempSecondary {
+                    Text(secondary).font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 8)
+    }
+
+    /// Secondary caption under the Skin Temp headline: "overnight" when we have a night
+    /// average, plus the live value as "now …" when actively connected.
+    private var skinTempSecondary: String? {
+        let now = session?.liveTemperature.map { "now \(tempString($0))" }
+        switch (nightTemp != nil, now) {
+        case (true, let now?):  return "overnight · \(now)"
+        case (true, nil):       return "overnight"
+        case (false, let now?): return now
+        case (false, nil):      return nil
+        }
+    }
+
+    /// Average skin temp (°C) over the most recent NIGHT window, or nil if that window has
+    /// no temperature samples (then the headline shows "—", never the noisy daytime value).
+    /// Window: the latest stored sleep summary's span (night..night+inBed) when available,
+    /// else local 00:00–06:00 of the most recent date that has temperature samples.
+    private var nightTemp: Double? {
+        guard let window = nightWindow,
+              let temps = try? LocalStore(modelContext)
+                  .samples(kind: .temperature, from: window.start, to: window.end) else { return nil }
+        let vals = temps.map(\.value).filter { $0 > 0 }
+        guard !vals.isEmpty else { return nil }
+        return vals.reduce(0, +) / Double(vals.count)
+    }
+
+    private var nightWindow: (start: Date, end: Date)? {
+        // Prefer the most recent night's actual sleep span.
+        if let s = storedSleep.first, s.asleepMin > 0 {
+            return (s.night, s.night.addingTimeInterval(s.asSummary.inBed))
+        }
+        // Fallback: 00:00–06:00 of the most recent date that has temperature samples.
+        guard let lastTemp = latest[.temperature]?.start else { return nil }
+        let dayStart = Calendar.current.startOfDay(for: lastTemp)
+        return (dayStart, dayStart.addingTimeInterval(6 * 3600))
     }
     /// Ring's onboard step count — live while connected (the descriptor streams it). It's
     /// the ring's own count, which can differ from the official app's cloud daily total.

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -131,11 +131,13 @@ struct VitalsTableView: View {
         VStack(alignment: .leading, spacing: 0) {
             measurableRow("Heart Rate", value: hrText, mode: .hr, active: hrActive,
                           time: hrActive && session?.liveHR == nil
-                              ? "measuring…" : timeFor(.heartRate, live: hrLive))
+                              ? (session?.livePreparing == true ? "preparing…" : "measuring…")
+                              : timeFor(.heartRate, live: hrLive))
             divider
             measurableRow("SpO₂", value: spo2Text, mode: .spo2, active: spo2Active,
                           time: spo2Active && session?.liveSpO2 == nil
-                              ? "measuring…" : timeFor(.spo2, live: spo2Live))
+                              ? (session?.livePreparing == true ? "preparing…" : "measuring…")
+                              : timeFor(.spo2, live: spo2Live))
             divider
             skinTempRow
             divider

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -9,8 +9,8 @@ struct VitalsTableView: View {
     @Query(sort: \StoredSample.start, order: .reverse) private var samples: [StoredSample]
     /// Live session (optional) — its readings override stored ones while connected.
     var session: RingSession?
-    /// Total sleep for the most recent night, minutes (from the last sync's segments).
-    var sleepMinutes: Int?
+    /// Sleep summary for the most recent night (total asleep + estimated stage breakdown).
+    var sleep: SleepStaging.Summary?
 
     private var latest: [MetricKind: StoredSample] {
         var out: [MetricKind: StoredSample] = [:]
@@ -44,9 +44,31 @@ struct VitalsTableView: View {
             divider
             row("Respiratory Rate", value: "— (todo)", time: nil)
             divider
-            row("Sleep", value: sleepText, time: nil)
+            sleepSection
         }
         .padding(.vertical, 4)
+    }
+
+    /// Sleep: total asleep + estimated Deep/Light/REM/Awake breakdown (stages are an
+    /// on-device estimate — the ring doesn't send stage labels).
+    @ViewBuilder private var sleepSection: some View {
+        if let s = sleep, s.minutes.asleep > 0 {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text("Sleep").font(.subheadline)
+                    Spacer()
+                    Text("\(s.minutes.asleep / 60)h \(s.minutes.asleep % 60)m")
+                        .font(.subheadline.weight(.semibold)).monospacedDigit()
+                }
+                Text("Deep \(s.minutes.deep)m · Light \(s.minutes.light)m · REM \(s.minutes.rem)m · Awake \(s.minutes.awake)m")
+                    .font(.caption2).foregroundStyle(.secondary)
+                Text("est. · \(Int((s.efficiency * 100).rounded()))% efficiency")
+                    .font(.caption2).foregroundStyle(.tertiary)
+            }
+            .padding(.vertical, 8)
+        } else {
+            row("Sleep", value: "—", time: nil)
+        }
     }
 
     // MARK: rows
@@ -79,11 +101,6 @@ struct VitalsTableView: View {
         if let c = session?.liveTemperature { return tempString(c) }
         return valueText(.temperature) { tempString($0) }
     }
-    private var sleepText: String {
-        guard let m = sleepMinutes, m > 0 else { return "—" }
-        return "\(m / 60)h \(m % 60)m"
-    }
-
     private func tempString(_ celsius: Double) -> String {
         String(format: "%.1f °C  (%.1f °F)", celsius, celsius * 9 / 5 + 32)
     }

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -121,10 +121,47 @@ struct VitalsTableView: View {
         return out
     }
 
-    /// Resting HR ≈ the lowest HR over the last 24 h (sleep low). `recentHR` is already the
-    /// bounded 24 h, value-positive HR window, so this is just its min. (#32)
+    /// Newest reading per kind from the JUST-SYNCED in-memory batch (`session.historySamples`),
+    /// independent of the store. The sync drain always refreshes this, and it lives on the
+    /// @Observable session so a completed sync re-renders the dashboard immediately — even when
+    /// the cursor dedup (SyncCursor) keeps those overlapping/last-night epochs out of the store
+    /// and the @Query therefore never changes. Without this, the sync card showed HR/HRV/SpO₂ the
+    /// Vitals rows didn't, until a manual (now-timestamped) reading forced a refresh. (#67)
+    private var latestSynced: [MetricKind: (value: Double, start: Date)] {
+        guard let samples = session?.historySamples, !samples.isEmpty else { return [:] }
+        var out: [MetricKind: (value: Double, start: Date)] = [:]
+        for s in samples where s.value > 0 {
+            if let cur = out[s.kind], cur.start >= s.start { continue }
+            out[s.kind] = (s.value, s.start)
+        }
+        return out
+    }
+
+    /// The reading to DISPLAY for a kind: whichever is more recent between the persisted store
+    /// sample and the just-synced in-memory batch (#67). After disconnect `latestSynced` is empty
+    /// so this falls back to the store. Only ever returns a real decoded reading.
+    private func latestReading(_ kind: MetricKind) -> (value: Double, start: Date)? {
+        let stored = latest[kind].map { (value: $0.value, start: $0.start) }
+        switch (stored, latestSynced[kind]) {
+        case let (s?, h?): return h.start > s.start ? h : s
+        case let (s?, nil): return s
+        case let (nil, h?): return h
+        case (nil, nil): return nil
+        }
+    }
+
+    /// Resting HR ≈ the lowest HR over the last 24 h (sleep low). `recentHR` is the bounded 24 h,
+    /// value-positive HR window from the store; the just-synced batch is folded in too so a fresh
+    /// sync lowers it immediately rather than waiting for a manual reading. (#32, #67)
     private var restingHR: Int? {
-        recentHR.map(\.value).min().map { Int($0) }
+        let dayAgo = Date().addingTimeInterval(-86_400)
+        var lows = recentHR.map(\.value)
+        if let samples = session?.historySamples {
+            lows += samples
+                .filter { $0.kind == .heartRate && $0.value > 0 && $0.start > dayAgo }
+                .map(\.value)
+        }
+        return lows.min().map { Int($0) }
     }
 
     // MARK: First-run empty-state (#58)
@@ -139,7 +176,7 @@ struct VitalsTableView: View {
     /// they show the first-run empty state rather than reading as genuinely missing today's value.
     /// (#58)
     private var hasSleepVitals: Bool {
-        latestHRV.first != nil || latestRR.first != nil || storedSleep.first != nil
+        latestReading(.hrvSDNN) != nil || latestReading(.respiratoryRate) != nil || storedSleep.first != nil
     }
 
     var body: some View {
@@ -157,7 +194,7 @@ struct VitalsTableView: View {
             // user understands WHY they're empty, rather than seeing a bare dash with no context.
             // The overnightSyncHint in the sleep section below gives the full explanation. (#58)
             row("HRV", value: valueText(.hrvSDNN) { "\(Int($0)) ms" },
-                time: latestHRV.isEmpty ? "after overnight sync" : nightlyWhen(.hrvSDNN))
+                time: nightlyWhen(.hrvSDNN) ?? "after overnight sync")
             divider
             row("Resting HR", value: restingHR.map { "\($0) bpm" } ?? "—",
                 time: restingHR == nil ? "after overnight sync" : nil)
@@ -165,7 +202,7 @@ struct VitalsTableView: View {
             row("Steps (today)", value: stepsText, time: stepsTime)
             divider
             row("Respiratory Rate", value: valueText(.respiratoryRate) { String(format: "%.1f /min", $0) },
-                time: latestRR.isEmpty ? "after overnight sync" : nightlyWhen(.respiratoryRate))
+                time: nightlyWhen(.respiratoryRate) ?? "after overnight sync")
             divider
             sleepSection
         }
@@ -436,7 +473,7 @@ struct VitalsTableView: View {
 
     /// Latest stored value for `kind`, formatted, or "—" if none.
     private func valueText(_ kind: MetricKind, _ fmt: (Double) -> String) -> String {
-        latest[kind].map { fmt($0.value) } ?? "—"
+        latestReading(kind).map { fmt($0.value) } ?? "—"
     }
 
     private static let rel: RelativeDateTimeFormatter = {
@@ -444,8 +481,8 @@ struct VitalsTableView: View {
     }()
     private func timeFor(_ kind: MetricKind, live: Bool = false) -> String? {
         if live { return "live" }
-        guard let s = latest[kind] else { return nil }
-        return Self.rel.localizedString(for: s.start, relativeTo: Date())
+        guard let r = latestReading(kind) else { return nil }
+        return Self.rel.localizedString(for: r.start, relativeTo: Date())
     }
 
     private static let nightlyDate: DateFormatter = {
@@ -455,15 +492,15 @@ struct VitalsTableView: View {
     /// these from sleep, so a relative "5h ago" misreads as a stale live value. Show which
     /// night it's from instead: "last night" for this morning's sleep, else the date.
     private func nightlyWhen(_ kind: MetricKind) -> String? {
-        guard let s = latest[kind] else { return nil }
+        guard let r = latestReading(kind) else { return nil }
         let cal = Calendar.current
-        let days = cal.dateComponents([.day], from: cal.startOfDay(for: s.start),
+        let days = cal.dateComponents([.day], from: cal.startOfDay(for: r.start),
                                       to: cal.startOfDay(for: Date())).day ?? 0
         switch days {
         case ..<0: return nil            // future timestamp (shouldn't happen) — omit
         case 0: return "last night"
         case 1: return "yesterday"
-        default: return Self.nightlyDate.string(from: s.start)
+        default: return Self.nightlyDate.string(from: r.start)
         }
     }
 }

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -42,6 +42,8 @@ struct VitalsTableView: View {
             divider
             row("Resting HR", value: restingHR.map { "\($0) bpm" } ?? "—", time: nil)
             divider
+            row("Steps (today)", value: stepsText, time: session?.steps != nil ? "live" : nil)
+            divider
             row("Respiratory Rate", value: "— (todo)", time: nil)
             divider
             sleepSection
@@ -101,6 +103,13 @@ struct VitalsTableView: View {
         if let c = session?.liveTemperature { return tempString(c) }
         return valueText(.temperature) { tempString($0) }
     }
+    /// Ring's onboard step count — live while connected (the descriptor streams it). It's
+    /// the ring's own count, which can differ from the official app's cloud daily total.
+    private var stepsText: String {
+        guard let s = session?.steps else { return "—" }
+        return "\(s)"
+    }
+
     private func tempString(_ celsius: Double) -> String {
         String(format: "%.1f °C  (%.1f °F)", celsius, celsius * 9 / 5 + 32)
     }

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -158,18 +158,25 @@ struct VitalsTableView: View {
     /// Window: the latest stored sleep summary's span (night..night+inBed) when available,
     /// else local 00:00–06:00 of the most recent date that has temperature samples.
     private var nightTemp: Double? {
-        guard let window = nightWindow,
-              let temps = try? LocalStore(modelContext)
-                  .samples(kind: .temperature, from: window.start, to: window.end) else { return nil }
-        let vals = temps.map(\.value).filter { $0 > 0 }
-        guard !vals.isEmpty else { return nil }
-        return vals.reduce(0, +) / Double(vals.count)
+        guard let window = nightWindow else { return nil }
+        // Filter the already-loaded @Query array in memory — no synchronous fetch in `body`
+        // (that hazard once caused a black-screen launch). #14
+        let tempKind = MetricKind.temperature.rawValue
+        let vals = samples.lazy
+            .filter { $0.kindRaw == tempKind && $0.value > 0
+                      && $0.start >= window.start && $0.start <= window.end }
+            .map(\.value)
+        var sum = 0.0, n = 0
+        for v in vals { sum += v; n += 1 }
+        return n > 0 ? sum / Double(n) : nil
     }
 
     private var nightWindow: (start: Date, end: Date)? {
-        // Prefer the most recent night's actual sleep span.
-        if let s = storedSleep.first, s.asleepMin > 0 {
-            return (s.night, s.night.addingTimeInterval(s.asSummary.inBed))
+        // Prefer the most recent night's ACTUAL sleep span (real onset/wake clock times),
+        // not a midnight-anchored guess — so pre-midnight sleep aligns correctly.
+        if let s = storedSleep.first, s.asleepMin > 0,
+           s.inBedStart > Date.distantPast, s.inBedEnd > s.inBedStart {
+            return (s.inBedStart, s.inBedEnd)
         }
         // Fallback: 00:00–06:00 of the most recent date that has temperature samples.
         guard let lastTemp = latest[.temperature]?.start else { return nil }

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -18,6 +18,11 @@ struct VitalsTableView: View {
     /// breakdown). When nil (no live session), `effectiveSleep` falls back to the store.
     var sleep: SleepStaging.Summary?
 
+    /// The user's sleep window (from the manual schedule, or the iOS Sleep schedule once
+    /// HealthKit is authorized) — the preferred bound for the night-temp window. Resolved
+    /// asynchronously into @State (see `.task`), never fetched synchronously in `body`.
+    @State private var scheduleWindow: DateInterval?
+
     /// Prefer the live session summary; fall back to the latest stored night offline.
     private var effectiveSleep: SleepStaging.Summary? {
         if let sleep { return sleep }
@@ -71,6 +76,9 @@ struct VitalsTableView: View {
             sleepSection
         }
         .padding(.vertical, 4)
+        // Resolve the (async) sleep-schedule window once the view appears. The selector
+        // returns the HealthKit window when authorized, else the manual one, else nil.
+        .task { scheduleWindow = await SleepSchedule.current(forNightEndingNear: Date()) }
     }
 
     /// Sleep: total asleep + estimated Deep/Light/REM/Awake breakdown (stages are an
@@ -172,7 +180,10 @@ struct VitalsTableView: View {
     }
 
     private var nightWindow: (start: Date, end: Date)? {
-        // Prefer the most recent night's ACTUAL sleep span (real onset/wake clock times),
+        // Prefer the user's sleep schedule (manual today; the iOS Sleep schedule once
+        // HealthKit is authorized — see SleepSchedule.swift). nil when no schedule is set.
+        if let w = scheduleWindow { return (w.start, w.end) }
+        // Else the most recent night's ACTUAL sleep span (real onset/wake clock times),
         // not a midnight-anchored guess — so pre-midnight sleep aligns correctly.
         if let s = storedSleep.first, s.asleepMin > 0,
            s.inBedStart > Date.distantPast, s.inBedEnd > s.inBedStart {

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -74,6 +74,9 @@ struct VitalsTableView: View {
             divider
             row("Steps (today)", value: stepsText, time: stepsTime)
             divider
+            row("Battery", value: session?.batteryPercent.map { "\($0)%" } ?? "—",
+                time: session?.batteryPercent != nil ? "live" : nil)
+            divider
             row("Respiratory Rate", value: valueText(.respiratoryRate) { String(format: "%.1f /min", $0) },
                 time: timeFor(.respiratoryRate))
             divider

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -129,13 +129,17 @@ struct VitalsTableView: View {
 
     // MARK: First-run empty-state (#58)
 
-    /// True once at least one sleep-vitals sample has been persisted (HRV, RR, sleep summary,
-    /// or a resting-HR window). All four overnight rows (HRV, Resting HR, Respiratory Rate,
-    /// Sleep) depend on this data; when false the rows are in a first-run empty state rather
-    /// than genuinely missing today's reading. (#58)
+    /// True once at least one genuinely sleep-derived sample has been persisted (HRV, RR, or a
+    /// stored sleep summary). Resting HR is deliberately EXCLUDED: it's the min of ANY heart-rate
+    /// sample in the last 24 h, and an on-demand "Measure HR" tap persists a `.heartRate` sample on
+    /// disconnect (RingSession.swift) — so a single daytime reading would otherwise flip this true
+    /// before any overnight sync, suppressing `overnightSyncHint` and reverting the Sleep row to a
+    /// bare "—" WHILE HRV/RR still show "after overnight sync" (a contradictory first-run UI). The
+    /// four overnight rows (HRV, Resting HR, Respiratory Rate, Sleep) reflect this data; when false
+    /// they show the first-run empty state rather than reading as genuinely missing today's value.
+    /// (#58)
     private var hasSleepVitals: Bool {
-        latestHRV.first != nil || latestRR.first != nil
-            || storedSleep.first != nil || restingHR != nil
+        latestHRV.first != nil || latestRR.first != nil || storedSleep.first != nil
     }
 
     var body: some View {

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -22,6 +22,10 @@ struct VitalsTableView: View {
     /// HealthKit is authorized) — the preferred bound for the night-temp window. Resolved
     /// asynchronously into @State (see `.task`), never fetched synchronously in `body`.
     @State private var scheduleWindow: DateInterval?
+    // Mirror the sleep-schedule settings so the window re-resolves when the user edits them.
+    @AppStorage(SleepScheduleDefaults.enabled) private var sleepEnabled = false
+    @AppStorage(SleepScheduleDefaults.bedMinutes) private var bedMinutes = SleepScheduleDefaults.defaultBedMinutes
+    @AppStorage(SleepScheduleDefaults.wakeMinutes) private var wakeMinutes = SleepScheduleDefaults.defaultWakeMinutes
 
     /// Prefer the live session summary; fall back to the latest stored night offline.
     private var effectiveSleep: SleepStaging.Summary? {
@@ -78,7 +82,9 @@ struct VitalsTableView: View {
         .padding(.vertical, 4)
         // Resolve the (async) sleep-schedule window once the view appears. The selector
         // returns the HealthKit window when authorized, else the manual one, else nil.
-        .task { scheduleWindow = await SleepSchedule.current(forNightEndingNear: Date()) }
+        .task(id: "\(sleepEnabled)-\(bedMinutes)-\(wakeMinutes)") {
+            scheduleWindow = await SleepSchedule.current(forNightEndingNear: Date())
+        }
     }
 
     /// Sleep: total asleep + estimated Deep/Light/REM/Awake breakdown (stages are an
@@ -181,8 +187,11 @@ struct VitalsTableView: View {
 
     private var nightWindow: (start: Date, end: Date)? {
         // Prefer the user's sleep schedule (manual today; the iOS Sleep schedule once
-        // HealthKit is authorized — see SleepSchedule.swift). nil when no schedule is set.
-        if let w = scheduleWindow { return (w.start, w.end) }
+        // HealthKit is authorized — see SleepSchedule.swift), but ONLY once that window has
+        // actually started — otherwise an evening's *upcoming* night (start in the future)
+        // would window the temp average over a range with no samples and blank the headline.
+        // Before tonight's window begins, fall through to last night's completed span.
+        if let w = scheduleWindow, w.start <= Date() { return (w.start, w.end) }
         // Else the most recent night's ACTUAL sleep span (real onset/wake clock times),
         // not a midnight-anchored guess — so pre-midnight sleep aligns correctly.
         if let s = storedSleep.first, s.asleepMin > 0,

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -286,7 +286,7 @@ struct VitalsTableView: View {
     }
 
     private func tempString(_ celsius: Double) -> String {
-        String(format: "%.1f °C  (%.1f °F)", celsius, celsius * 9 / 5 + 32)
+        String(format: "%.1f °F", celsius * 9 / 5 + 32)
     }
 
     /// Latest stored value for `kind`, formatted, or "—" if none.

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -62,20 +62,24 @@ struct VitalsTableView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            row("Heart Rate", value: hrText, time: timeFor(.heartRate, live: session?.liveHR != nil))
+            measurableRow("Heart Rate", value: hrText, mode: .hr, active: hrActive,
+                          time: hrActive && session?.liveHR == nil
+                              ? "measuring…" : timeFor(.heartRate, live: session?.liveHR != nil))
             divider
-            row("SpO₂", value: spo2Text, time: timeFor(.spo2, live: session?.liveSpO2 != nil))
+            measurableRow("SpO₂", value: spo2Text, mode: .spo2, active: spo2Active,
+                          time: spo2Active && session?.liveSpO2 == nil
+                              ? "measuring…" : timeFor(.spo2, live: session?.liveSpO2 != nil))
             divider
             skinTempRow
             divider
-            row("HRV", value: valueText(.hrvSDNN) { "\(Int($0)) ms" }, time: timeFor(.hrvSDNN))
+            row("HRV", value: valueText(.hrvSDNN) { "\(Int($0)) ms" }, time: nightlyWhen(.hrvSDNN))
             divider
             row("Resting HR", value: restingHR.map { "\($0) bpm" } ?? "—", time: nil)
             divider
             row("Steps (today)", value: stepsText, time: stepsTime)
             divider
             row("Respiratory Rate", value: valueText(.respiratoryRate) { String(format: "%.1f /min", $0) },
-                time: timeFor(.respiratoryRate))
+                time: nightlyWhen(.respiratoryRate))
             divider
             sleepSection
         }
@@ -121,6 +125,50 @@ struct VitalsTableView: View {
             }
         }
         .padding(.vertical, 8)
+    }
+
+    // MARK: On-demand metrics (HR / SpO₂) — an inline Measure control replaces the old big cards
+
+    private var hrActive: Bool { session?.monitoring == true && session?.liveMode == .hr }
+    private var spo2Active: Bool { session?.monitoring == true && session?.liveMode == .spo2 }
+
+    /// A vitals row carrying an inline start/stop measure control for an on-demand metric.
+    private func measurableRow(_ label: String, value: String, mode: RingSession.LiveMode,
+                               active: Bool, time: String?) -> some View {
+        HStack(spacing: 10) {
+            Text(label).font(.subheadline).foregroundStyle(.primary)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(value).font(.subheadline.weight(.semibold)).monospacedDigit()
+                if let time { Text(time).font(.caption2).foregroundStyle(.secondary) }
+            }
+            measureButton(mode, active: active)
+        }
+        .padding(.vertical, 8)
+    }
+
+    /// Small circular start/stop control. Appears only when the ring link is ready; disabled
+    /// while a history sync holds the link. Starting one metric stops the other (the ring
+    /// measures one at a time); tapping the active one stops it.
+    @ViewBuilder
+    private func measureButton(_ mode: RingSession.LiveMode, active: Bool) -> some View {
+        if session?.ready == true {
+            let color: Color = mode == .hr ? .red : .blue
+            let icon = mode == .hr ? "heart.fill" : "lungs.fill"
+            Button {
+                if active { session?.stopLiveMonitoring() }
+                else { session?.startMonitoring(mode: mode) }
+            } label: {
+                Image(systemName: active ? "stop.fill" : icon)
+                    .font(.caption2.weight(.bold))
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(active ? color : Color(.systemGray5)))
+                    .foregroundStyle(active ? .white : color)
+                    .symbolEffect(.pulse, isActive: active)
+            }
+            .buttonStyle(.plain)
+            .disabled(session?.syncing == true)
+        }
     }
 
     private var divider: some View { Divider().opacity(0.4) }
@@ -253,5 +301,24 @@ struct VitalsTableView: View {
         if live { return "live" }
         guard let s = latest[kind] else { return nil }
         return Self.rel.localizedString(for: s.start, relativeTo: Date())
+    }
+
+    private static let nightlyDate: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "MMM d"; return f
+    }()
+    /// Freshness label for NIGHTLY metrics (HRV, Respiratory Rate) — the ring only derives
+    /// these from sleep, so a relative "5h ago" misreads as a stale live value. Show which
+    /// night it's from instead: "last night" for this morning's sleep, else the date.
+    private func nightlyWhen(_ kind: MetricKind) -> String? {
+        guard let s = latest[kind] else { return nil }
+        let cal = Calendar.current
+        let days = cal.dateComponents([.day], from: cal.startOfDay(for: s.start),
+                                      to: cal.startOfDay(for: Date())).day ?? 0
+        switch days {
+        case ..<0: return nil            // future timestamp (shouldn't happen) — omit
+        case 0: return "last night"
+        case 1: return "yesterday"
+        default: return Self.nightlyDate.string(from: s.start)
+        }
     }
 }

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -6,12 +6,25 @@ import OpenRingKit
 /// are always visible offline) and prefers the live session reading when connected.
 struct VitalsTableView: View {
     @Environment(\.modelContext) private var modelContext
-    /// Most-recent samples first; we reduce to the latest per kind in `latest`.
-    @Query(sort: \StoredSample.start, order: .reverse) private var samples: [StoredSample]
-    /// Persisted sleep summaries (latest night first) — the offline fallback for `sleep`.
-    @Query(sort: \StoredSleepSummary.night, order: .reverse) private var storedSleep: [StoredSleepSummary]
-    /// Persisted daily rollups (latest day first) — the offline fallback for live steps.
-    @Query(sort: \StoredDaily.day, order: .reverse) private var storedDaily: [StoredDaily]
+    // BOUNDED fetches replace the old unbounded `@Query` that loaded every StoredSample on every
+    // view update (#32). Each "latest" query is `fetchLimit = 1`; the two windowed queries cap
+    // the scan to a recent time slice instead of all history. All filtering done in `body` is
+    // over these already-bounded arrays — never a synchronous fetch (the #14 black-screen hazard).
+    /// Latest stored sample per displayed kind (newest first, capped at 1 each).
+    @Query private var latestHR: [StoredSample]
+    @Query private var latestSpO2: [StoredSample]
+    @Query private var latestTemp: [StoredSample]
+    @Query private var latestHRV: [StoredSample]
+    @Query private var latestRR: [StoredSample]
+    /// Heart-rate samples over the last 24 h — the window resting HR (the sleep low) scans.
+    @Query private var recentHR: [StoredSample]
+    /// Temperature samples over the last few days — narrowed in memory to the precise night
+    /// window for the overnight average (the exact window depends on async @State).
+    @Query private var recentTemp: [StoredSample]
+    /// Latest persisted sleep summary (capped at 1) — the offline fallback for `sleep`.
+    @Query private var storedSleep: [StoredSleepSummary]
+    /// Latest persisted daily rollup (capped at 1) — the offline fallback for live steps.
+    @Query private var storedDaily: [StoredDaily]
     /// Live session (optional) — its readings override stored ones while connected.
     var session: RingSession?
     /// LIVE sleep summary for the most recent night (total asleep + estimated stage
@@ -26,6 +39,59 @@ struct VitalsTableView: View {
     @AppStorage(SleepScheduleDefaults.enabled) private var sleepEnabled = false
     @AppStorage(SleepScheduleDefaults.bedMinutes) private var bedMinutes = SleepScheduleDefaults.defaultBedMinutes
     @AppStorage(SleepScheduleDefaults.wakeMinutes) private var wakeMinutes = SleepScheduleDefaults.defaultWakeMinutes
+
+    /// Days of temperature history the night-temp window query scans before the precise night
+    /// window is applied in memory — generous enough to cover the most recent night, still tiny
+    /// versus all history.
+    private static let tempWindowDays: TimeInterval = 3
+
+    init(session: RingSession? = nil, sleep: SleepStaging.Summary? = nil) {
+        self.session = session
+        self.sleep = sleep
+
+        // Anchor the time windows to the start of the current hour so the @Query descriptors stay
+        // stable across rapid SwiftUI re-renders (only re-fetching hourly or when data changes),
+        // instead of churning on every render with a millisecond-fresh cutoff.
+        let hourStart = Calendar.current.dateInterval(of: .hour, for: Date())?.start ?? Date()
+        let dayAgo = hourStart.addingTimeInterval(-86_400)
+        let tempLookback = hourStart.addingTimeInterval(-Self.tempWindowDays * 86_400)
+
+        let hr = MetricKind.heartRate.rawValue
+        let spo2 = MetricKind.spo2.rawValue
+        let temp = MetricKind.temperature.rawValue
+        let hrv = MetricKind.hrvSDNN.rawValue
+        let rr = MetricKind.respiratoryRate.rawValue
+
+        _latestHR = Query(Self.latestDescriptor(hr))
+        _latestSpO2 = Query(Self.latestDescriptor(spo2))
+        _latestTemp = Query(Self.latestDescriptor(temp))
+        _latestHRV = Query(Self.latestDescriptor(hrv))
+        _latestRR = Query(Self.latestDescriptor(rr))
+        _recentHR = Query(FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == hr && $0.start > dayAgo && $0.value > 0 },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]))
+        _recentTemp = Query(FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == temp && $0.start > tempLookback && $0.value > 0 },
+            sortBy: [SortDescriptor(\.start, order: .reverse)]))
+
+        var sleepDesc = FetchDescriptor<StoredSleepSummary>(
+            sortBy: [SortDescriptor(\.night, order: .reverse)])
+        sleepDesc.fetchLimit = 1
+        _storedSleep = Query(sleepDesc)
+        var dailyDesc = FetchDescriptor<StoredDaily>(sortBy: [SortDescriptor(\.day, order: .reverse)])
+        dailyDesc.fetchLimit = 1
+        _storedDaily = Query(dailyDesc)
+    }
+
+    /// Newest-first, single-row descriptor for one metric kind. Predicate shape (`kindRaw` then
+    /// `start`) is index-friendly so it can use a composite index if one is added later. (#32)
+    private static func latestDescriptor(_ kindRaw: String) -> FetchDescriptor<StoredSample> {
+        var d = FetchDescriptor<StoredSample>(
+            predicate: #Predicate { $0.kindRaw == kindRaw },
+            sortBy: [SortDescriptor(\.start, order: .reverse)])
+        d.fetchLimit = 1
+        return d
+    }
 
     /// Prefer the live session summary; fall back to the latest stored night offline.
     private var effectiveSleep: SleepStaging.Summary? {
@@ -42,22 +108,23 @@ struct VitalsTableView: View {
         return storedDaily.first.flatMap { $0.day == today ? $0.steps : nil }
     }
 
+    /// Latest stored sample per displayed kind, assembled from the per-kind `fetchLimit = 1`
+    /// queries (absent kinds stay out of the dict). Replaces the old in-memory reduce over every
+    /// stored row. (#32)
     private var latest: [MetricKind: StoredSample] {
         var out: [MetricKind: StoredSample] = [:]
-        for s in samples {
-            guard let k = MetricKind(rawValue: s.kindRaw), out[k] == nil else { continue }
-            out[k] = s
-        }
+        out[.heartRate] = latestHR.first
+        out[.spo2] = latestSpO2.first
+        out[.temperature] = latestTemp.first
+        out[.hrvSDNN] = latestHRV.first
+        out[.respiratoryRate] = latestRR.first
         return out
     }
 
-    /// Resting HR ≈ the lowest HR over the last 24 h (sleep low), derived from stored HR.
+    /// Resting HR ≈ the lowest HR over the last 24 h (sleep low). `recentHR` is already the
+    /// bounded 24 h, value-positive HR window, so this is just its min. (#32)
     private var restingHR: Int? {
-        let dayAgo = Date().addingTimeInterval(-86_400)
-        let hrs = samples
-            .filter { $0.kindRaw == MetricKind.heartRate.rawValue && $0.start > dayAgo && $0.value > 0 }
-            .map { $0.value }
-        return hrs.min().map { Int($0) }
+        recentHR.map(\.value).min().map { Int($0) }
     }
 
     var body: some View {
@@ -232,12 +299,10 @@ struct VitalsTableView: View {
     /// else local 00:00–06:00 of the most recent date that has temperature samples.
     private var nightTemp: Double? {
         guard let window = nightWindow else { return nil }
-        // Filter the already-loaded @Query array in memory — no synchronous fetch in `body`
-        // (that hazard once caused a black-screen launch). #14
-        let tempKind = MetricKind.temperature.rawValue
-        let vals = samples.lazy
-            .filter { $0.kindRaw == tempKind && $0.value > 0
-                      && $0.start >= window.start && $0.start <= window.end }
+        // Narrow the already-loaded (bounded) `recentTemp` window to the precise night in memory
+        // — no synchronous fetch in `body` (that hazard once caused a black-screen launch). #14
+        let vals = recentTemp.lazy
+            .filter { $0.start >= window.start && $0.start <= window.end }
             .map(\.value)
         var sum = 0.0, n = 0
         for v in vals { sum += v; n += 1 }

--- a/ios/OpenRingConn/VitalsTableView.swift
+++ b/ios/OpenRingConn/VitalsTableView.swift
@@ -133,9 +133,7 @@ struct VitalsTableView: View {
                           time: hrActive && session?.liveHR == nil
                               ? "measuring…" : timeFor(.heartRate, live: hrLive))
             divider
-            measurableRow("SpO₂", value: spo2Text, mode: .spo2, active: spo2Active,
-                          time: spo2Active && session?.liveSpO2 == nil
-                              ? "measuring…" : timeFor(.spo2, live: spo2Live))
+            spo2Row
             divider
             skinTempRow
             divider
@@ -178,6 +176,25 @@ struct VitalsTableView: View {
         } else {
             row("Sleep", value: "—", time: nil)
         }
+    }
+
+    /// SpO₂ row with estimate caveat: live SpO₂ is a single-window measurement (🟡),
+    /// not multi-sample ground-truthed. Label it consistently with sleep stages ("est.").
+    @ViewBuilder private var spo2Row: some View {
+        HStack(spacing: 10) {
+            Text("SpO₂").font(.subheadline).foregroundStyle(.primary)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(spo2Text).font(.subheadline.weight(.semibold)).monospacedDigit()
+                Text("est.").font(.caption2).foregroundStyle(.tertiary)
+                if let time = (spo2Active && session?.liveSpO2 == nil
+                    ? "measuring…" : timeFor(.spo2, live: spo2Live)) {
+                    Text(time).font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+            measureButton(.spo2, active: spo2Active)
+        }
+        .padding(.vertical, 8)
     }
 
     // MARK: rows

--- a/ios/OpenRingConn/WorkoutSessionManager.swift
+++ b/ios/OpenRingConn/WorkoutSessionManager.swift
@@ -1,0 +1,405 @@
+// WorkoutSessionManager.swift — App-side workout session: HR collection via the ring's
+// existing live-HR poll path, GPS route capture (phone CoreLocation), and HKWorkout write.
+//
+// RISK — Issue #45 (live HR flakiness):
+//   The 0x95→0x15 live-HR path has no background refresh; on-demand polling often misses
+//   updates. A long workout session is the worst-case scenario for this flakiness. This
+//   manager tolerates HR dropouts gracefully: only ACTUAL decoded readings are recorded;
+//   gaps are never filled by interpolation or fabrication. A best-effort note is surfaced
+//   to the user in the UI. See #45 for the root cause and expected follow-up.
+//
+// GPS: phone-side only (CoreLocation). The ring has no GPS. Route capture is opt-in —
+//   only for outdoor sport types — and gracefully degrades when location permission is
+//   denied (workout still proceeds without a route).
+//
+// HealthKit: writes HKWorkout + HR quantity samples + HKWorkoutRoute (outdoor only).
+//   Sport type is mapped to HKWorkoutActivityType; active calories are labeled ESTIMATE.
+
+import Foundation
+import CoreLocation
+import HealthKit
+import OpenRingKit
+import Observation
+
+// MARK: - Workout state
+
+enum WorkoutRecordingState: Equatable {
+    case idle
+    case starting   // brief: monitoring starting, drain in progress
+    case active
+    case finishing  // writing to HealthKit
+    case finished(summary: WorkoutSummary)
+    case error(String)
+
+    static func == (lhs: WorkoutRecordingState, rhs: WorkoutRecordingState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.starting, .starting), (.active, .active), (.finishing, .finishing): return true
+        case (.finished(let a), .finished(let b)): return a == b
+        case (.error(let a), .error(let b)): return a == b
+        default: return false
+        }
+    }
+}
+
+// MARK: - Manager
+
+@Observable
+@MainActor
+final class WorkoutSessionManager: NSObject {
+
+    // MARK: Public state (observed by WorkoutView)
+
+    private(set) var recordingState: WorkoutRecordingState = .idle
+    var selectedSport: WorkoutSportType = .runningOutdoor
+
+    /// Live elapsed seconds since the session started (updated by the timer loop).
+    private(set) var elapsedSeconds: TimeInterval = 0
+    /// Live HR mirror (nil when the ring hasn't locked a reading or HR is dropping; see #45).
+    private(set) var currentHR: Int?
+    /// Running zone breakdown updated as HR samples arrive.
+    private(set) var liveZoneBreakdown = WorkoutZoneBreakdown()
+    /// GPS distance in meters (phone CoreLocation). nil until first location fix.
+    private(set) var distanceMeters: Double?
+    /// Whether GPS is currently active for this session.
+    private(set) var gpsActive = false
+    /// Location authorization status — surfaced so the UI can explain a denied state.
+    private(set) var locationAuthStatus: CLAuthorizationStatus = .notDetermined
+    /// Count of HR samples captured so far (helps UI surface "good / sparse data").
+    private(set) var hrSampleCount: Int = 0
+
+    // MARK: Private
+
+    private var aggregator: WorkoutSessionAggregator?
+    private var sessionStart: Date?
+
+    private var hrPollTask: Task<Void, Never>?
+    private var timerTask: Task<Void, Never>?
+
+    /// CoreLocation manager for outdoor GPS route capture.
+    private var locationManager: CLLocationManager?
+    /// Accumulated route locations (outdoor sessions only).
+    private var routeLocations: [CLLocation] = []
+    private var lastLocation: CLLocation?
+
+    private weak var session: RingSession?
+
+    // MARK: HealthKit
+
+    private let hkStore = HKHealthStore()
+
+    /// Mapping from WorkoutSportType to HKWorkoutActivityType.
+    static func hkActivityType(for sport: WorkoutSportType) -> HKWorkoutActivityType {
+        switch sport {
+        case .walkingOutdoor:    return .walking
+        case .runningOutdoor:    return .running
+        case .cyclingOutdoor:    return .cycling
+        case .hiking:            return .hiking
+        case .strengthTraining:  return .traditionalStrengthTraining
+        case .yoga:              return .yoga
+        case .other:             return .other
+        }
+    }
+
+    // MARK: - Start / Stop
+
+    /// Begin a workout session. Drives the ring's existing live-HR poll (0x95→0x15) via
+    /// `RingSession.startMonitoring`. Does NOT send any new BLE write command to the ring
+    /// beyond what the existing live-HR path already uses.
+    func start(session: RingSession) {
+        guard case .idle = recordingState else { return }
+        self.session = session
+        let start = Date()
+        sessionStart = start
+        let age = HealthKitWriter.storedUserProfile().age
+        aggregator = WorkoutSessionAggregator(startDate: start, userAge: age)
+        elapsedSeconds = 0
+        currentHR = nil
+        liveZoneBreakdown = WorkoutZoneBreakdown()
+        distanceMeters = nil
+        gpsActive = false
+        hrSampleCount = 0
+        routeLocations = []
+        lastLocation = nil
+
+        recordingState = .starting
+
+        // Start the ring's live HR polling (existing path — no new BLE commands).
+        session.startMonitoring(mode: .hr, userInitiated: false, quickLiveRead: true)
+
+        // Begin GPS if this is an outdoor sport type.
+        if selectedSport.isOutdoor { startGPS() }
+
+        // HR collection loop: snapshots session.liveHR every 2 s.
+        // #45 NOTE: live HR is best-effort. Gaps are preserved (no gap-filling/interpolation).
+        hrPollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2))
+                await MainActor.run { self?.collectHRSnapshot() }
+            }
+        }
+        // Elapsed-time ticker (1 s resolution).
+        timerTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                await MainActor.run {
+                    guard let self, let start = self.sessionStart else { return }
+                    self.elapsedSeconds = Date().timeIntervalSince(start)
+                }
+            }
+        }
+
+        recordingState = .active
+    }
+
+    /// Stop the session, write to HealthKit, transition to `.finished`.
+    func stop() async {
+        // Allow stopping from both .starting and .active
+        switch recordingState {
+        case .starting, .active: break
+        default: return
+        }
+        recordingState = .finishing
+
+        hrPollTask?.cancel(); hrPollTask = nil
+        timerTask?.cancel(); timerTask = nil
+
+        // Stop the ring's live monitoring.
+        session?.stopLiveMonitoring()
+        session = nil
+
+        // Stop GPS.
+        locationManager?.stopUpdatingLocation()
+        locationManager?.delegate = nil
+        gpsActive = false
+
+        let endDate = Date()
+        let profile = HealthKitWriter.storedUserProfile()
+
+        guard let agg = aggregator else {
+            recordingState = .error("No session data")
+            return
+        }
+
+        let hasRoute = !routeLocations.isEmpty && selectedSport.isOutdoor
+        let summary = agg.finalize(
+            sport: selectedSport,
+            endDate: endDate,
+            distanceMeters: hasRoute ? distanceMeters : nil,
+            hasRoute: hasRoute,
+            profile: profile
+        )
+
+        // Write to HealthKit (best-effort; gracefully silent on failure).
+        await writeWorkout(summary: summary,
+                           hrSamples: agg.collectedSamples,
+                           routeLocations: hasRoute ? routeLocations : [])
+
+        recordingState = .finished(summary: summary)
+    }
+
+    /// Discard the session without writing to HealthKit.
+    func cancel() {
+        hrPollTask?.cancel(); hrPollTask = nil
+        timerTask?.cancel(); timerTask = nil
+        session?.stopLiveMonitoring()
+        session = nil
+        locationManager?.stopUpdatingLocation()
+        locationManager?.delegate = nil
+        recordingState = .idle
+    }
+
+    func reset() {
+        recordingState = .idle
+        elapsedSeconds = 0
+        currentHR = nil
+    }
+
+    // MARK: - HR collection
+
+    /// Snapshot the current liveHR from the ring session. Only records when monitoring is
+    /// active AND the ring has a locked reading (>= LiveHR.minValidBPM). Attributes a 2-s
+    /// window to each poll result — the ring holds the last known value between polls, so
+    /// this is the best honest approximation of "HR was X for the last 2 s."
+    ///
+    /// Gaps (liveHR == nil or below minValidBPM) are preserved — we NEVER fabricate or
+    /// interpolate values to fill them (ref #45: live HR is best-effort / on-demand).
+    private func collectHRSnapshot() {
+        guard let session, session.monitoring,
+              let bpm = session.liveHR, bpm >= LiveHR.minValidBPM else {
+            // No lock — gap preserved, not filled (#45).
+            currentHR = nil
+            return
+        }
+        let now = Date()
+        let sampleStart = now.addingTimeInterval(-2)
+        let sample = HRSample(bpm: bpm, start: sampleStart, end: now)
+        aggregator?.add(sample: sample)
+        hrSampleCount += 1
+        currentHR = bpm
+
+        // Update live zone breakdown.
+        if let agg = aggregator {
+            let maxHR = max(220 - HealthKitWriter.storedUserProfile().age, 1)
+            liveZoneBreakdown = HRZoneClassifier.timeInZones(
+                hrSamples: agg.collectedSamples, maxHR: maxHR)
+        }
+    }
+
+    // MARK: - GPS / CoreLocation
+
+    private func startGPS() {
+        let mgr = CLLocationManager()
+        mgr.delegate = self
+        mgr.desiredAccuracy = kCLLocationAccuracyBest
+        mgr.distanceFilter = 5   // update every 5 m
+        locationManager = mgr
+        locationAuthStatus = mgr.authorizationStatus
+        switch mgr.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            mgr.startUpdatingLocation()
+            gpsActive = true
+        case .notDetermined:
+            mgr.requestWhenInUseAuthorization()
+        default:
+            // Permission denied — workout proceeds without GPS (graceful).
+            gpsActive = false
+        }
+    }
+
+    // MARK: - HealthKit write
+
+    /// Write the completed workout to Apple Health. Best-effort: silent on auth/API failures.
+    /// Writes HKWorkout, HR quantity samples, and optional HKWorkoutRoute.
+    private func writeWorkout(
+        summary: WorkoutSummary,
+        hrSamples: [HRSample],
+        routeLocations: [CLLocation]
+    ) async {
+        guard HKHealthStore.isHealthDataAvailable() else { return }
+        let activityType = Self.hkActivityType(for: summary.sport)
+
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = activityType
+        if summary.sport.isOutdoor { configuration.locationType = .outdoor }
+        else { configuration.locationType = .indoor }
+
+        let builder = HKWorkoutBuilder(
+            healthStore: hkStore,
+            configuration: configuration,
+            device: .local()
+        )
+
+        // Begin collection
+        do {
+            try await builder.beginCollection(at: summary.startDate)
+        } catch {
+            return   // HealthKit auth not granted or unavailable
+        }
+
+        // Add HR samples during the workout window
+        if !hrSamples.isEmpty {
+            let hrType = HKQuantityType(.heartRate)
+            let hkHRSamples: [HKQuantitySample] = hrSamples.map { s in
+                let q = HKQuantity(unit: HKUnit.count().unitDivided(by: .minute()),
+                                   doubleValue: Double(s.bpm))
+                return HKQuantitySample(
+                    type: hrType, quantity: q, start: s.start, end: s.end,
+                    metadata: [HKMetadataKeyWasUserEntered: false])
+            }
+            try? await builder.addSamples(hkHRSamples)
+        }
+
+        // Add active energy (ESTIMATE — TRIMP-based, labeled in metadata)
+        if let kcal = summary.estimatedActiveKcal, kcal > 0 {
+            let energyType = HKQuantityType(.activeEnergyBurned)
+            let q = HKQuantity(unit: .kilocalorie(), doubleValue: kcal)
+            let energySample = HKQuantitySample(
+                type: energyType, quantity: q,
+                start: summary.startDate, end: summary.endDate,
+                metadata: ["OpenRingConnCaloriesEstimated": true,
+                           HKMetadataKeyWasUserEntered: false])
+            try? await builder.addSamples([energySample])
+        }
+
+        // Add distance (GPS — only for outdoor with route)
+        if let dist = summary.distanceMeters, dist > 0, summary.hasRoute {
+            let distType = HKQuantityType(.distanceWalkingRunning)
+            let q = HKQuantity(unit: .meter(), doubleValue: dist)
+            let distSample = HKQuantitySample(
+                type: distType, quantity: q,
+                start: summary.startDate, end: summary.endDate,
+                metadata: [HKMetadataKeyWasUserEntered: false])
+            try? await builder.addSamples([distSample])
+        }
+
+        // End collection and finish workout
+        do {
+            try await builder.endCollection(at: summary.endDate)
+        } catch { return }
+
+        let workout: HKWorkout
+        do {
+            guard let finished = try await builder.finishWorkout() else { return }
+            workout = finished
+        } catch { return }
+
+        // Write GPS route if available
+        if !routeLocations.isEmpty, summary.hasRoute {
+            await writeRoute(locations: routeLocations, to: workout)
+        }
+    }
+
+    private func writeRoute(locations: [CLLocation], to workout: HKWorkout) async {
+        let routeBuilder = HKWorkoutRouteBuilder(healthStore: hkStore, device: nil)
+        do {
+            try await routeBuilder.insertRouteData(locations)
+            _ = try await routeBuilder.finishRoute(with: workout, metadata: nil)
+        } catch {
+            // Route write failed — workout and HR samples already saved; route is optional.
+        }
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension WorkoutSessionManager: CLLocationManagerDelegate {
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.locationAuthStatus = manager.authorizationStatus
+            if manager.authorizationStatus == .authorizedWhenInUse
+                || manager.authorizationStatus == .authorizedAlways {
+                manager.startUpdatingLocation()
+                self.gpsActive = true
+            } else {
+                self.gpsActive = false
+            }
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager,
+                                     didUpdateLocations locations: [CLLocation]) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            for loc in locations {
+                // Reject low-accuracy fixes (> 50 m horizontal accuracy).
+                guard loc.horizontalAccuracy >= 0, loc.horizontalAccuracy <= 50 else { continue }
+                if let prev = self.lastLocation {
+                    let delta = loc.distance(from: prev)
+                    self.distanceMeters = (self.distanceMeters ?? 0) + delta
+                }
+                self.lastLocation = loc
+                self.routeLocations.append(loc)
+            }
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager,
+                                     didFailWithError error: Error) {
+        // GPS error — graceful, location data is optional.
+        Task { @MainActor [weak self] in
+            self?.gpsActive = false
+        }
+    }
+}

--- a/ios/OpenRingConn/WorkoutSessionManager.swift
+++ b/ios/OpenRingConn/WorkoutSessionManager.swift
@@ -134,15 +134,17 @@ final class WorkoutSessionManager: NSObject {
         hrPollTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(2))
-                await MainActor.run { self?.collectHRSnapshot() }
+                guard let self else { break }   // self-terminate if the manager went away
+                await MainActor.run { self.collectHRSnapshot() }
             }
         }
         // Elapsed-time ticker (1 s resolution).
         timerTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(1))
+                guard let self else { break }   // self-terminate if the manager went away
                 await MainActor.run {
-                    guard let self, let start = self.sessionStart else { return }
+                    guard let start = self.sessionStart else { return }
                     self.elapsedSeconds = Date().timeIntervalSince(start)
                 }
             }
@@ -213,6 +215,11 @@ final class WorkoutSessionManager: NSObject {
         elapsedSeconds = 0
         currentHR = nil
     }
+
+    // Belt-and-suspenders: the poll/timer loops capture `self` weakly and `break` as soon as
+    // the manager is deallocated (the `guard let self else { break }` in `start`), so they can
+    // never outlive the manager even without an explicit cancel. Ring teardown
+    // (`stopLiveMonitoring`) is handled by `stop()` via the view's `.onDisappear`. (#75)
 
     // MARK: - HR collection
 
@@ -321,15 +328,24 @@ final class WorkoutSessionManager: NSObject {
             try? await builder.addSamples([energySample])
         }
 
-        // Add distance (GPS — only for outdoor with route)
+        // Add distance (GPS — only for outdoor with route). Pick the correct HK type by sport:
+        // cycling → .distanceCycling; walking/running/hiking → .distanceWalkingRunning. Writing
+        // a cycling ride to the walk/run type would pollute that total (and never show as cycling
+        // distance).
         if let dist = summary.distanceMeters, dist > 0, summary.hasRoute {
-            let distType = HKQuantityType(.distanceWalkingRunning)
+            let isCycling = summary.sport == .cyclingOutdoor
+            let distType = HKQuantityType(isCycling ? .distanceCycling : .distanceWalkingRunning)
             let q = HKQuantity(unit: .meter(), doubleValue: dist)
             let distSample = HKQuantitySample(
                 type: distType, quantity: q,
                 start: summary.startDate, end: summary.endDate,
                 metadata: [HKMetadataKeyWasUserEntered: false])
             try? await builder.addSamples([distSample])
+            // Record foot-based GPS distance so the daily steps×stride estimate nets it out and
+            // doesn't double-count this window in Health's Walking + Running Distance total.
+            if !isCycling {
+                HealthKitWriter.recordWorkoutWalkRunDistance(dist)
+            }
         }
 
         // End collection and finish workout

--- a/ios/OpenRingConn/WorkoutView.swift
+++ b/ios/OpenRingConn/WorkoutView.swift
@@ -1,0 +1,427 @@
+// WorkoutView.swift — Workout session UI: sport picker → live session → summary.
+//
+// Structure:
+//   • Idle:    sport picker + Start button
+//   • Active:  live duration, live HR, zone bars, GPS distance (outdoor)
+//   • Summary: duration, avg/max HR, 5-zone bar chart, distance (outdoor), HealthKit note
+//
+// IMPORTANT — Issue #45 (live HR flakiness):
+//   Live HR during a workout is best-effort. The ring's 0x95→0x15 on-demand poll has no
+//   background refresh and frequently misses updates during a long session. HR gaps are
+//   displayed honestly; the data shown is ONLY from actual decoded readings — never
+//   fabricated or interpolated. A disclaimer note is shown during active sessions.
+
+import SwiftUI
+import OpenRingKit
+
+// MARK: - Main view
+
+struct WorkoutView: View {
+    let session: RingSession?
+    @State private var manager = WorkoutSessionManager()
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch manager.recordingState {
+                case .idle:
+                    idleView
+                case .starting, .active:
+                    activeView
+                case .finishing:
+                    ProgressView("Saving workout…")
+                        .padding()
+                case .finished(let summary):
+                    summaryView(summary)
+                case .error(let msg):
+                    VStack(spacing: 16) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.largeTitle).foregroundStyle(.orange)
+                        Text("Workout error").font(.title3.weight(.semibold))
+                        Text(msg).font(.caption).foregroundStyle(.secondary)
+                        Button("Dismiss") { manager.reset(); dismiss() }
+                            .buttonStyle(.bordered)
+                    }
+                    .padding()
+                }
+            }
+            .navigationTitle("Workout")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    if case .idle = manager.recordingState {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Idle
+
+    private var idleView: some View {
+        VStack(spacing: 24) {
+            Text("SELECT SPORT")
+                .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 110))], spacing: 12) {
+                ForEach(WorkoutSportType.allCases, id: \.rawValue) { sport in
+                    SportButton(sport: sport, selected: manager.selectedSport == sport) {
+                        manager.selectedSport = sport
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Best-effort HR note (#45)
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "info.circle").foregroundStyle(.secondary)
+                Text("Live heart rate during workouts is best-effort (issue #45: on-demand polling, no background refresh). HR gaps will be shown honestly — data is never fabricated.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+            .padding(10)
+            .background(RoundedRectangle(cornerRadius: 10).fill(Color(.secondarySystemGroupedBackground)))
+
+            if manager.selectedSport.isOutdoor {
+                HStack(spacing: 6) {
+                    Image(systemName: "location.fill").foregroundStyle(.blue)
+                    Text("GPS route will be captured using your phone's location.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+
+            Button {
+                guard let session else { return }
+                manager.selectedSport = manager.selectedSport
+                manager.start(session: session)
+            } label: {
+                Label("Start Workout", systemImage: "play.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(session == nil || session?.ready != true)
+
+            if session == nil || session?.ready != true {
+                Text("Connect to the ring before starting a workout.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+    }
+
+    // MARK: - Active
+
+    private var activeView: some View {
+        VStack(spacing: 20) {
+            // Duration
+            VStack(spacing: 4) {
+                Text(formattedElapsed)
+                    .font(.system(size: 56, weight: .bold, design: .monospaced))
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                Text(manager.selectedSport.displayName.uppercased())
+                    .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            }
+            .padding(.top, 8)
+
+            // Live HR
+            HStack(spacing: 16) {
+                VStack(spacing: 4) {
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        if let hr = manager.currentHR {
+                            Text("\(hr)").font(.system(size: 40, weight: .bold, design: .rounded))
+                                .monospacedDigit().contentTransition(.numericText())
+                                .foregroundStyle(.red)
+                        } else {
+                            Text("--").font(.system(size: 40, weight: .bold, design: .rounded))
+                                .foregroundStyle(.secondary)
+                        }
+                        Text("bpm").font(.subheadline).foregroundStyle(.secondary)
+                    }
+                    Text("Heart Rate").font(.caption2).foregroundStyle(.secondary)
+                }
+                Spacer()
+                VStack(spacing: 4) {
+                    Text("\(manager.hrSampleCount)")
+                        .font(.title2.weight(.semibold)).monospacedDigit()
+                    Text("Readings").font(.caption2).foregroundStyle(.secondary)
+                }
+                if manager.selectedSport.isOutdoor {
+                    Spacer()
+                    VStack(spacing: 4) {
+                        HStack(alignment: .firstTextBaseline, spacing: 2) {
+                            Text(distanceText)
+                                .font(.title2.weight(.semibold)).monospacedDigit()
+                            Text("km").font(.caption).foregroundStyle(.secondary)
+                        }
+                        HStack(spacing: 3) {
+                            if manager.gpsActive {
+                                Image(systemName: "location.fill")
+                                    .font(.caption2).foregroundStyle(.blue)
+                            }
+                            Text("Distance").font(.caption2).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal)
+
+            Divider()
+
+            // Live zone bars
+            VStack(alignment: .leading, spacing: 8) {
+                Text("HR ZONES (live)")
+                    .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                ForEach(HRZone.allCases, id: \.rawValue) { zone in
+                    ZoneBarRow(
+                        zone: zone,
+                        seconds: manager.liveZoneBreakdown.seconds(in: zone),
+                        fraction: manager.liveZoneBreakdown.fraction(in: zone)
+                    )
+                }
+            }
+            .padding(.horizontal)
+
+            Spacer()
+
+            // #45 disclaimer
+            Text("Live HR is best-effort (polling, no background refresh — issue #45). Gaps are shown honestly.")
+                .font(.caption2).foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            // Stop button
+            Button(role: .destructive) {
+                Task { await manager.stop() }
+            } label: {
+                Label("Stop Workout", systemImage: "stop.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+            .controlSize(.large)
+            .padding()
+        }
+    }
+
+    // MARK: - Summary
+
+    private func summaryView(_ summary: WorkoutSummary) -> some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(spacing: 6) {
+                    Image(systemName: summary.sport.systemImageName)
+                        .font(.system(size: 40)).foregroundStyle(.blue)
+                    Text(summary.sport.displayName)
+                        .font(.title2.weight(.bold))
+                    Text(summarySubtitle(summary))
+                        .font(.subheadline).foregroundStyle(.secondary)
+                }
+                .padding(.top)
+
+                // Stats grid
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                    statCell("Duration", formattedDuration(summary.durationSeconds))
+                    if let avg = summary.avgHR {
+                        statCell("Avg HR", "\(avg) bpm")
+                    } else {
+                        statCell("Avg HR", "--")
+                    }
+                    if let max = summary.maxHR {
+                        statCell("Max HR", "\(max) bpm")
+                    } else {
+                        statCell("Max HR", "--")
+                    }
+                    if let kcal = summary.estimatedActiveKcal {
+                        statCell("Active Cal (est.)", "\(Int(kcal.rounded())) kcal")
+                    } else {
+                        statCell("Active Cal (est.)", "--")
+                    }
+                    statCell("HR Readings", "\(summary.hrSampleCount)")
+                    if let dist = summary.distanceMeters {
+                        statCell("Distance", String(format: "%.2f km", dist / 1000))
+                    }
+                }
+                .padding(.horizontal)
+
+                // Zone chart
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("HR ZONE DISTRIBUTION").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    if summary.zoneBreakdown.totalZoneSeconds > 0 {
+                        ForEach(HRZone.allCases, id: \.rawValue) { zone in
+                            ZoneBarRow(
+                                zone: zone,
+                                seconds: summary.zoneBreakdown.seconds(in: zone),
+                                fraction: summary.zoneBreakdown.fraction(in: zone)
+                            )
+                        }
+                    } else {
+                        Text("No HR zone data captured (insufficient readings — see issue #45).")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal)
+
+                // Honesty notes
+                VStack(alignment: .leading, spacing: 6) {
+                    if summary.hrSampleCount < 30 {
+                        noteRow(icon: "exclamationmark.triangle", color: .orange,
+                                text: "Few HR readings captured (\(summary.hrSampleCount)). Live HR polling is best-effort — the ring may have missed updates (issue #45).")
+                    }
+                    if summary.estimatedActiveKcal != nil {
+                        noteRow(icon: "info.circle", color: .secondary,
+                                text: "Active calories are an ESTIMATE (Edwards-TRIMP from HR — not ring sensor data).")
+                    }
+                    if summary.hasRoute {
+                        noteRow(icon: "location.fill", color: .blue,
+                                text: "GPS route captured and saved to Apple Health.")
+                    } else if summary.sport.isOutdoor {
+                        noteRow(icon: "location.slash", color: .secondary,
+                                text: "No GPS route (location permission not granted or denied).")
+                    }
+                    noteRow(icon: "checkmark.circle", color: .green,
+                            text: "Workout saved to Apple Health.")
+                }
+                .padding(.horizontal)
+
+                Button("Done") {
+                    manager.reset()
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .padding()
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var formattedElapsed: String {
+        let t = Int(manager.elapsedSeconds)
+        let h = t / 3600
+        let m = (t % 3600) / 60
+        let s = t % 60
+        if h > 0 { return String(format: "%d:%02d:%02d", h, m, s) }
+        return String(format: "%02d:%02d", m, s)
+    }
+
+    private var distanceText: String {
+        let km = (manager.distanceMeters ?? 0) / 1000
+        return String(format: "%.2f", km)
+    }
+
+    private func formattedDuration(_ seconds: TimeInterval) -> String {
+        let t = Int(seconds)
+        let h = t / 3600; let m = (t % 3600) / 60; let s = t % 60
+        if h > 0 { return String(format: "%dh %02dm", h, m) }
+        return String(format: "%dm %02ds", m, s)
+    }
+
+    private func summarySubtitle(_ s: WorkoutSummary) -> String {
+        let df = DateFormatter(); df.dateStyle = .medium; df.timeStyle = .short
+        return df.string(from: s.startDate)
+    }
+
+    @ViewBuilder
+    private func statCell(_ label: String, _ value: String) -> some View {
+        VStack(spacing: 4) {
+            Text(value).font(.title3.weight(.bold)).monospacedDigit()
+            Text(label).font(.caption2).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 12)
+            .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    @ViewBuilder
+    private func noteRow(icon: String, color: Color, text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: icon).foregroundStyle(color).frame(width: 16)
+            Text(text).font(.caption).foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Sport button
+
+private struct SportButton: View {
+    let sport: WorkoutSportType
+    let selected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 8) {
+                Image(systemName: sport.systemImageName)
+                    .font(.title2)
+                Text(sport.displayName)
+                    .font(.caption.weight(.medium))
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(12)
+            .background(RoundedRectangle(cornerRadius: 12)
+                .fill(selected
+                      ? Color.blue.opacity(0.15)
+                      : Color(.secondarySystemGroupedBackground)))
+            .overlay(RoundedRectangle(cornerRadius: 12)
+                .stroke(selected ? Color.blue : Color.clear, lineWidth: 2))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Zone bar row
+
+private struct ZoneBarRow: View {
+    let zone: HRZone
+    let seconds: Double
+    let fraction: Double
+
+    private var zoneColor: Color {
+        switch zone {
+        case .warmUp:    return .blue
+        case .fatBurn:   return .green
+        case .aerobic:   return .yellow
+        case .anaerobic: return .orange
+        case .extreme:   return .red
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(zone.displayName)
+                .font(.caption).foregroundStyle(.secondary)
+                .frame(width: 80, alignment: .leading)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color(.systemFill))
+                        .frame(height: 14)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(zoneColor.opacity(0.8))
+                        .frame(width: max(geo.size.width * fraction, fraction > 0 ? 4 : 0),
+                               height: 14)
+                        .animation(.easeInOut(duration: 0.3), value: fraction)
+                }
+            }
+            .frame(height: 14)
+            Text(formattedTime)
+                .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
+                .frame(width: 44, alignment: .trailing)
+        }
+    }
+
+    private var formattedTime: String {
+        let t = Int(seconds)
+        if t == 0 { return "  0:00" }
+        let m = t / 60; let s = t % 60
+        return String(format: "%2d:%02d", m, s)
+    }
+}

--- a/ios/OpenRingConn/WorkoutView.swift
+++ b/ios/OpenRingConn/WorkoutView.swift
@@ -21,6 +21,14 @@ struct WorkoutView: View {
     @State private var manager = WorkoutSessionManager()
     @Environment(\.dismiss) private var dismiss
 
+    /// True while a session is starting/active (recording in progress).
+    private var isRecording: Bool {
+        switch manager.recordingState {
+        case .starting, .active: return true
+        default: return false
+        }
+    }
+
     var body: some View {
         NavigationStack {
             Group {
@@ -55,6 +63,16 @@ struct WorkoutView: View {
                     }
                 }
             }
+        }
+        // Block interactive swipe-to-dismiss while recording so the session can't be abandoned
+        // mid-workout (which would leave the ring stuck polling and silently drop the workout).
+        .interactiveDismissDisabled(isRecording)
+        // Guarantee teardown if the sheet is dismissed any other way while still recording:
+        // stop() cancels the poll/timer tasks, calls session.stopLiveMonitoring() (so the ring
+        // stops live-HR polling), and writes the in-progress workout to HealthKit. No-op once
+        // the session has already finished/idled (stop() guards its own state). (#75)
+        .onDisappear {
+            if isRecording { Task { await manager.stop() } }
         }
     }
 

--- a/ios/OpenRingConnTests/BackgroundRefreshSchedulerTests.swift
+++ b/ios/OpenRingConnTests/BackgroundRefreshSchedulerTests.swift
@@ -1,0 +1,58 @@
+import BackgroundTasks
+import XCTest
+@testable import OpenRingConn
+
+final class BackgroundRefreshSchedulerTests: XCTestCase {
+    func testRequestUsesExpectedIdentifierAndFifteenMinuteEarliestBeginDate() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let scheduler = BackgroundRefreshScheduler(
+            scheduler: RecordingScheduler(),
+            now: { now }
+        )
+
+        let request = scheduler.makeRequest()
+
+        XCTAssertEqual(request.identifier, BackgroundRefreshScheduler.identifier)
+        XCTAssertEqual(
+            request.earliestBeginDate?.timeIntervalSince1970,
+            now.addingTimeInterval(15 * 60).timeIntervalSince1970
+        )
+    }
+
+    func testScheduleSubmitsRefreshRequest() {
+        let recording = RecordingScheduler()
+        let now = Date(timeIntervalSince1970: 2_000)
+        let scheduler = BackgroundRefreshScheduler(
+            scheduler: recording,
+            now: { now }
+        )
+
+        scheduler.schedule()
+
+        XCTAssertEqual(recording.cancelledIdentifier, BackgroundRefreshScheduler.identifier)
+        XCTAssertEqual(recording.submitted?.identifier, BackgroundRefreshScheduler.identifier)
+        XCTAssertEqual(
+            recording.submitted?.earliestBeginDate?.timeIntervalSince1970,
+            now.addingTimeInterval(15 * 60).timeIntervalSince1970
+        )
+    }
+}
+
+private final class RecordingScheduler: BGTaskScheduling {
+    private(set) var cancelledIdentifier: String?
+    private(set) var submitted: BGTaskRequest?
+
+    func register(forTaskWithIdentifier identifier: String,
+                  using queue: DispatchQueue?,
+                  launchHandler: @escaping (BGTask) -> Void) -> Bool {
+        true
+    }
+
+    func cancel(taskRequestWithIdentifier identifier: String) {
+        cancelledIdentifier = identifier
+    }
+
+    func submit(_ taskRequest: BGTaskRequest) throws {
+        submitted = taskRequest
+    }
+}

--- a/ios/OpenRingConnTests/HealthWatermarkTests.swift
+++ b/ios/OpenRingConnTests/HealthWatermarkTests.swift
@@ -1,0 +1,62 @@
+import SwiftData
+import XCTest
+import OpenRingKit
+@testable import OpenRingConn
+
+@MainActor
+final class HealthWatermarkTests: XCTestCase {
+    private func makeStore() throws -> LocalStore {
+        let container = try ModelContainer(
+            for: StoredSample.self, StoredCursor.self,
+            StoredSleepSummary.self, StoredDaily.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return LocalStore(container.mainContext)
+    }
+
+    private func hr(_ value: Double, _ t: TimeInterval) -> QuantitySample {
+        QuantitySample(kind: .heartRate, start: Date(timeIntervalSince1970: t), value: value)
+    }
+
+    /// The dashboard auto-persist (`ingest`) must NOT starve the Health write: samples
+    /// persisted for the dashboard still appear in `pendingHealthSamples` until they're
+    /// explicitly marked written. (Regression test for the shared-cursor bug.)
+    func testAutoPersistDoesNotStarveHealthWrite() throws {
+        let store = try makeStore()
+        _ = try store.ingest([hr(70, 100), hr(72, 200)])   // dashboard auto-persist
+
+        let pending = try store.pendingHealthSamples()
+        XCTAssertEqual(pending.map(\.value), [70, 72])
+    }
+
+    /// After a confirmed Health write the watermark advances, so the same samples aren't
+    /// offered again — but newer samples synced afterward still surface.
+    func testMarkWrittenAdvancesWatermark() throws {
+        let store = try makeStore()
+        _ = try store.ingest([hr(70, 100), hr(72, 200)])
+        let first = try store.pendingHealthSamples()
+        try store.markHealthWritten(first)
+
+        XCTAssertTrue(try store.pendingHealthSamples().isEmpty)
+
+        _ = try store.ingest([hr(75, 300)])
+        XCTAssertEqual(try store.pendingHealthSamples().map(\.value), [75])
+    }
+
+    /// An un-authorized / failed write leaves the watermark untouched, so the samples
+    /// backfill on the next flush (no data lost to a one-off Health failure).
+    func testUnwrittenSamplesBackfill() throws {
+        let store = try makeStore()
+        _ = try store.ingest([hr(70, 100)])
+        _ = try store.pendingHealthSamples()   // read but DON'T mark written
+
+        XCTAssertEqual(try store.pendingHealthSamples().map(\.value), [70])
+    }
+
+    /// Zero/placeholder values never go to Health.
+    func testZeroValuesExcluded() throws {
+        let store = try makeStore()
+        _ = try store.ingest([hr(0, 100), hr(70, 200)])
+        XCTAssertEqual(try store.pendingHealthSamples().map(\.value), [70])
+    }
+}

--- a/ios/OpenRingConnTests/HealthWatermarkTests.swift
+++ b/ios/OpenRingConnTests/HealthWatermarkTests.swift
@@ -8,7 +8,7 @@ final class HealthWatermarkTests: XCTestCase {
     private func makeStore() throws -> LocalStore {
         let container = try ModelContainer(
             for: StoredSample.self, StoredCursor.self,
-            StoredSleepSummary.self, StoredDaily.self,
+            StoredSleepSummary.self, StoredDaily.self, StoredNap.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         return LocalStore(container.mainContext)

--- a/ios/OpenRingConnTests/LocalStoreLaunchTests.swift
+++ b/ios/OpenRingConnTests/LocalStoreLaunchTests.swift
@@ -1,0 +1,31 @@
+import SwiftData
+import XCTest
+@testable import OpenRingConn
+
+@MainActor
+final class LocalStoreLaunchTests: XCTestCase {
+    func testLaunchSnapshotReadsLastKnownHeartRate() throws {
+        let container = try ModelContainer(
+            for: StoredSample.self, StoredCursor.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let context = container.mainContext
+        context.insert(StoredSample(
+            kindRaw: "heartRate",
+            start: Date(timeIntervalSince1970: 100),
+            end: Date(timeIntervalSince1970: 100),
+            value: 71
+        ))
+        context.insert(StoredSample(
+            kindRaw: "heartRate",
+            start: Date(timeIntervalSince1970: 200),
+            end: Date(timeIntervalSince1970: 200),
+            value: 74
+        ))
+        try context.save()
+
+        let snapshot = try LaunchSnapshot.load(from: LocalStore(context))
+
+        XCTAssertEqual(snapshot.lastHeartRate?.value, 74)
+    }
+}

--- a/ios/OpenRingConnTests/LocalStoreLaunchTests.swift
+++ b/ios/OpenRingConnTests/LocalStoreLaunchTests.swift
@@ -7,7 +7,7 @@ final class LocalStoreLaunchTests: XCTestCase {
     func testLaunchSnapshotReadsLastKnownHeartRate() throws {
         let container = try ModelContainer(
             for: StoredSample.self, StoredCursor.self,
-            StoredSleepSummary.self, StoredDaily.self,
+            StoredSleepSummary.self, StoredDaily.self, StoredNap.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         let context = container.mainContext

--- a/ios/OpenRingConnTests/LocalStoreLaunchTests.swift
+++ b/ios/OpenRingConnTests/LocalStoreLaunchTests.swift
@@ -7,6 +7,7 @@ final class LocalStoreLaunchTests: XCTestCase {
     func testLaunchSnapshotReadsLastKnownHeartRate() throws {
         let container = try ModelContainer(
             for: StoredSample.self, StoredCursor.self,
+            StoredSleepSummary.self, StoredDaily.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         let context = container.mainContext

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/BatteryTTE.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/BatteryTTE.swift
@@ -1,0 +1,78 @@
+// Battery time-to-empty estimate from a rolling discharge history (#86).
+//
+// Algorithm (pure, no BLE):
+//   1. Sort samples by time and extract the strictly-DISCHARGING window (percent falls
+//      monotonically). Any rising run (charging) resets the window — we want a clean
+//      discharge slope. A flat run is skipped.
+//   2. Require drop ≥ 2 pp across the window (below that it's noise from the sensor's
+//      1 % granularity) and at least 2 samples.
+//   3. Compute rate = drop / elapsed_hours.
+//   4. Guard rate ≤ 50 %/hr — higher implies a charger was plugged/unplugged mid-window
+//      and the slope is garbage.
+//   5. TTE = last_percent / rate × 3600 seconds.
+//
+// All `now` parameters are explicit so tests are deterministic.
+
+import Foundation
+
+public enum BatteryTTE {
+
+    // MARK: - Sample
+
+    public struct Sample: Equatable, Sendable {
+        public let percent: Int
+        public let at: Date
+        public init(percent: Int, at: Date) { self.percent = percent; self.at = at }
+    }
+
+    // MARK: - Core estimate
+
+    /// Seconds until the battery reaches 0 %, or nil when the window is too noisy /
+    /// too small / actively charging / implausible.
+    public static func timeToEmpty(_ samples: [Sample], now: Date = Date()) -> TimeInterval? {
+        guard samples.count >= 2 else { return nil }
+
+        // Build the longest trailing strictly-discharging window.
+        let sorted = samples.sorted { $0.at < $1.at }
+        var window: [Sample] = []
+        for s in sorted {
+            if let prev = window.last {
+                if s.percent < prev.percent {
+                    window.append(s)
+                } else if s.percent > prev.percent {
+                    // Rising sample (charging) — reset the window; start fresh at this point.
+                    window = [s]
+                }
+                // Flat (equal) — skip; neither confirms discharge nor resets.
+            } else {
+                window.append(s)
+            }
+        }
+
+        guard window.count >= 2 else { return nil }
+        let first = window.first!
+        let last  = window.last!
+        let drop    = Double(first.percent - last.percent)
+        let elapsed = last.at.timeIntervalSince(first.at)   // seconds
+        guard drop >= 2, elapsed > 0 else { return nil }
+
+        let ratePerHour = drop / (elapsed / 3_600)
+        guard ratePerHour <= 50 else { return nil }          // implausible — charger event
+
+        let tte = Double(last.percent) / ratePerHour * 3_600
+        return tte > 0 ? tte : nil
+    }
+
+    /// The estimated wall-clock time at which the battery reaches 0 %, or nil.
+    public static func estimatedDepletionDate(_ samples: [Sample], now: Date = Date()) -> Date? {
+        guard let tte = timeToEmpty(samples, now: now) else { return nil }
+        return now.addingTimeInterval(tte)
+    }
+
+    /// True when the battery just crossed 100 % WHILE the ring is inferred to be on the
+    /// charger AND we haven't already fired a "full" notification for this charge cycle.
+    /// Callers set `wasFull = false` when percent drops below 100 to re-arm.
+    public static func justReachedFull(percent: Int, inferredCharging: Bool, wasFull: Bool) -> Bool {
+        percent >= 100 && inferredCharging && !wasFull
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/Calories.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/Calories.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public struct HRSample: Equatable, Codable, Sendable {
+    public let bpm: Int
+    public let start: Date
+    public let end: Date
+
+    public init(bpm: Int, start: Date, end: Date? = nil) {
+        self.bpm = bpm
+        self.start = start
+        self.end = end ?? start
+    }
+}
+
+public enum Calories {
+    public static let trimpKcalFactor = 5.0
+    public static let defaultRestingHR = 60
+
+    public static func bmrKcalPerDay(profile: UserProfile) -> Double {
+        let base = (10.0 * profile.weightKg)
+            + (6.25 * profile.heightCm)
+            - (5.0 * Double(profile.age))
+        switch profile.sex {
+        case .male: return base + 5.0
+        case .female: return base - 161.0
+        }
+    }
+
+    public static func bmrKcalPerHour(profile: UserProfile) -> Double {
+        bmrKcalPerDay(profile: profile) / 24.0
+    }
+
+    public static func activeKcal(hrSamples: [HRSample], maxHR: Int) -> Double {
+        guard let trimp = Strain.edwardsTRIMP(
+            hrSamples: hrSamples,
+            maxHR: maxHR,
+            restingHR: defaultRestingHR
+        ) else {
+            return 0.0
+        }
+        return trimp * trimpKcalFactor
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/CyclePredictor.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/CyclePredictor.swift
@@ -156,18 +156,27 @@ public enum CyclePredictor {
     ///   - skinTempDeviations: Optional nightly signed offsets (°C above baseline)
     ///     from `SkinTempBaseline.offset`. Used as a SOFT corroboration signal only —
     ///     clearly labeled as such in the UI. Pass `[]` when unavailable.
+    ///   - now: Reference "present" used to roll the prediction forward (injected for
+    ///     deterministic tests). The next period is always in the future relative to this.
     ///
     /// - Returns: `nil` when fewer than `minPeriodsForPrediction` valid cycles exist.
     public static func predict(
         from periods: [PeriodEntry],
-        skinTempDeviations: [(night: Date, offsetC: Double)] = []
+        skinTempDeviations: [(night: Date, offsetC: Double)] = [],
+        now: Date = Date()
     ) -> CyclePrediction? {
         guard let stats = cycleStats(from: periods) else { return nil }
         let sorted = periods.sorted { $0.start < $1.start }
         guard let lastPeriod = sorted.last else { return nil }
 
         let cycleInterval = stats.avgCycleLengthDays * 86_400
-        let nextStart = lastPeriod.start.addingTimeInterval(cycleInterval)
+        // One cycle after the last LOGGED period — then roll forward by whole cycles until it
+        // is in the future, so a user who stopped logging for ≥1 cycle still sees the NEXT
+        // period (and a future fertile/ovulation window) rather than a date already elapsed.
+        var nextStart = lastPeriod.start.addingTimeInterval(cycleInterval)
+        if cycleInterval > 0 {
+            while nextStart < now { nextStart = nextStart.addingTimeInterval(cycleInterval) }
+        }
 
         let durationDays = stats.avgPeriodDurationDays ?? 5.0   // default 5 days
         let nextEnd = nextStart.addingTimeInterval(durationDays * 86_400)

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/CyclePredictor.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/CyclePredictor.swift
@@ -1,0 +1,242 @@
+// Analytics/CyclePredictor.swift — Women's health cycle prediction (#78).
+//
+// Pure math: rolling average cycle length from logged period history,
+// next-period date, fertile/ovulation window, and an optional soft
+// skin-temperature corroboration signal.
+//
+// IMPORTANT: All outputs are ESTIMATES only.
+// This is NOT a medical device; outputs are NOT a basis for contraception
+// or medical decisions. Label all predictions in the UI.
+//
+// Skin-temp integration: a post-ovulation BBT rise (typically +0.2–0.5 °C,
+// APK: "temperature fluctuations may affect the accuracy of the prediction"
+// pp.txt:46113) is used as a SOFT corroboration signal only — it never
+// overrides the calendar estimate. Requires SkinTempBaseline data from #69.
+
+import Foundation
+
+public enum CyclePredictor {
+
+    // MARK: Constants
+
+    /// Minimum logged period starts (separate cycles) before predicting.
+    /// Two is the minimum to derive one cycle length; three gives a first average.
+    public static let minPeriodsForPrediction = 2
+
+    /// Typical luteal phase used when estimating ovulation from the predicted
+    /// next period. Clinical mean ≈ 14 days; individual range 12–16. We use 14.
+    public static let lutealPhaseDays = 14
+
+    /// Days before ovulation included in the fertile window (+ ovulation day = 6 days total).
+    public static let fertileWindowDaysBeforeOvulation = 5
+
+    /// Minimum sane cycle length (days). Intervals shorter than this are excluded
+    /// as likely logging errors or back-to-back partial entries.
+    public static let minCycleLengthDays = 21
+
+    /// Maximum sane cycle length (days). Intervals longer than this are excluded
+    /// (likely a skipped log rather than a true 46+ day cycle).
+    public static let maxCycleLengthDays = 45
+
+    /// Skin-temp offset (°C above baseline) required to count as a "post-ovulation
+    /// rise" data point for the soft corroboration signal.
+    public static let tempRiseCorroborationC: Double = 0.2
+
+    /// Number of nights with a qualifying temp rise needed to set `tempCorroborated`.
+    /// Require two nights to reduce single-reading noise.
+    public static let tempRiseNightsRequired = 2
+
+    // MARK: Input types
+
+    /// One manually-logged period entry.
+    public struct PeriodEntry: Equatable, Sendable {
+        /// First day of the period (required).
+        public let start: Date
+        /// Last day of the period (optional — user may not log end immediately).
+        public let end: Date?
+
+        public init(start: Date, end: Date? = nil) {
+            self.start = start
+            self.end = end
+        }
+    }
+
+    // MARK: Output types
+
+    /// Descriptive statistics derived from logged cycle history.
+    public struct CycleStats: Equatable, Sendable {
+        /// Rolling mean cycle length (days) from the valid inter-period intervals.
+        public let avgCycleLengthDays: Double
+        /// Number of complete cycle intervals used (always ≥ 1).
+        public let sampleCount: Int
+        /// Mean period duration (days) from completed (start + end) entries, or nil.
+        public let avgPeriodDurationDays: Double?
+
+        public init(avgCycleLengthDays: Double, sampleCount: Int,
+                    avgPeriodDurationDays: Double?) {
+            self.avgCycleLengthDays = avgCycleLengthDays
+            self.sampleCount = sampleCount
+            self.avgPeriodDurationDays = avgPeriodDurationDays
+        }
+    }
+
+    /// ESTIMATE — predicted next period + fertile/ovulation window.
+    /// All dates are statistical estimates; label them clearly in the UI.
+    public struct CyclePrediction: Equatable, Sendable {
+        /// Predicted first day of the next period (ESTIMATE).
+        public let nextPeriodStart: Date
+        /// Predicted last day of the next period (ESTIMATE — start + avg duration).
+        public let nextPeriodEnd: Date
+        /// Predicted fertile window start (ESTIMATE — ovulation − 5 days).
+        public let fertileWindowStart: Date
+        /// Predicted fertile window end = ovulation day (ESTIMATE).
+        public let fertileWindowEnd: Date
+        /// Predicted ovulation day (ESTIMATE — nextPeriodStart − lutealPhaseDays).
+        public let ovulationEstimate: Date
+        /// Average cycle length used for this prediction (days).
+        public let avgCycleLengthDays: Double
+        /// True when skin-temp data shows a qualifying rise near the predicted ovulation
+        /// window (soft corroboration signal only — labeled as such in the UI).
+        public let tempCorroborated: Bool
+
+        public init(nextPeriodStart: Date, nextPeriodEnd: Date,
+                    fertileWindowStart: Date, fertileWindowEnd: Date,
+                    ovulationEstimate: Date, avgCycleLengthDays: Double,
+                    tempCorroborated: Bool) {
+            self.nextPeriodStart = nextPeriodStart
+            self.nextPeriodEnd = nextPeriodEnd
+            self.fertileWindowStart = fertileWindowStart
+            self.fertileWindowEnd = fertileWindowEnd
+            self.ovulationEstimate = ovulationEstimate
+            self.avgCycleLengthDays = avgCycleLengthDays
+            self.tempCorroborated = tempCorroborated
+        }
+    }
+
+    // MARK: Core functions
+
+    /// Compute rolling cycle statistics from logged period history.
+    ///
+    /// Periods are sorted by start internally; inter-period intervals outside
+    /// `[minCycleLengthDays, maxCycleLengthDays]` are excluded as likely errors.
+    /// Returns `nil` when fewer than `minPeriodsForPrediction` valid cycles exist.
+    public static func cycleStats(from periods: [PeriodEntry]) -> CycleStats? {
+        let sorted = periods.sorted { $0.start < $1.start }
+        guard sorted.count >= minPeriodsForPrediction else { return nil }
+
+        var intervals: [Double] = []
+        for i in 1 ..< sorted.count {
+            let days = sorted[i].start.timeIntervalSince(sorted[i - 1].start) / 86_400
+            if days >= Double(minCycleLengthDays) && days <= Double(maxCycleLengthDays) {
+                intervals.append(days)
+            }
+        }
+        guard !intervals.isEmpty else { return nil }
+
+        let avgCycle = intervals.reduce(0, +) / Double(intervals.count)
+
+        // Average period duration — only from entries with both start and end.
+        let completedDurations: [Double] = sorted.compactMap { e in
+            guard let end = e.end else { return nil }
+            let d = end.timeIntervalSince(e.start) / 86_400
+            return (d >= 1 && d <= 10) ? d : nil   // sanity: 1–10 day periods
+        }
+        let avgDuration = completedDurations.isEmpty ? nil
+            : completedDurations.reduce(0, +) / Double(completedDurations.count)
+
+        return CycleStats(avgCycleLengthDays: avgCycle,
+                          sampleCount: intervals.count,
+                          avgPeriodDurationDays: avgDuration)
+    }
+
+    /// Predict next period + fertile/ovulation window from logged history.
+    ///
+    /// - Parameters:
+    ///   - periods: All logged period entries (in any order; sorted internally).
+    ///   - skinTempDeviations: Optional nightly signed offsets (°C above baseline)
+    ///     from `SkinTempBaseline.offset`. Used as a SOFT corroboration signal only —
+    ///     clearly labeled as such in the UI. Pass `[]` when unavailable.
+    ///
+    /// - Returns: `nil` when fewer than `minPeriodsForPrediction` valid cycles exist.
+    public static func predict(
+        from periods: [PeriodEntry],
+        skinTempDeviations: [(night: Date, offsetC: Double)] = []
+    ) -> CyclePrediction? {
+        guard let stats = cycleStats(from: periods) else { return nil }
+        let sorted = periods.sorted { $0.start < $1.start }
+        guard let lastPeriod = sorted.last else { return nil }
+
+        let cycleInterval = stats.avgCycleLengthDays * 86_400
+        let nextStart = lastPeriod.start.addingTimeInterval(cycleInterval)
+
+        let durationDays = stats.avgPeriodDurationDays ?? 5.0   // default 5 days
+        let nextEnd = nextStart.addingTimeInterval(durationDays * 86_400)
+
+        // Ovulation = predicted next period start − luteal phase (14 days).
+        let ovulation = nextStart.addingTimeInterval(-Double(lutealPhaseDays) * 86_400)
+        // Fertile window: 5 days before ovulation up to and including ovulation day.
+        let fertileStart = ovulation.addingTimeInterval(-Double(fertileWindowDaysBeforeOvulation) * 86_400)
+
+        // Skin-temp corroboration: look for ≥ tempRiseNightsRequired nights with
+        // offsetC ≥ tempRiseCorroborationC in a ±3-day window around predicted ovulation.
+        // "temperature fluctuations may affect the accuracy of the prediction" (APK).
+        // This is labeled as a SOFT signal — it cannot confirm ovulation occurred.
+        let corrobWindowStart = ovulation.addingTimeInterval(-3 * 86_400)
+        let corrobWindowEnd   = ovulation.addingTimeInterval( 3 * 86_400)
+        let risingNights = skinTempDeviations.filter {
+            $0.night >= corrobWindowStart
+            && $0.night <= corrobWindowEnd
+            && $0.offsetC >= tempRiseCorroborationC
+        }.count
+        let corroborated = risingNights >= tempRiseNightsRequired
+
+        return CyclePrediction(
+            nextPeriodStart:    nextStart,
+            nextPeriodEnd:      nextEnd,
+            fertileWindowStart: fertileStart,
+            fertileWindowEnd:   ovulation,      // fertile window ends on ovulation day
+            ovulationEstimate:  ovulation,
+            avgCycleLengthDays: stats.avgCycleLengthDays,
+            tempCorroborated:   corroborated
+        )
+    }
+
+    // MARK: Day-classification helpers
+
+    /// Whether `date` falls within a logged period (start…end, inclusive on both ends).
+    /// When `end` is nil, considers only the single start day logged.
+    public static func isLoggedPeriodDay(_ date: Date, entries: [PeriodEntry],
+                                         calendar: Calendar = .current) -> Bool {
+        let day = calendar.startOfDay(for: date)
+        for entry in entries {
+            let start = calendar.startOfDay(for: entry.start)
+            let end = entry.end.map { calendar.startOfDay(for: $0) } ?? start
+            if day >= start && day <= end { return true }
+        }
+        return false
+    }
+
+    /// Whether `date` falls within the predicted period (inclusive).
+    public static func isInPredictedPeriod(_ date: Date, prediction: CyclePrediction,
+                                            calendar: Calendar = .current) -> Bool {
+        let day = calendar.startOfDay(for: date)
+        let s = calendar.startOfDay(for: prediction.nextPeriodStart)
+        let e = calendar.startOfDay(for: prediction.nextPeriodEnd)
+        return day >= s && day <= e
+    }
+
+    /// Whether `date` falls within the predicted fertile window (inclusive).
+    public static func isInFertileWindow(_ date: Date, prediction: CyclePrediction,
+                                          calendar: Calendar = .current) -> Bool {
+        let day = calendar.startOfDay(for: date)
+        let s = calendar.startOfDay(for: prediction.fertileWindowStart)
+        let e = calendar.startOfDay(for: prediction.fertileWindowEnd)
+        return day >= s && day <= e
+    }
+
+    /// Whether `date` is the predicted ovulation day.
+    public static func isOvulationDay(_ date: Date, prediction: CyclePrediction,
+                                       calendar: Calendar = .current) -> Bool {
+        calendar.isDate(date, inSameDayAs: prediction.ovulationEstimate)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/DistanceEstimate.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/DistanceEstimate.swift
@@ -1,0 +1,43 @@
+// Estimate walking/running distance from decoded step count × stride length (#81).
+//
+// Stride length is derived from the user's height and biological sex using standard
+// anthropometric ratios (ACSM reference). This is an ESTIMATE — NOT GPS distance and
+// NOT decoded device distance. Labeled as such in HealthKit metadata and UI.
+//
+// HealthKit target: `.distanceWalkingRunning` (written by HealthKitWriter, not stored
+// as a ring sample in LocalStore).
+//
+// Replaced by true decoded distance once the 0x4c activity-epoch [15:22] payload is
+// decoded (#93) — that payload carries `HistoryActivitySyncInfo.distance`.
+
+import Foundation
+
+public enum DistanceEstimate {
+
+    /// Stride length ratio (step / height) for walking, by sex.
+    /// Source: ACSM walking stride-length normative data.
+    /// Male:   ~0.415 × height
+    /// Female: ~0.413 × height
+    static let strideRatioMale   = 0.415
+    static let strideRatioFemale = 0.413
+
+    /// Estimated stride length in centimetres from height and sex.
+    public static func strideCm(heightCm: Double, sex: BiologicalSex) -> Double {
+        let ratio = sex == .male ? strideRatioMale : strideRatioFemale
+        return max(heightCm, 0) * ratio
+    }
+
+    /// Estimated distance in metres from step count and user profile.
+    /// Returns 0 for non-positive step counts.
+    /// ESTIMATE — height-based stride, not GPS or decoded ring data.
+    public static func meters(steps: Int, profile: UserProfile) -> Double {
+        guard steps > 0 else { return 0 }
+        return Double(steps) * strideCm(heightCm: profile.heightCm, sex: profile.sex) / 100.0
+    }
+
+    /// Convenience overload with explicit height and sex.
+    public static func meters(steps: Int, heightCm: Double, sex: BiologicalSex) -> Double {
+        guard steps > 0 else { return 0 }
+        return Double(steps) * strideCm(heightCm: heightCm, sex: sex) / 100.0
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/ExerciseMinutes.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/ExerciseMinutes.swift
@@ -30,9 +30,16 @@ public enum ExerciseMinutes {
     ///
     /// Algorithm:
     /// 1. Filter to samples with HR ≥ threshold and outside the sleep window.
-    /// 2. Map each sample to an interval [start, max(end, start+epochSeconds)] — point
-    ///    samples (start==end) get a one-epoch width so a single elevated bulk record
-    ///    contributes its full epoch instead of 0 seconds.
+    /// 2. Map each sample to an interval. Samples with a real span (end > start) use it
+    ///    directly. POINT samples (start == end) are ambiguous on the wire: a 0x4c bulk
+    ///    sleep-vitals epoch genuinely spans `epochSeconds`, but a live-HR spot read
+    ///    (RingSession persists these as point samples too) represents only an instant.
+    ///    To keep the bulk-epoch behavior without letting one isolated non-exercise spot
+    ///    read inflate the Apple Exercise ring by a full 2.5 min, a point sample gets the
+    ///    full `epochSeconds` width ONLY when it is part of a run of ≥2 consecutive
+    ///    elevated readings spaced within one epoch (back-to-back bulk epochs / sustained
+    ///    elevated HR). An ISOLATED elevated point read gets only `pointSampleWidth`
+    ///    (default 0 — a single spot read is not evidence of voluntary exercise).
     /// 3. Merge overlapping intervals so consecutive elevated epochs are counted once.
     /// 4. Return the sum of merged interval durations in minutes.
     ///
@@ -41,7 +48,8 @@ public enum ExerciseMinutes {
         hrSamples: [HRSample],
         maxHR: Int,
         sleepWindow: DateInterval? = nil,
-        epochSeconds: TimeInterval = TimeInterval(BulkRecord.epochSeconds)
+        epochSeconds: TimeInterval = TimeInterval(BulkRecord.epochSeconds),
+        pointSampleWidth: TimeInterval = 0
     ) -> Double {
         let thresh = threshold(maxHR: maxHR)
         let elevated = hrSamples
@@ -53,11 +61,18 @@ public enum ExerciseMinutes {
 
         guard !elevated.isEmpty else { return 0 }
 
-        // Build intervals: point samples get one epoch width.
-        let intervals: [(Date, Date)] = elevated.map { s in
+        // Build intervals. Real-span samples use their own duration. A point sample gets a
+        // full epoch only when it neighbours another elevated reading within one epoch
+        // (a sustained run); an isolated point read gets only `pointSampleWidth`.
+        let intervals: [(Date, Date)] = elevated.enumerated().map { idx, s in
             let dur = s.end.timeIntervalSince(s.start)
-            let end = dur > 0 ? s.end : s.start.addingTimeInterval(epochSeconds)
-            return (s.start, end)
+            if dur > 0 { return (s.start, s.end) }
+            let prevClose = idx > 0
+                && s.start.timeIntervalSince(elevated[idx - 1].start) <= epochSeconds
+            let nextClose = idx < elevated.count - 1
+                && elevated[idx + 1].start.timeIntervalSince(s.start) <= epochSeconds
+            let width = (prevClose || nextClose) ? epochSeconds : pointSampleWidth
+            return (s.start, s.start.addingTimeInterval(width))
         }
 
         // Merge overlapping / adjacent intervals.

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/ExerciseMinutes.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/ExerciseMinutes.swift
@@ -1,0 +1,77 @@
+// Estimate Apple Exercise Time (elevated-HR minutes) from stored HR samples (#82).
+//
+// SCOPE — BASIC ESTIMATE ONLY.
+// A basic threshold model: minutes where HR ≥ 50% of max HR (equivalent to brisk
+// walking, Apple's own exercise definition). This estimate uses ONLY the decoded
+// HR samples we have — sleep-window bulk epochs (0x4c[4], 🟢) and live monitoring
+// readings — and EXCLUDES the overnight sleep window to avoid counting sleeping
+// elevated HR as voluntary exercise.
+//
+// ⚠️ The FULL 4-level intensity mapping (Vigorous/Moderate/Low/Inactive minutes)
+// is GATED on the activity-epoch decode (#93). That payload at 0x4c[15:22] carries
+// the true per-epoch activity intensity; do NOT invent 4 intensity buckets from
+// the basic HR threshold alone. This file is the basic-threshold placeholder only.
+//
+// HealthKit target: `.appleExerciseTime` (written by HealthKitWriter as a delta,
+// not stored as a ring sample in LocalStore).
+
+import Foundation
+
+public enum ExerciseMinutes {
+
+    /// HR threshold for exercise: ≥ 50% of max HR (brisk-walking equivalent).
+    /// NOTE: Full 4-level intensity (Vigorous/Moderate/Low/Inactive) follows #93 decode.
+    public static func threshold(maxHR: Int) -> Int {
+        return max(Int(Double(max(maxHR, 1)) * 0.5), 60)
+    }
+
+    /// Estimate exercise minutes as the total merged duration of elevated-HR intervals,
+    /// excluding samples that fall inside a sleep window.
+    ///
+    /// Algorithm:
+    /// 1. Filter to samples with HR ≥ threshold and outside the sleep window.
+    /// 2. Map each sample to an interval [start, max(end, start+epochSeconds)] — point
+    ///    samples (start==end) get a one-epoch width so a single elevated bulk record
+    ///    contributes its full epoch instead of 0 seconds.
+    /// 3. Merge overlapping intervals so consecutive elevated epochs are counted once.
+    /// 4. Return the sum of merged interval durations in minutes.
+    ///
+    /// ESTIMATE — based on available HR samples only. Accuracy improves after #93 decode.
+    public static func estimate(
+        hrSamples: [HRSample],
+        maxHR: Int,
+        sleepWindow: DateInterval? = nil,
+        epochSeconds: TimeInterval = TimeInterval(BulkRecord.epochSeconds)
+    ) -> Double {
+        let thresh = threshold(maxHR: maxHR)
+        let elevated = hrSamples
+            .filter { s in
+                s.bpm >= thresh
+                    && (sleepWindow.map { !$0.contains(s.start) } ?? true)
+            }
+            .sorted { $0.start < $1.start }
+
+        guard !elevated.isEmpty else { return 0 }
+
+        // Build intervals: point samples get one epoch width.
+        let intervals: [(Date, Date)] = elevated.map { s in
+            let dur = s.end.timeIntervalSince(s.start)
+            let end = dur > 0 ? s.end : s.start.addingTimeInterval(epochSeconds)
+            return (s.start, end)
+        }
+
+        // Merge overlapping / adjacent intervals.
+        var merged: [(Date, Date)] = [intervals[0]]
+        for (start, end) in intervals.dropFirst() {
+            if start <= merged[merged.count - 1].1 {
+                let last = merged[merged.count - 1]
+                merged[merged.count - 1] = (last.0, max(end, last.1))
+            } else {
+                merged.append((start, end))
+            }
+        }
+
+        let totalSeconds = merged.reduce(0.0) { $0 + $1.1.timeIntervalSince($1.0) }
+        return totalSeconds / 60.0
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/NapDetection.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/NapDetection.swift
@@ -1,0 +1,90 @@
+// Automatic nap detection — #76.
+//
+// The ring auto-recognises naps longer than 15 minutes and folds them into daily sleep totals
+// (APK: pp.txt:47434 "automatically recognize and record your naps that are longer than 15
+// minutes"; `SleepNapModel(start,end,isLongNap,sleepPhases,isEdited)` pp.txt:b3458). We detect
+// the same daytime sleep from the SAME motion signal `SleepDetection` already uses — reusing
+// `ActivityPeriod.detectFromMotion` over the day's 0x4c `[10:15]` motion 🟢 — then keep only
+// stillness blocks that are (a) ≥ 15 min, (b) NOT the main overnight sleep, and (c) daytime
+// (a non-overnight midpoint, via `SleepWindow.isOvernightBlock`). That last gate is what keeps
+// naps from double-counting against the main night.
+
+import Foundation
+
+public enum NapDetection {
+
+    /// Minimum length for a stillness block to count as a nap (APK: 15 min).
+    public static let minNapDuration: TimeInterval = 15 * 60
+    /// A daytime block longer than this is more likely a long sedentary period (a movie, a long
+    /// meeting) than a nap; still recorded, but flagged `isLongNap` for the UI to caveat. The app
+    /// carries the same `isLongNap` distinction.
+    public static let longNapDuration: TimeInterval = 3 * 60 * 60
+
+    public struct Nap: Equatable, Sendable {
+        public let start: Date
+        public let end: Date
+        public let segments: [SleepSegment]    // inBed + asleep/awake sub-segments for HealthKit
+        public init(start: Date, end: Date, segments: [SleepSegment]) {
+            self.start = start; self.end = end; self.segments = segments
+        }
+        public var duration: TimeInterval { end.timeIntervalSince(start) }
+        public var isLongNap: Bool { duration >= NapDetection.longNapDuration }
+        /// Time actually asleep within the nap (asleep sub-segments only).
+        public var asleep: TimeInterval {
+            segments.filter { $0.stage == .asleepCore || $0.stage == .asleepDeep || $0.stage == .asleepREM }
+                .reduce(0) { $0 + $1.duration }
+        }
+    }
+
+    /// Detect daytime naps from a day's records, excluding whatever overlaps the main overnight
+    /// sleep block. Pass the already-detected `mainSleep` (e.g. `BulkSleep.mainSleep`) so a nap
+    /// can never overlap it; pass `temperatures` to apply the same off-wrist/charging wear gate
+    /// the night uses (#41). Naps are returned in chronological order.
+    public static func naps(from records: [BulkRecord],
+                            mainSleep: ActivityPeriod?,
+                            temperatures: [TemperatureSample] = [],
+                            epoch: Int = Command.syncEpoch) -> [Nap] {
+        let timeline = BulkSleep.motionTimeline(from: records, epoch: epoch)
+        let periods = ActivityPeriod.detectFromMotion(timeline, temperatureSamples: temperatures)
+
+        return periods.compactMap { p -> Nap? in
+            guard p.activity == .sleep else { return nil }
+            guard p.duration >= minNapDuration else { return nil }
+            // Exclude the main overnight sleep (and anything overlapping it) — no double-count.
+            if let main = mainSleep, p.start < main.end && p.end > main.start { return nil }
+            // Daytime only: a block whose MIDPOINT is at night is (another) night/long sleep,
+            // not a nap — reuse the overnight-block test (inverted) so the rule matches the
+            // main-night gate exactly.
+            if SleepWindow.isOvernightBlock(start: p.start, end: p.end) { return nil }
+
+            let segs = napSegments(from: records, period: p, epoch: epoch)
+            return Nap(start: p.start, end: p.end, segments: segs)
+        }
+        .sorted { $0.start < $1.start }
+    }
+
+    /// Coarse HealthKit segments for a nap: an `inBed` span plus the asleep/awake sub-blocks
+    /// detected inside it (same shape as `BulkSleep.sleepSegments`, scoped to the nap window).
+    private static func napSegments(from records: [BulkRecord],
+                                    period: ActivityPeriod,
+                                    epoch: Int) -> [SleepSegment] {
+        let inWindow = records.filter {
+            let t = $0.date(epoch: epoch)
+            return t >= period.start && t <= period.end
+        }
+        let timeline = BulkSleep.motionTimeline(from: inWindow, epoch: epoch)
+        let periods = ActivityPeriod.detectFromMotion(timeline)
+        var segs = [SleepSegment(start: period.start, end: period.end, stage: .inBed)]
+        for p in periods where p.start < period.end && p.end > period.start {
+            let s = max(p.start, period.start), e = min(p.end, period.end)
+            if e <= s { continue }
+            segs.append(SleepSegment(start: s, end: e,
+                                     stage: p.activity == .sleep ? .asleepCore : .awake))
+        }
+        // No interior detection (e.g. a short uniform nap) → treat the whole window as asleep.
+        if segs.count == 1 {
+            segs.append(SleepSegment(start: period.start, end: period.end, stage: .asleepCore))
+        }
+        return segs
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/RestingHR.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/RestingHR.swift
@@ -1,0 +1,119 @@
+// Resting heart rate (daily) — derived on-device; the ring does not report it (#18, #37).
+//
+// Two tiers, in preference order:
+//   1. Sleep mean — the average HR across the night's `asleep*` segments. Sleeping HR is
+//      the most stable, least motion-contaminated signal, so its mean is the best single
+//      resting estimate when sleep staging is available.
+//   2. Lowest sustained — the minimum of a rolling `window`-length mean (default 5 min).
+//      This mirrors the convention Apple Health uses for its own resting-HR estimate
+//      (lowest sustained HR during inactivity), so our value sits alongside Apple's on a
+//      comparable basis. Requiring a multi-reading window rejects single-reading dips.
+//
+// Pure value-type math (no HealthKit / device types) so it unit-tests on macOS.
+
+import Foundation
+
+public enum RestingHR {
+    /// Shortest span over which a depressed HR counts as "sustained" rather than a
+    /// transient dip — 5 minutes, matching Apple Health's resting-HR convention.
+    public static let sustainedWindow: TimeInterval = 5 * 60
+    /// Floor on the sleep-mean path: fewer asleep readings than this is too thin to trust as
+    /// a night's resting value, so we fall back to the low-activity method instead.
+    public static let minSleepSamples = 3
+
+    /// One day's resting-HR estimate in bpm, or nil when there are no readings at all.
+    /// `sleep` should be the segments overlapping this day; only `asleep*` stages count
+    /// (in-bed/awake carry motion and arousals and are excluded).
+    public static func value(
+        hr: [HRSample],
+        sleep: [SleepSegment] = [],
+        window: TimeInterval = sustainedWindow,
+        minSleepSamples: Int = minSleepSamples
+    ) -> Double? {
+        if let asleepMean = sleepMean(hr: hr, sleep: sleep, minSleepSamples: minSleepSamples) {
+            return asleepMean
+        }
+        return lowestSustained(hr: hr, window: window)
+    }
+
+    /// Mean HR of readings that fall inside an `asleep*` segment; nil below the floor or
+    /// when there are no asleep segments.
+    static func sleepMean(hr: [HRSample], sleep: [SleepSegment], minSleepSamples: Int) -> Double? {
+        let asleep = sleep.filter { isAsleep($0.stage) }
+        guard !asleep.isEmpty else { return nil }
+        let inSleep = hr.filter { s in
+            asleep.contains { seg in s.start >= seg.start && s.start < seg.end }
+        }
+        guard inSleep.count >= minSleepSamples else { return nil }
+        return mean(inSleep)
+    }
+
+    /// Lowest rolling `window`-mean across the readings. Each window is anchored at a
+    /// reading and must hold ≥2 readings to count as "sustained"; if no window qualifies
+    /// (all readings isolated) we fall back to the single lowest reading. nil if empty.
+    static func lowestSustained(hr: [HRSample], window: TimeInterval) -> Double? {
+        guard !hr.isEmpty else { return nil }
+        let sorted = hr.sorted { $0.start < $1.start }
+        var best: Double?
+        for i in sorted.indices {
+            let cutoff = sorted[i].start.addingTimeInterval(window)
+            var bucket: [HRSample] = []
+            var j = i
+            while j < sorted.count, sorted[j].start < cutoff {
+                bucket.append(sorted[j]); j += 1
+            }
+            guard bucket.count >= 2 || sorted.count == 1 else { continue }
+            let m = mean(bucket)
+            best = best.map { Swift.min($0, m) } ?? m
+        }
+        // Readings existed but none formed a sustained window (all isolated): fall back to
+        // the single lowest reading so the day still produces a value.
+        if best == nil { best = sorted.map { Double($0.bpm) }.min() }
+        return best
+    }
+
+    /// Per-calendar-day resting HR over a span of readings, oldest day first. HR is bucketed
+    /// by the local day of each reading's start; `sleep` segments are matched to a day by
+    /// temporal overlap (so an early-morning night lands on the day you woke). Days with no
+    /// readings are omitted.
+    public struct DailyValue: Equatable, Sendable {
+        public let day: Date    // start-of-day (in `calendar`)
+        public let bpm: Double
+        public init(day: Date, bpm: Double) { self.day = day; self.bpm = bpm }
+    }
+
+    public static func dailyValues(
+        hr: [HRSample],
+        sleep: [SleepSegment] = [],
+        calendar: Calendar = .current,
+        window: TimeInterval = sustainedWindow,
+        minSleepSamples: Int = minSleepSamples
+    ) -> [DailyValue] {
+        guard !hr.isEmpty else { return [] }
+        let byDay = Dictionary(grouping: hr) { calendar.startOfDay(for: $0.start) }
+        var out: [DailyValue] = []
+        for day in byDay.keys.sorted() {
+            let dayHR = byDay[day] ?? []
+            let dayEnd = calendar.date(byAdding: .day, value: 1, to: day)
+                ?? day.addingTimeInterval(86_400)
+            let daySleep = sleep.filter { $0.start < dayEnd && $0.end > day }
+            if let v = value(hr: dayHR, sleep: daySleep, window: window,
+                             minSleepSamples: minSleepSamples) {
+                out.append(DailyValue(day: day, bpm: v))
+            }
+        }
+        return out
+    }
+
+    private static func isAsleep(_ stage: SleepStage) -> Bool {
+        switch stage {
+        case .asleepCore, .asleepDeep, .asleepREM: return true
+        case .inBed, .awake: return false
+        }
+    }
+
+    private static func mean(_ samples: [HRSample]) -> Double {
+        guard !samples.isEmpty else { return 0 }
+        return samples.reduce(0.0) { $0 + Double($1.bpm) } / Double(samples.count)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SkinTempBaseline.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SkinTempBaseline.swift
@@ -1,0 +1,148 @@
+// Sleeping skin-temperature baseline + nightly deviation (Oura-style) — #69.
+//
+// The signature ring feature: each night's MEAN sleeping skin temperature, a signed
+// DEVIATION from a rolling baseline (the app uses the previous 30 nights), and a
+// normal/abnormal classification. The APK's own copy (pp.txt:47432) defines it exactly:
+//   "the baseline represents the average sleeping skin temperature of the previous 30
+//    days … Temperatures within 1°C (1.8°F) of the baseline are considered normal."
+//
+// Skin temp is decoded 🟢 (0.1 °C, descriptor 0x10/0x87 — PROTOCOL §5.4) but rides the
+// LIVE descriptor, not the bulk 0x4c/0x47 drain — so a nightly value depends on the ring
+// staying connected through the night (RingSession window-gates + persists those readings),
+// OR on the temp/RR capture ticket (#87) for a connection-free fetch. Honor that caveat in
+// the UI ("est." + connected-overnight note); this file is the pure math only.
+//
+// This computes the temperature INPUT (nightly mean, baseline, signed offset, raw anomaly
+// flags). Fever (HR+temp cross-reference) is owned by the vitals-anomaly ticket (#72) and
+// notifications by #85 — NOT here.
+
+import Foundation
+
+public enum SkinTempBaseline {
+
+    /// Trailing nights the rolling baseline averages over (the app uses 30).
+    public static let baselineWindowNights = 30
+    /// Minimum prior nights before a baseline is considered meaningful. Below this the
+    /// average swings too much night-to-night to call a deviation, so callers should show
+    /// the nightly value without an offset until enough history accrues.
+    public static let minBaselineNights = 3
+    /// Deviation within ±this many °C of the baseline is "normal" (APK: 1 °C). Beyond it is
+    /// an abnormal rise/drop. A signed, symmetric band — never a hardcoded temperature.
+    public static let normalDeviationC = 1.0
+    /// Night-to-night change beyond ±this °C is a "fluctuation" rise/drop (the 0x10/0x11
+    /// flags). Distinct from the baseline deviation (0x12/0x13). Heuristic — labeled as such.
+    public static let fluctuationC = 0.6
+
+    /// One night's mean sleeping skin temperature, keyed by the night it belongs to.
+    public struct NightlyTemp: Equatable, Sendable {
+        public let night: Date     // start-of-day (or any stable per-night key)
+        public let celsius: Double
+        public init(night: Date, celsius: Double) {
+            self.night = night
+            self.celsius = celsius
+        }
+    }
+
+    /// Mean of skin-temperature readings inside a sleep window. Pass the night's persisted
+    /// `.temperature` samples (already worn- and window-gated by RingSession). nil when there
+    /// are no readings — a connection-free night has none until #87 lands.
+    public static func nightlyMean(_ celsius: [Double]) -> Double? {
+        guard !celsius.isEmpty else { return nil }
+        return celsius.reduce(0, +) / Double(celsius.count)
+    }
+
+    /// Convenience over `TemperatureSample`s, scoped to `[start, end]` (inclusive).
+    public static func nightlyMean(samples: [TemperatureSample], in window: DateInterval) -> Double? {
+        nightlyMean(samples.filter { window.contains($0.time) }.map(\.celsius))
+    }
+
+    /// Rolling baseline = mean of the most recent `windowNights` PRIOR nightly means. The
+    /// caller passes prior nights only (exclude tonight); we additionally sort by night and
+    /// take the trailing window so order/extra history can't skew it. nil below
+    /// `minBaselineNights` (too little history to trust).
+    public static func baseline(priorNights: [NightlyTemp],
+                                windowNights: Int = baselineWindowNights,
+                                minNights: Int = minBaselineNights) -> Double? {
+        let trailing = priorNights.sorted { $0.night < $1.night }.suffix(windowNights)
+        guard trailing.count >= minNights else { return nil }
+        return trailing.map(\.celsius).reduce(0, +) / Double(trailing.count)
+    }
+
+    /// Signed nightly offset = tonight − baseline (°C). Positive = warmer than baseline.
+    public static func offset(tonight: Double, baseline: Double) -> Double {
+        tonight - baseline
+    }
+
+    /// Where tonight's deviation from the baseline falls. `.normal` within ±`normalC`,
+    /// else a signed rise/drop. These map to the APK's `skinTempAbnormalRise` (0x12) /
+    /// `skinTempAbnormalDrop` (0x13) flags — app-side only, NOT fever (0x14).
+    public enum DeviationBand: String, Equatable, Sendable {
+        case normal, abnormalRise, abnormalDrop
+    }
+
+    public static func deviationBand(offset: Double, normalC: Double = normalDeviationC) -> DeviationBand {
+        if offset > normalC { return .abnormalRise }
+        if offset < -normalC { return .abnormalDrop }
+        return .normal
+    }
+
+    /// The five raw temperature anomaly flags the app exposes, computed app-side (#69 owns
+    /// these; fever 0x14 does not live here). `abnormal*` compare tonight to the BASELINE;
+    /// `fluctuation*` compare tonight to the PREVIOUS night. All are honest derivations of
+    /// the decoded skin temp — none is fabricated.
+    public struct AnomalyFlags: Equatable, Sendable {
+        public var abnormalRise = false        // 0x12 — well above baseline
+        public var abnormalDrop = false        // 0x13 — well below baseline
+        public var fluctuationRise = false     // 0x10 — sharp jump vs last night
+        public var fluctuationDrop = false     // 0x11 — sharp fall vs last night
+        public init() {}
+        public var any: Bool { abnormalRise || abnormalDrop || fluctuationRise || fluctuationDrop }
+    }
+
+    /// Classify tonight against an optional baseline and an optional previous night.
+    public static func anomalyFlags(tonight: Double,
+                                    baseline: Double?,
+                                    previousNight: Double?,
+                                    normalC: Double = normalDeviationC,
+                                    fluctC: Double = fluctuationC) -> AnomalyFlags {
+        var flags = AnomalyFlags()
+        if let base = baseline {
+            switch deviationBand(offset: tonight - base, normalC: normalC) {
+            case .abnormalRise: flags.abnormalRise = true
+            case .abnormalDrop: flags.abnormalDrop = true
+            case .normal: break
+            }
+        }
+        if let prev = previousNight {
+            let d = tonight - prev
+            if d > fluctC { flags.fluctuationRise = true }
+            else if d < -fluctC { flags.fluctuationDrop = true }
+        }
+        return flags
+    }
+
+    /// Everything the UI needs for one night in a single value: nightly mean, baseline (if
+    /// enough history), signed offset, band, and the raw anomaly flags.
+    public struct NightReport: Equatable, Sendable {
+        public let nightlyC: Double
+        public let baselineC: Double?
+        public let offsetC: Double?
+        public let band: DeviationBand?
+        public let flags: AnomalyFlags
+    }
+
+    /// Build a `NightReport` from tonight's mean and the prior nights' means.
+    public static func report(tonight: Double,
+                              priorNights: [NightlyTemp],
+                              previousNight: Double? = nil,
+                              windowNights: Int = baselineWindowNights,
+                              normalC: Double = normalDeviationC,
+                              fluctC: Double = fluctuationC) -> NightReport {
+        let base = baseline(priorNights: priorNights, windowNights: windowNights)
+        let off = base.map { offset(tonight: tonight, baseline: $0) }
+        let band = off.map { deviationBand(offset: $0, normalC: normalC) }
+        let flags = anomalyFlags(tonight: tonight, baseline: base,
+                                 previousNight: previousNight, normalC: normalC, fluctC: fluctC)
+        return NightReport(nightlyC: tonight, baselineC: base, offsetC: off, band: band, flags: flags)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepDetailMetrics.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepDetailMetrics.swift
@@ -1,0 +1,115 @@
+// Sleep-detail metrics — per-stage average HR + a 2.5-min, 3-level body-movement chart (#70).
+//
+// These are the "detail" half of the composite-sleep-score ticket. Both are pure functions
+// of the decoded 0x4c epochs (PROTOCOL §5.3): per-epoch HR `[4]` 🟢 and the `[10:15]` motion
+// channel 🟢. The app surfaces `hrAvgPhaseDeep/Light/Rem/Awake` (pp.txt) and a movement chart
+// with a "value every 2.5 minutes, three intensity levels" (pp.txt:544f0) — one level per
+// 150 s epoch — which is exactly what one 0x4c record spans.
+
+import Foundation
+
+public enum SleepDetailMetrics {
+
+    // MARK: - Per-stage average HR
+
+    /// Average HR (bpm, rounded) within each sleep stage. A sleep-vitals epoch's HR is
+    /// attributed to whichever segment contains its timestamp. Stages with no HR coverage are
+    /// omitted. Pure over (time, hr) pairs + the night's segments.
+    public static func averageHRByStage(records: [BulkRecord],
+                                        segments: [SleepSegment],
+                                        epoch: Int = Command.syncEpoch) -> [SleepStage: Int] {
+        // Staged (non-inBed) segments only — inBed overlaps everything and would double-count.
+        let staged = segments.filter { $0.stage != .inBed }
+        guard !staged.isEmpty else { return [:] }
+
+        var sums: [SleepStage: Int] = [:]
+        var counts: [SleepStage: Int] = [:]
+        for r in records where r.layout == .sleepVitals {
+            guard let hr = r.heartRate else { continue }
+            let t = r.date(epoch: epoch)
+            // First containing segment wins (segments tile the night in order).
+            guard let seg = staged.first(where: { $0.start <= t && t < $0.end })
+                    ?? staged.first(where: { $0.start <= t && t <= $0.end }) else { continue }
+            sums[seg.stage, default: 0] += hr
+            counts[seg.stage, default: 0] += 1
+        }
+        var out: [SleepStage: Int] = [:]
+        for (stage, count) in counts where count > 0 {
+            out[stage] = Int((Double(sums[stage]!) / Double(count)).rounded())
+        }
+        return out
+    }
+
+    // MARK: - Movement timeline (2.5-min, 3 levels)
+
+    /// Three intensity levels for one 2.5-min epoch, from the `[10:15]` motion counts.
+    public enum MovementLevel: Int, Equatable, Sendable, CaseIterable {
+        case still = 0    // baseline only — no movement
+        case light = 1    // some movement
+        case active = 2   // substantial movement (likely awake/arousal)
+    }
+
+    /// Motion threshold (summed non-baseline `[10:15]` counts) above which an epoch is `.active`
+    /// rather than `.light`. `1` per sub-sample is the still baseline and contributes 0; this
+    /// `.active` cut-off aligns with `SleepStaging`'s awake-motion default, so a movement spike
+    /// the chart calls "active" is the same energy that drives an Awake classification.
+    public static let activeThreshold = 15
+
+    public struct MovementEpoch: Equatable, Sendable {
+        public let time: Date
+        public let level: MovementLevel
+        public let magnitude: Int   // summed non-baseline motion (for tooltips/debug)
+        public init(time: Date, level: MovementLevel, magnitude: Int) {
+            self.time = time; self.level = level; self.magnitude = magnitude
+        }
+    }
+
+    /// Per-epoch movement levels across the records, optionally scoped to a window. One entry
+    /// per 0x4c record (≈ every 2.5 min). Idle/unworn epochs read as `.still`.
+    public static func movement(records: [BulkRecord],
+                                in window: DateInterval? = nil,
+                                activeThreshold: Int = activeThreshold,
+                                epoch: Int = Command.syncEpoch) -> [MovementEpoch] {
+        records
+            .sorted { $0.counter < $1.counter }
+            .compactMap { r in
+                let t = r.date(epoch: epoch)
+                if let w = window, !w.contains(t) { return nil }
+                let mag = r.motion.reduce(0) { $0 + ($1 == 1 ? 0 : Int($1)) }
+                let level: MovementLevel = mag == 0 ? .still : (mag > activeThreshold ? .active : .light)
+                return MovementEpoch(time: t, level: level, magnitude: mag)
+            }
+    }
+
+    /// Compact movement summary for persistence/display: the per-epoch level series plus
+    /// counts. The series is small (≈ a few hundred bytes/night) so it persists as-is, letting
+    /// the chart redraw offline without re-fetching the records.
+    public struct MovementSummary: Equatable, Sendable {
+        public let levels: [Int]    // one MovementLevel.rawValue per epoch
+        public let still: Int
+        public let light: Int
+        public let active: Int
+        public var total: Int { still + light + active }
+        /// Share of epochs with any movement (light or active), 0…1 — a one-glance "restlessness".
+        public var movementFraction: Double {
+            total > 0 ? Double(light + active) / Double(total) : 0
+        }
+    }
+
+    public static func movementSummary(records: [BulkRecord],
+                                       in window: DateInterval? = nil,
+                                       activeThreshold: Int = activeThreshold,
+                                       epoch: Int = Command.syncEpoch) -> MovementSummary {
+        let epochs = movement(records: records, in: window, activeThreshold: activeThreshold, epoch: epoch)
+        var still = 0, light = 0, active = 0
+        for e in epochs {
+            switch e.level {
+            case .still: still += 1
+            case .light: light += 1
+            case .active: active += 1
+            }
+        }
+        return MovementSummary(levels: epochs.map { $0.level.rawValue },
+                               still: still, light: light, active: active)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepDetection.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepDetection.swift
@@ -34,6 +34,18 @@ public struct MotionSample: Sendable, Equatable {
     }
 }
 
+/// One skin-temperature reading on the wear-detection timeline (#41). Skin temp rides
+/// the 0x10/0x87 descriptor (PROTOCOL.md §5.4), not the 0x4c sleep records, so callers
+/// thread the night's persisted temperature samples in alongside the motion timeline.
+public struct TemperatureSample: Sendable, Equatable {
+    public let time: Date
+    public let celsius: Double
+    public init(time: Date, celsius: Double) {
+        self.time = time
+        self.celsius = celsius
+    }
+}
+
 public enum Activity: Equatable, Sendable { case sleep, active }
 
 public struct ActivityPeriod: Equatable, Sendable {
@@ -61,6 +73,13 @@ public struct ActivityPeriod: Equatable, Sendable {
     /// Motion-count stillness threshold for the 0x4c [10:15] channel (🟢 grounded:
     /// recovers the captured night's in-bed window). Baseline `01` = still.
     static let motionStillThreshold: Float = 2
+
+    /// Minimum skin temperature for the ring to count as WORN (🟡 heuristic, NOT yet
+    /// ground-truthed — validate against a known charging-night capture). A worn Gen-2
+    /// reads ~30–34 °C; off-wrist / on the charger it falls toward room ambient (~20–24 °C).
+    /// 28 °C is a conservative midpoint. Used ONLY to exclude cold "still" blocks from
+    /// sleep (#41), never to add sleep — so a miss costs at worst an unfiltered charger block.
+    public static let wornMinTemperatureC: Double = 28.0
 
     private struct Temp { var activity: Activity; var start: Date; var end: Date }
 
@@ -101,6 +120,31 @@ public struct ActivityPeriod: Equatable, Sendable {
         guard history.count >= 2 else { return [] }
         return detect(times: history.map(\.time), deltas: history.map(\.movement),
                       stillThreshold: motionStillThreshold)
+    }
+
+    /// Sleep/Active detection (motion) with a WEAR GATE (#41): any detected `.sleep` block
+    /// whose median skin temperature indicates the ring was off-wrist / on the charger is
+    /// reclassified `.active`, so a perfectly still ring on the nightstand can't masquerade
+    /// as a night of sleep. A `.sleep` block with no temperature coverage is left as
+    /// detected — absence of data is not evidence of being unworn. `temperatureSamples`
+    /// may be unordered and sparse; only readings inside a block are considered.
+    public static func detectFromMotion(_ history: [MotionSample],
+                                        temperatureSamples: [TemperatureSample],
+                                        wornMinC: Double = wornMinTemperatureC) -> [ActivityPeriod] {
+        let periods = detectFromMotion(history)
+        guard !temperatureSamples.isEmpty else { return periods }
+        return periods.map { p in
+            guard p.activity == .sleep else { return p }
+            let inside = temperatureSamples
+                .filter { $0.time >= p.start && $0.time <= p.end }
+                .map(\.celsius)
+                .sorted()
+            guard !inside.isEmpty else { return p }   // no coverage → trust the motion verdict
+            let median = inside[inside.count / 2]
+            return median < wornMinC
+                ? ActivityPeriod(activity: .active, start: p.start, end: p.end)
+                : p
+        }
     }
 
     /// Shared core: classify a stillness-magnitude timeline into Sleep/Active runs.

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepDetection.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepDetection.swift
@@ -1,12 +1,14 @@
 // Sleep/active period detection — ported from openwhoop-algos/src/activity.rs.
-// Classifies a timeline of gravity-vector readings into Sleep/Active periods by
-// stillness, then `findSleep` extracts the main sleep block. Device-agnostic.
+// Classifies a timeline of stillness readings into Sleep/Active periods, then
+// `findSleep` extracts the main sleep block. Device-agnostic.
 //
-// ⚠️ INPUT GAP (PROTOCOL.md §5, 🔴): this needs a per-reading **gravity vector**
-// (3-axis, in g). RingConn's IMU/accelerometer stream is not yet decoded — the
-// 0x47/0x4c bulk frames in the reference capture are the likely source but their
-// format is unconfirmed. The algorithm is ported and tested; wiring it to real
-// ring data is gated on a capture. Nothing about the device is invented here.
+// Two front-ends feed the same core pipeline:
+//   • detectFromGravity — a 3-axis gravity vector (openwhoop's original input).
+//   • detectFromMotion  — RingConn's 0x4c [10:15] per-30 s motion counts (🟢,
+//     PROTOCOL.md §5.3). On the 2026-06-13 night this recovers the in-bed window
+//     00:33→09:34 vs the app's ~00:32→09:30 (time-in-bed). This is the real wiring.
+// Finer Awake/Light/Deep/REM staging needs an HR-based model (see BulkSleep) and
+// is not part of openwhoop's stillness detection.
 
 import Foundation
 
@@ -18,6 +20,17 @@ public struct GravitySample: Sendable, Equatable {
     public init(time: Date, gravity: SIMD3<Float>?) {
         self.time = time
         self.gravity = gravity
+    }
+}
+
+/// One reading on the motion timeline: a per-30 s movement magnitude (the 0x4c
+/// [10:15] motion count). Unworn/no-measurement samples carry `.greatestFiniteMagnitude`.
+public struct MotionSample: Sendable, Equatable {
+    public let time: Date
+    public let movement: Float
+    public init(time: Date, movement: Float) {
+        self.time = time
+        self.movement = movement
     }
 }
 
@@ -45,6 +58,9 @@ public struct ActivityPeriod: Equatable, Sendable {
     static let gravityWindowMinutes = 15
     static let gravityStillFraction: Float = 0.70
     static let gravityMaxGap: TimeInterval = 20 * 60
+    /// Motion-count stillness threshold for the 0x4c [10:15] channel (🟢 grounded:
+    /// recovers the captured night's in-bed window). Baseline `01` = still.
+    static let motionStillThreshold: Float = 2
 
     private struct Temp { var activity: Activity; var start: Date; var end: Date }
 
@@ -60,7 +76,6 @@ public struct ActivityPeriod: Equatable, Sendable {
     /// Detect Sleep/Active periods from a gravity-vector timeline.
     public static func detectFromGravity(_ history: [GravitySample]) -> [ActivityPeriod] {
         guard history.count >= 2 else { return [] }
-
         // Magnitude of change between consecutive gravity vectors (first = 0).
         // Missing gravity -> treat as max movement (active).
         var deltas: [Float] = [0]
@@ -73,11 +88,31 @@ public struct ActivityPeriod: Equatable, Sendable {
                 deltas.append(.greatestFiniteMagnitude)
             }
         }
+        return detect(times: history.map(\.time), deltas: deltas,
+                      stillThreshold: gravityStillThreshold)
+    }
+
+    /// Detect Sleep/Active periods from RingConn's per-30 s motion counts (the
+    /// 0x4c [10:15] channel; PROTOCOL.md §5.3). `movement` is the motion count
+    /// directly — it already IS a movement magnitude, so it feeds the same core
+    /// as the gravity deltas. Unworn/no-measurement samples should be passed as a
+    /// large value (active) by the caller.
+    public static func detectFromMotion(_ history: [MotionSample]) -> [ActivityPeriod] {
+        guard history.count >= 2 else { return [] }
+        return detect(times: history.map(\.time), deltas: history.map(\.movement),
+                      stillThreshold: motionStillThreshold)
+    }
+
+    /// Shared core: classify a stillness-magnitude timeline into Sleep/Active runs.
+    /// `deltas[i]` < `stillThreshold` => still at sample i. Faithful to activity.rs.
+    private static func detect(times: [Date], deltas: [Float],
+                               stillThreshold: Float) -> [ActivityPeriod] {
+        guard times.count == deltas.count, times.count >= 2 else { return [] }
 
         // Median sample interval (seconds), bounded like openwhoop.
         var diffs: [Int] = []
-        for i in 1 ..< history.count {
-            let d = Int(history[i].time.timeIntervalSince(history[i - 1].time))
+        for i in 1 ..< times.count {
+            let d = Int(times[i].timeIntervalSince(times[i - 1]))
             if d > 0 && d < 300 { diffs.append(d) }
         }
         diffs.sort()
@@ -92,7 +127,7 @@ public struct ActivityPeriod: Equatable, Sendable {
             let start = i >= half ? i - half : 0
             let end = min(i + half + 1, n)
             let window = deltas[start ..< end]
-            let still = window.filter { $0 < gravityStillThreshold }.count
+            let still = window.filter { $0 < stillThreshold }.count
             isSleep[i] = Float(still) / Float(window.count) >= gravityStillFraction
         }
 
@@ -103,10 +138,10 @@ public struct ActivityPeriod: Equatable, Sendable {
             let endOfData = (i == n)
             let classChange = !endOfData && isSleep[i] != isSleep[runStart]
             let gapBreak = !endOfData &&
-                history[i].time.timeIntervalSince(history[i - 1].time) > gravityMaxGap
+                times[i].timeIntervalSince(times[i - 1]) > gravityMaxGap
             if endOfData || classChange || gapBreak {
                 temps.append(Temp(activity: isSleep[runStart] ? .sleep : .active,
-                                  start: history[runStart].time, end: history[i - 1].time))
+                                  start: times[runStart], end: times[i - 1]))
                 if !endOfData { runStart = i }
             }
         }

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepScore.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepScore.swift
@@ -1,10 +1,10 @@
-// Sleep score — ported from openwhoop-algos/src/sleep.rs `sleep_score`.
+// Sleep score — adapted from openwhoop-algos/src/sleep.rs `sleep_score`.
 // Device-agnostic: a function of sleep duration only. 0…100.
 //
-// Faithful to openwhoop, including its INTEGER-division behavior: the ratio
-// duration / 8h is computed in whole units, so e.g. 4h → 0, 8h → 100, and it is
-// clamped to 0…100. (This is openwhoop's current scoring; a finer model is a
-// future Phase 5 refinement, flagged here rather than silently "fixed".)
+// openwhoop computes `duration / 8h` in INTEGER units, which collapses the score to a
+// 0-or-100 step function (anything < 8h → 0, ≥ 8h → 100) — useless as a daily metric:
+// a 7h45m night scores 0 (#28). We compute the ratio in floating point so the score
+// grades linearly with duration and clamps at the 8h ideal: 4h → 50, 6h → 75, 8h+ → 100.
 
 import Foundation
 
@@ -14,8 +14,8 @@ public enum SleepScore {
 
     /// Score from a sleep duration in seconds.
     public static func score(durationSeconds: Int) -> Double {
-        let ratio = durationSeconds / idealDurationSeconds   // integer division, as openwhoop
-        return min(max(Double(ratio) * 100.0, 0.0), 100.0)
+        let ratio = Double(durationSeconds) / Double(idealDurationSeconds)   // #28: graded, not a step
+        return min(max(ratio * 100.0, 0.0), 100.0)
     }
 
     /// Convenience for a start/end span.

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepScore.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepScore.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public enum SleepScore {
     /// Ideal sleep duration in seconds (8h).
-    static let idealDurationSeconds = 60 * 60 * 8
+    public static let idealDurationSeconds = 60 * 60 * 8
 
     /// Score from a sleep duration in seconds.
     public static func score(durationSeconds: Int) -> Double {
@@ -22,4 +22,124 @@ public enum SleepScore {
     public static func score(start: Date, end: Date) -> Double {
         score(durationSeconds: Int(end.timeIntervalSince(start)))
     }
+
+    // MARK: - Composite 0–100 sleep score (#70)
+    //
+    // The duration-only `score` above (the ported openwhoop piece, #28) is NOT the
+    // RingConn app's headline number. The app's Sleep Score is a 6-FACTOR composite
+    // (pp.txt:47425): "Time Asleep, Sleep Stages, Sleep Efficiency, Heart Rate,
+    // Temperature, and Time Awake", with tiers ≥85 / 70–84 / <70.
+    //
+    // We reproduce that SHAPE from what we actually decode, and degrade gracefully when an
+    // optional input is missing (no resting HR / no temp baseline): the missing factor is
+    // dropped and the remaining factors are renormalised, rather than fabricating a value.
+    // It is an on-device ESTIMATE — label it as such in the UI — not the app's proprietary
+    // algorithm, which we can't see.
+
+    /// Quality tiers, matching the app's cut-offs.
+    public enum Tier: String, Equatable, Sendable {
+        case excellent   // ≥ 85
+        case good        // 70–84
+        case needsImprovement  // < 70
+
+        public static func of(_ score: Int) -> Tier {
+            if score >= 85 { return .excellent }
+            if score >= 70 { return .good }
+            return .needsImprovement
+        }
+    }
+
+    /// Inputs to the composite, all derived from decoded data. Optional inputs (`restingHR`,
+    /// `tempOffsetC`) are dropped from the weighting when nil so the score never invents them.
+    public struct CompositeInput: Equatable, Sendable {
+        public var totalAsleep: TimeInterval
+        public var timeAwake: TimeInterval
+        public var efficiency: Double          // 0…1 (already shipped in SleepCardView)
+        public var deep: TimeInterval
+        public var light: TimeInterval
+        public var rem: TimeInterval
+        public var restingHR: Double?          // night's resting/avg HR, bpm (optional)
+        public var tempOffsetC: Double?        // nightly skin-temp offset from baseline (optional)
+        public var sleepGoal: TimeInterval     // target time asleep (default 8 h)
+
+        public init(totalAsleep: TimeInterval, timeAwake: TimeInterval, efficiency: Double,
+                    deep: TimeInterval, light: TimeInterval, rem: TimeInterval,
+                    restingHR: Double? = nil, tempOffsetC: Double? = nil,
+                    sleepGoal: TimeInterval = TimeInterval(idealDurationSeconds)) {
+            self.totalAsleep = totalAsleep
+            self.timeAwake = timeAwake
+            self.efficiency = efficiency
+            self.deep = deep
+            self.light = light
+            self.rem = rem
+            self.restingHR = restingHR
+            self.tempOffsetC = tempOffsetC
+            self.sleepGoal = sleepGoal
+        }
+    }
+
+    /// The composite result plus each factor's 0…1 sub-score (handy for a breakdown view).
+    public struct Composite: Equatable, Sendable {
+        public let score: Int
+        public let tier: Tier
+        public let factors: [Factor: Double]   // each 0…1
+        public enum Factor: String, Equatable, Sendable, CaseIterable {
+            case timeAsleep, stages, efficiency, heartRate, temperature, timeAwake
+        }
+    }
+
+    /// Default factor weights (sum need not be 1 — we renormalise over the PRESENT factors).
+    /// Time asleep + efficiency carry the most signal; HR and temperature are lighter
+    /// modifiers, mirroring how the app frames them as secondary contributors.
+    static let factorWeights: [Composite.Factor: Double] = [
+        .timeAsleep: 0.30, .stages: 0.20, .efficiency: 0.20,
+        .heartRate: 0.10, .temperature: 0.10, .timeAwake: 0.10,
+    ]
+
+    /// 6-factor composite Sleep Score (0–100) with tiers. Pure; unit-tested.
+    public static func composite(_ input: CompositeInput) -> Composite {
+        var f: [Composite.Factor: Double] = [:]
+
+        // Time asleep: linear vs the goal, capped at 1 (the duration factor REUSES the ported
+        // ratio idea, #28, but against the personal goal rather than a fixed 8 h).
+        f[.timeAsleep] = clamp(input.sleepGoal > 0 ? input.totalAsleep / input.sleepGoal : 0)
+
+        // Stages: reward a healthy share of restorative sleep (Deep + REM). Adults spend
+        // ~13–23 % in deep and ~20–25 % in REM; ~40 % combined is a reasonable "ideal" target.
+        let asleep = max(input.deep + input.light + input.rem, 1)
+        let restorative = (input.deep + input.rem) / asleep
+        f[.stages] = clamp(restorative / 0.40)
+
+        // Efficiency: 0.85+ is excellent (the app calls 80–100 % optimal). Map [0.5, 0.95]→[0,1].
+        f[.efficiency] = clamp((input.efficiency - 0.50) / (0.95 - 0.50))
+
+        // Time awake: less awake-in-bed is better. 0 min → 1, ≥60 min → 0.
+        f[.timeAwake] = clamp(1 - input.timeAwake / (60 * 60))
+
+        // Heart rate (optional): a lower sleeping HR is generally better recovery. Map a broad
+        // [45, 75] bpm band to [1, 0]; outside it clamps. Omitted entirely when no HR decoded.
+        if let hr = input.restingHR {
+            f[.heartRate] = clamp((75 - hr) / (75 - 45))
+        }
+
+        // Temperature (optional): closer to baseline is better. |offset| 0 → 1, ≥1 °C → 0,
+        // matching the ±1 °C "normal" band. Omitted when no baseline yet.
+        if let off = input.tempOffsetC {
+            f[.temperature] = clamp(1 - abs(off) / SkinTempBaseline.normalDeviationC)
+        }
+
+        // Weighted mean over the PRESENT factors only (renormalise so a missing optional
+        // factor doesn't silently drag the score toward zero).
+        var num = 0.0, den = 0.0
+        for (factor, value) in f {
+            let w = factorWeights[factor] ?? 0
+            num += w * value
+            den += w
+        }
+        let raw = den > 0 ? num / den : 0
+        let score = Int((raw * 100).rounded())
+        return Composite(score: score, tier: .of(score), factors: f)
+    }
+
+    private static func clamp(_ x: Double) -> Double { min(max(x, 0), 1) }
 }

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepStaging.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepStaging.swift
@@ -52,10 +52,12 @@ public enum SleepStaging {
         public var remVarPercentile: Double
         /// Half-window (epochs each side) for the rolling HR/HRV variability estimate.
         public var variabilityHalfWindow: Int
-        /// Absolute floor (bpm) for the Deep variability gate, so a flat night still
-        /// admits Deep.
+        /// Non-degeneracy floor for the Deep variability gate, so a flat night still admits
+        /// Deep. NOTE: this is on the *blended* variability scale (HR rolling-SD plus
+        /// `hrvVarWeight`×HRV rolling-SD), not raw bpm — the threshold is `max(percentile, floor)`
+        /// over that same blended pool, so the floor only binds on near-zero-variance nights.
         public var deepVarFloor: Double
-        /// Absolute floor (bpm) for the REM variability gate, so tiny noise is not REM.
+        /// Non-degeneracy floor for the REM variability gate (blended scale; see deepVarFloor).
         public var remVarFloor: Double
         /// Minimum consolidated run length (epochs) for Deep; shorter → relabelled Light.
         public var minDeepRunEpochs: Int
@@ -182,10 +184,12 @@ public enum SleepStaging {
         while i < rows.count {
             var j = i
             while j + 1 < rows.count && stages[j + 1] == stages[i] { j += 1 }
-            let end = j + 1 < rows.count
-                ? rows[j + 1].time
-                : rows[j].time.addingTimeInterval(Double(BulkRecord.epochSeconds))
-            segs.append(SleepSegment(start: rows[i].time, end: min(end, block.end), stage: stages[i]))
+            // Fully tile [block.start, block.end] so staged segments partition the inBed
+            // window (else efficiency is understated): clamp the first segment's start to
+            // block.start and the last segment's end to block.end. (Reviewer MINOR fix.)
+            let segStart = (i == 0) ? block.start : rows[i].time
+            let segEnd = (j + 1 < rows.count) ? rows[j + 1].time : block.end
+            segs.append(SleepSegment(start: segStart, end: min(segEnd, block.end), stage: stages[i]))
             i = j + 1
         }
         return segs

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepStaging.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepStaging.swift
@@ -1,0 +1,279 @@
+// Sleep-stage classifier — Awake / Light / Deep / REM from the 0x4c per-epoch
+// signals (PROTOCOL.md §5.3). The ring does NOT transmit a hypnogram; the RingConn
+// app computes stages on-device from the same vitals we decode, so we approximate
+// that proprietary algorithm here with standard consumer-wearable heuristics.
+//
+// ⚠️ APPROXIMATION, NOT GROUND TRUTH. We have no PSG (or even per-epoch app) labels —
+// only the app's NIGHT TOTALS to sanity-check against (see the night of 2026-06-14:
+// asleep 7:37, awake 43m, REM 1:42, light 4:45, deep 1:10). So this is tuned to be
+// physiologically principled and to roughly partition a night the way a wrist/ring
+// tracker would; it is NOT validated to reproduce per-epoch stage timing, and the
+// exact Deep/REM split should be read as approximate proportions, not a clinical
+// hypnogram.
+//
+// Signals per 150 s epoch (forward-filled across epochs that drop a reading):
+//   • HR  [4]  — the spine of the model. Stage bands are set from the NIGHT'S OWN HR
+//                distribution (percentiles of the asleep HR), never absolute bpm, so
+//                it generalises across people and nights.
+//   • HRV [5]  — RMSSD; fused in as a secondary REM cue via its short-term variability.
+//   • motion [10:15] — the awake signal (a moving sleeper is awake).
+//
+// Stage logic, per asleep epoch (Awake is decided first, from motion):
+//   • Deep  — HR near the night's minimum (low percentile) AND low HR variability AND
+//             no motion: the calm, consolidated low-HR troughs.
+//   • REM   — HR elevated toward waking OR HR/HRV notably variable, but motion ~0
+//             (muscle atonia). Variability — not absolute HR — is what separates REM
+//             from Light, matching the physiology.
+//   • Light — everything else asleep (the remainder).
+// Stages persist in real sleep, so short Deep/REM runs are smoothed back to Light to
+// avoid single-epoch flapping.
+
+import Foundation
+
+/// Stage-by-stage classifier over a night's `0x4c` `BulkRecord`s. Pure/testable:
+/// it takes records, returns `[SleepSegment]`, and touches no I/O.
+public enum SleepStaging {
+
+    /// Tunable thresholds. All HR/variability cut-offs are PERCENTILES of the night's
+    /// own asleep distribution (plus small absolute floors), so they adapt per night
+    /// rather than baking in fixed bpm. Defaults are general heuristics, not fitted to
+    /// any single night.
+    public struct Tuning: Sendable, Equatable {
+        /// Motion magnitude (sum of non-baseline `[10:15]` counts over the epoch) above
+        /// which the epoch is Awake. Baseline `01` contributes 0.
+        public var awakeMotion: Int
+        /// Lower HR percentile (of asleep epochs) bounding Deep — near the night's floor.
+        public var deepHRPercentile: Double
+        /// Upper HR percentile bounding "HR elevated toward waking" → a REM cue.
+        public var remHRPercentile: Double
+        /// HR-variability percentile below which an epoch is "calm enough" for Deep.
+        public var deepVarPercentile: Double
+        /// HR-variability percentile above which an epoch is "variable" → a REM cue.
+        public var remVarPercentile: Double
+        /// Half-window (epochs each side) for the rolling HR/HRV variability estimate.
+        public var variabilityHalfWindow: Int
+        /// Absolute floor (bpm) for the Deep variability gate, so a flat night still
+        /// admits Deep.
+        public var deepVarFloor: Double
+        /// Absolute floor (bpm) for the REM variability gate, so tiny noise is not REM.
+        public var remVarFloor: Double
+        /// Minimum consolidated run length (epochs) for Deep; shorter → relabelled Light.
+        public var minDeepRunEpochs: Int
+        /// Minimum consolidated run length (epochs) for REM; shorter → relabelled Light.
+        public var minREMRunEpochs: Int
+        /// Minimum Awake run; shorter motion blips inside sleep → relabelled Light.
+        public var minAwakeRunEpochs: Int
+        /// Weight of HRV short-term variability fused into the variability score (0 = HR
+        /// only). Only contributes on epochs where HRV is present.
+        public var hrvVarWeight: Double
+
+        public init(awakeMotion: Int = 15,
+                    deepHRPercentile: Double = 0.20,
+                    remHRPercentile: Double = 0.80,
+                    deepVarPercentile: Double = 0.50,
+                    remVarPercentile: Double = 0.75,
+                    variabilityHalfWindow: Int = 2,
+                    deepVarFloor: Double = 2.5,
+                    remVarFloor: Double = 3.0,
+                    minDeepRunEpochs: Int = 3,
+                    minREMRunEpochs: Int = 2,
+                    minAwakeRunEpochs: Int = 1,
+                    hrvVarWeight: Double = 0.5) {
+            self.awakeMotion = awakeMotion
+            self.deepHRPercentile = deepHRPercentile
+            self.remHRPercentile = remHRPercentile
+            self.deepVarPercentile = deepVarPercentile
+            self.remVarPercentile = remVarPercentile
+            self.variabilityHalfWindow = variabilityHalfWindow
+            self.deepVarFloor = deepVarFloor
+            self.remVarFloor = remVarFloor
+            self.minDeepRunEpochs = minDeepRunEpochs
+            self.minREMRunEpochs = minREMRunEpochs
+            self.minAwakeRunEpochs = minAwakeRunEpochs
+            self.hrvVarWeight = hrvVarWeight
+        }
+
+        public static let `default` = Tuning()
+    }
+
+    /// Per-stage durations for a night, plus convenience totals. `inBed` is the whole
+    /// detected window; `totalAsleep` excludes Awake (and the overlapping inBed span).
+    public struct Summary: Equatable, Sendable {
+        public let inBed: TimeInterval
+        public let awake: TimeInterval
+        public let light: TimeInterval
+        public let deep: TimeInterval
+        public let rem: TimeInterval
+
+        public init(inBed: TimeInterval, awake: TimeInterval,
+                    light: TimeInterval, deep: TimeInterval, rem: TimeInterval) {
+            self.inBed = inBed; self.awake = awake
+            self.light = light; self.deep = deep; self.rem = rem
+        }
+
+        /// Time actually asleep = Light + Deep + REM.
+        public var totalAsleep: TimeInterval { light + deep + rem }
+        /// Sleep efficiency = asleep / in-bed, 0…1 (0 if no in-bed window).
+        public var efficiency: Double { inBed > 0 ? totalAsleep / inBed : 0 }
+
+        /// The same numbers in whole minutes, handy for dashboards/sanity checks.
+        public var minutes: (inBed: Int, awake: Int, light: Int, deep: Int, rem: Int, asleep: Int) {
+            func m(_ t: TimeInterval) -> Int { Int((t / 60).rounded()) }
+            return (m(inBed), m(awake), m(light), m(deep), m(rem), m(totalAsleep))
+        }
+    }
+
+    /// Classify a night's records into `inBed` + Awake/Light(core)/Deep/REM segments.
+    /// Returns `[]` when no sleep block (≥1 h still) is detected. The first element is
+    /// always the `inBed` span; the rest tile the staged epochs in order.
+    public static func classify(from records: [BulkRecord],
+                                epoch: Int = Command.syncEpoch,
+                                tuning: Tuning = .default) -> [SleepSegment] {
+        guard let block = BulkSleep.mainSleep(from: records, epoch: epoch) else { return [] }
+
+        // Epochs inside the in-bed window, forward-filling HR/HRV across dropped reads.
+        let inBlock = records
+            .filter { $0.date(epoch: epoch) >= block.start && $0.date(epoch: epoch) <= block.end }
+            .sorted { $0.counter < $1.counter }
+        var lastHR: Int?, lastHRV: Int?
+        var rows: [(time: Date, hr: Int, hrv: Int?, motion: Int)] = []
+        for r in inBlock {
+            if let hr = r.heartRate { lastHR = hr }
+            if let v = r.hrvRMSSD { lastHRV = v }
+            guard let hr = lastHR else { continue }   // skip until the first HR reading
+            let motion = r.motion.reduce(0) { $0 + ($1 == 1 ? 0 : Int($1)) }
+            rows.append((r.date(epoch: epoch), hr, lastHRV, motion))
+        }
+        guard rows.count >= 2 else { return [] }
+
+        // --- Variability (rolling SD of HR, optionally fused with HRV) -------------
+        let hr = rows.map { Double($0.hr) }
+        var variability = rollingSD(hr, half: tuning.variabilityHalfWindow)
+        if tuning.hrvVarWeight > 0, rows.contains(where: { $0.hrv != nil }) {
+            let hrv = filledForward(rows.map { $0.hrv }).map { Double($0 ?? 0) }
+            let hrvVar = rollingSD(hrv, half: tuning.variabilityHalfWindow)
+            for i in variability.indices { variability[i] += tuning.hrvVarWeight * hrvVar[i] }
+        }
+
+        // --- Night-relative bands from the ASLEEP (non-moving) distribution --------
+        let asleep = rows.indices.filter { rows[$0].motion <= tuning.awakeMotion }
+        let hrPool = (asleep.count >= 4 ? asleep.map { hr[$0] } : hr).sorted()
+        let varPoolRaw = asleep.count >= 4 ? asleep.map { variability[$0] } : variability
+        let varPool = varPoolRaw.sorted()
+
+        let deepHR = percentile(hrPool, tuning.deepHRPercentile)
+        let remHR = percentile(hrPool, tuning.remHRPercentile)
+        let deepVar = max(percentile(varPool, tuning.deepVarPercentile), tuning.deepVarFloor)
+        let remVar = max(percentile(varPool, tuning.remVarPercentile), tuning.remVarFloor)
+
+        // --- Per-epoch decision ----------------------------------------------------
+        var stages: [SleepStage] = rows.indices.map { i in
+            let r = rows[i]
+            if r.motion > tuning.awakeMotion { return .awake }
+            if hr[i] <= deepHR && variability[i] <= deepVar { return .asleepDeep }
+            if hr[i] >= remHR || variability[i] > remVar { return .asleepREM }
+            return .asleepCore
+        }
+        smooth(&stages, tuning)
+
+        // --- Merge consecutive same-stage epochs into segments ---------------------
+        var segs = [SleepSegment(start: block.start, end: block.end, stage: .inBed)]
+        var i = 0
+        while i < rows.count {
+            var j = i
+            while j + 1 < rows.count && stages[j + 1] == stages[i] { j += 1 }
+            let end = j + 1 < rows.count
+                ? rows[j + 1].time
+                : rows[j].time.addingTimeInterval(Double(BulkRecord.epochSeconds))
+            segs.append(SleepSegment(start: rows[i].time, end: min(end, block.end), stage: stages[i]))
+            i = j + 1
+        }
+        return segs
+    }
+
+    /// Total time spent in each stage across the night. The overlapping `inBed` span is
+    /// excluded so the asleep stages sum to time-asleep.
+    public static func stageTotals(_ segments: [SleepSegment]) -> [SleepStage: TimeInterval] {
+        var out: [SleepStage: TimeInterval] = [:]
+        for s in segments where s.stage != .inBed { out[s.stage, default: 0] += s.duration }
+        return out
+    }
+
+    /// Roll the segments up into a `Summary` (per-stage durations + total asleep).
+    public static func summary(_ segments: [SleepSegment]) -> Summary {
+        let t = stageTotals(segments)
+        let awake: TimeInterval = t[.awake] ?? 0
+        let light: TimeInterval = t[.asleepCore] ?? 0
+        let deep: TimeInterval = t[.asleepDeep] ?? 0
+        let rem: TimeInterval = t[.asleepREM] ?? 0
+        let staged = awake + light + deep + rem
+        let inBed = segments.first { $0.stage == .inBed }?.duration ?? staged
+        return Summary(inBed: inBed, awake: awake, light: light, deep: deep, rem: rem)
+    }
+
+    /// Convenience: total time asleep (Light + Deep + REM) for a set of segments.
+    public static func totalAsleep(_ segments: [SleepSegment]) -> TimeInterval {
+        let t = stageTotals(segments)
+        return (t[.asleepCore] ?? 0) + (t[.asleepDeep] ?? 0) + (t[.asleepREM] ?? 0)
+    }
+
+    // MARK: - Helpers
+
+    /// Relabel sub-minimum Deep/REM/Awake runs to Light, so stages don't flap epoch to
+    /// epoch (real stages persist for minutes).
+    private static func smooth(_ stages: inout [SleepStage], _ t: Tuning) {
+        let n = stages.count
+        var i = 0
+        while i < n {
+            var j = i
+            while j + 1 < n && stages[j + 1] == stages[i] { j += 1 }
+            let run = j - i + 1
+            let minRun: Int?
+            switch stages[i] {
+            case .asleepDeep: minRun = t.minDeepRunEpochs
+            case .asleepREM:  minRun = t.minREMRunEpochs
+            case .awake:      minRun = t.minAwakeRunEpochs
+            default:          minRun = nil
+            }
+            if let m = minRun, run < m {
+                for k in i ... j { stages[k] = .asleepCore }
+            }
+            i = j + 1
+        }
+    }
+
+    /// Centered rolling standard deviation over a ±`half`-epoch window.
+    private static func rollingSD(_ xs: [Double], half: Int) -> [Double] {
+        let n = xs.count
+        guard n > 0 else { return [] }
+        var out = [Double](repeating: 0, count: n)
+        for i in 0 ..< n {
+            let s = max(0, i - half), e = min(n - 1, i + half)
+            let w = xs[s ... e]
+            let mean = w.reduce(0, +) / Double(w.count)
+            let varr = w.reduce(0) { $0 + ($1 - mean) * ($1 - mean) } / Double(w.count)
+            out[i] = varr.squareRoot()
+        }
+        return out
+    }
+
+    /// Forward-then-backward fill of nil gaps, so a sparse HRV channel has no artificial
+    /// jumps where readings drop out.
+    private static func filledForward(_ xs: [Int?]) -> [Int?] {
+        var out = xs
+        var last: Int?
+        for i in out.indices { if let v = out[i] { last = v } else { out[i] = last } }
+        var next: Int?
+        for i in stride(from: out.count - 1, through: 0, by: -1) {
+            if let v = out[i] { next = v } else { out[i] = next }
+        }
+        return out
+    }
+
+    /// Value at quantile `q` (0…1) of a pre-sorted array (nearest-rank). 0 if empty.
+    private static func percentile(_ sorted: [Double], _ q: Double) -> Double {
+        guard !sorted.isEmpty else { return 0 }
+        let idx = Int((q * Double(sorted.count - 1)).rounded())
+        return sorted[min(max(idx, 0), sorted.count - 1)]
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepStress.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/SleepStress.swift
@@ -1,0 +1,103 @@
+// Overnight / sleep stress score from sleep-window HRV — #71.
+//
+// ⚠️ This is a NEW mapping, NOT the ported `Analytics/Stress.swift`. That file is Baevsky's
+// Stress Index over RR INTERVALS (0…10), and we do NOT decode RR intervals (PROTOCOL §5 🔴),
+// so it is unusable here. The ONLY HRV we decode is the per-epoch RMSSD at `0x4c[5]` 🟢 during
+// the sleep window — so this builds a defensible RMSSD→stress-band mapping from that single
+// statistic instead.
+//
+// SCOPE: OVERNIGHT / SLEEP stress only. All-day/daytime stress needs daytime HRV, which lives
+// in the UNDECODED activity-epoch `[15:22]` payload (or 0x47 PPG, #38) — a separate, blocked
+// ticket (#94). Label this "overnight/sleeping stress (estimate)", never all-day.
+//
+// Bands follow the app's own thresholds (pp.txt:45236 / 0x12678): a 1–100 score where
+//   1–29  = relaxed/low, 30–59 = normal, 60–79 = medium, 80–100 = high,
+// and "Stress index is measured by Heart Rate Variability (HRV)". Higher HRV ⇒ more
+// parasympathetic (rested) ⇒ LOWER stress; lower HRV ⇒ HIGHER stress. The RMSSD→score curve
+// below is a HEURISTIC reference range (no fabricated health values) and is labeled an estimate
+// in the UI; the band thresholds themselves are the app's.
+
+import Foundation
+
+public enum SleepStress {
+
+    /// App stress bands over a 1–100 score.
+    public enum Band: String, Equatable, Sendable, CaseIterable {
+        case relaxed   // 1–29
+        case normal    // 30–59
+        case medium    // 60–79
+        case high      // 80–100
+
+        public static func of(_ score: Int) -> Band {
+            switch score {
+            case ..<30: return .relaxed
+            case ..<60: return .normal
+            case ..<80: return .medium
+            default: return .high
+            }
+        }
+
+        public var label: String {
+            switch self {
+            case .relaxed: return "Relaxed"
+            case .normal: return "Normal"
+            case .medium: return "Medium"
+            case .high: return "High"
+            }
+        }
+    }
+
+    /// Reference RMSSD bounds (ms) for the mapping. At/above `restedRMSSD` the score floors
+    /// near "relaxed"; at/below `stressedRMSSD` it tops out near "high". These bracket a broad,
+    /// defensible adult nocturnal RMSSD range; the curve interpolates in LOG space between them
+    /// (HRV is approximately log-normal), so it grades smoothly rather than stepping.
+    public static let restedRMSSD = 70.0
+    public static let stressedRMSSD = 15.0
+    /// Score endpoints the bounds map to (kept inside, not at, the 1/100 extremes so a single
+    /// value isn't over-claimed as a perfect/worst night).
+    static let lowScore = 15.0    // maps to a "relaxed" reading
+    static let highScore = 90.0   // maps to a "high" reading
+
+    /// Map a single RMSSD (ms) to a 0–100 overnight stress score (higher = more stress).
+    /// Monotonic decreasing in RMSSD, clamped to the reference window. Defensible heuristic.
+    public static func score(rmssdMs: Double) -> Int {
+        let rmssd = max(rmssdMs, 1)   // guard log(0)
+        let hi = log(restedRMSSD), lo = log(stressedRMSSD)
+        // t = 0 at the rested bound, 1 at the stressed bound.
+        let t = (hi - log(rmssd)) / (hi - lo)
+        let clamped = min(max(t, 0), 1)
+        let s = lowScore + clamped * (highScore - lowScore)
+        return Int(s.rounded())
+    }
+
+    /// Overnight stress from the night's per-epoch RMSSD values. Uses the MEDIAN RMSSD (robust
+    /// to the odd noisy epoch) as the night's representative HRV. nil when there's no HRV
+    /// (e.g. a connection-free night, or SpO2-only epochs). Non-positive values are dropped.
+    public static func overnightScore(rmssd: [Int]) -> Int? {
+        let valid = rmssd.filter { $0 > 0 }.sorted()
+        guard !valid.isEmpty else { return nil }
+        let median = Double(valid[valid.count / 2])
+        return score(rmssdMs: median)
+    }
+
+    /// Convenience: overnight stress straight from the night's sleep-vitals records.
+    public static func overnightScore(records: [BulkRecord]) -> Int? {
+        overnightScore(rmssd: records.compactMap { $0.hrvRMSSD })
+    }
+
+    /// Time spent in each stress band across the night, by classifying EACH epoch's RMSSD and
+    /// multiplying by the epoch length. Lets the UI show "X min relaxed · Y min high" honestly
+    /// from the data, not from the single nightly score. Epochs with no/invalid RMSSD are skipped.
+    public static func stateDurations(rmssd: [Int],
+                                      epochSeconds: Int = BulkRecord.epochSeconds) -> [Band: TimeInterval] {
+        var out: [Band: TimeInterval] = [:]
+        for v in rmssd where v > 0 {
+            out[Band.of(score(rmssdMs: Double(v))), default: 0] += TimeInterval(epochSeconds)
+        }
+        return out
+    }
+
+    public static func stateDurations(records: [BulkRecord]) -> [Band: TimeInterval] {
+        stateDurations(rmssd: records.compactMap { $0.hrvRMSSD })
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/Strain.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/Strain.swift
@@ -39,13 +39,43 @@ public struct Strain: Sendable {
     /// Strain for a BPM series sampled every `sampleSeconds`. nil if too few
     /// readings or maxHR ≤ restingHR. Mirrors `StrainCalculator::calculate`.
     public func calculate(bpms: [Int], sampleSeconds: Double = 1.0) -> Double? {
-        guard bpms.count >= Self.minReadings, maxHR > restingHR else { return nil }
+        guard let trimp = Self.edwardsTRIMP(
+            bpms: bpms,
+            maxHR: maxHR,
+            restingHR: restingHR,
+            sampleSeconds: sampleSeconds
+        ) else { return nil }
+        return Self.trimpToStrain(trimp)
+    }
+
+    /// Raw Edwards zone-weighted TRIMP for a BPM series.
+    public static func edwardsTRIMP(
+        bpms: [Int],
+        maxHR: Int,
+        restingHR: Int,
+        sampleSeconds: Double = 1.0
+    ) -> Double? {
+        guard bpms.count >= minReadings, maxHR > restingHR else { return nil }
         let hrReserve = Double(maxHR) - Double(restingHR)
         let sampleMin = sampleSeconds <= 0 ? 1.0 / 60.0 : sampleSeconds / 60.0
-        let trimp = bpms.reduce(0.0) { acc, bpm in
-            acc + sampleMin * Double(Self.zoneWeight(bpm: bpm, restingHR: restingHR, hrReserve: hrReserve))
+        return bpms.reduce(0.0) { acc, bpm in
+            acc + sampleMin * Double(zoneWeight(bpm: bpm, restingHR: restingHR, hrReserve: hrReserve))
         }
-        return Self.trimpToStrain(trimp)
+    }
+
+    /// Raw Edwards zone-weighted TRIMP for timestamped HR samples.
+    public static func edwardsTRIMP(hrSamples: [HRSample], maxHR: Int, restingHR: Int) -> Double? {
+        guard hrSamples.count >= minReadings, maxHR > restingHR else { return nil }
+        let hrReserve = Double(maxHR) - Double(restingHR)
+        return hrSamples.reduce(0.0) { acc, sample in
+            let duration = sample.end.timeIntervalSince(sample.start)
+            let sampleMin = duration > 0 ? duration / 60.0 : 1.0 / 60.0
+            return acc + sampleMin * Double(zoneWeight(
+                bpm: sample.bpm,
+                restingHR: restingHR,
+                hrReserve: hrReserve
+            ))
+        }
     }
 
     static func trimpToStrain(_ trimp: Double) -> Double {

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/TrendsEngine.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/TrendsEngine.swift
@@ -136,21 +136,30 @@ public enum TrendsEngine {
 
     // MARK: - Sleep regularity
 
-    /// Sleep regularity score 0–100: how consistent bedtime and wake time are across
-    /// the `window` nights. Based on the variance of bedtime offsets (minutes from midnight).
-    /// A low-variance schedule scores near 100; a high-variance one scores near 0.
-    /// nil when fewer than 2 nights have valid window data.
+    /// Sleep regularity score 0–100: how consistent bedtime is across the `window` nights.
+    /// Bedtime is "minutes since midnight" — a CIRCULAR quantity (23:58 and 00:02 are 4 min
+    /// apart, not 1436), so we use circular statistics: map each minute to an angle, take the
+    /// mean resultant length R, and convert the circular standard deviation back to minutes.
+    /// A tight near-midnight cluster therefore scores near 100 (a plain linear variance would
+    /// wrongly score the most-regular midnight sleeper as the MOST irregular). A widely spread
+    /// schedule scores near 0. nil when fewer than 2 nights have valid window data.
     public static func sleepRegularity(
         bedtimeMinutes: [Int],   // minutes since midnight for each night
         window: Int = 7
     ) -> Int? {
         let tail = Array(bedtimeMinutes.suffix(window))
         guard tail.count >= 2 else { return nil }
-        let mean = Double(tail.reduce(0, +)) / Double(tail.count)
-        let variance = tail.map { pow(Double($0) - mean, 2) }.reduce(0, +) / Double(tail.count)
-        let stdDev = sqrt(variance)
+        let n = Double(tail.count)
+        let angles = tail.map { 2.0 * Double.pi * Double($0) / 1440.0 }
+        let meanCos = angles.map(cos).reduce(0, +) / n
+        let meanSin = angles.map(sin).reduce(0, +) / n
+        // Mean resultant length R ∈ [0, 1]: 1 = perfectly clustered, 0 = uniformly spread.
+        let R = min(max((meanCos * meanCos + meanSin * meanSin).squareRoot(), 0), 1)
+        // Circular standard deviation (radians) = sqrt(-2 ln R); R→0 ⇒ maximal spread (π rad).
+        let circStdDevRad = R > 1e-9 ? (-2.0 * Foundation.log(R)).squareRoot() : Double.pi
+        let stdDevMinutes = circStdDevRad * 1440.0 / (2.0 * Double.pi)
         // Map stdDev → score: 0 min SD = 100, 60+ min SD = 0.
-        let score = max(0, Int((1.0 - stdDev / 60.0) * 100.0))
+        let score = max(0, Int((1.0 - stdDevMinutes / 60.0) * 100.0))
         return min(score, 100)
     }
 

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/TrendsEngine.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/TrendsEngine.swift
@@ -1,0 +1,168 @@
+// 7-day rolling aggregate computation for available decoded metrics (#74).
+//
+// SCOPE — AVAILABLE DATA ONLY.
+// Daily aggregates and 7-day rolling means for the metrics we actually decode:
+//   • Sleep-window HR / HRV / SpO2 / RR averages (from stored bulk-epoch samples)
+//   • Steps (from StoredDaily)
+//   • Nightly skin temp (from StoredSleepSummary.skinTempC)
+//   • Sleep score (from StoredSleepSummary.sleepScore)
+//   • Overnight stress (from StoredSleepSummary.stressScore)
+//   • Resting HR (optional, from caller-supplied values)
+//
+// ⚠️ Daytime/waking HR, HRV, SpO2 aggregates are NOT included. They need the
+// undecoded activity-epoch payload ([15:22] / #93). Those aggregates follow that
+// decode — do not guess or invent daytime values.
+//
+// The >29 bpm HR guard is applied per the APK SQL (pp.txt:62996):
+//   `AVG(CASE WHEN hrAvg>29 THEN hrAvg END) AS hr7Avg`
+
+import Foundation
+
+public enum TrendsEngine {
+
+    // MARK: - Data types
+
+    /// One day's aggregated data for trends display. All optional: nil = not available
+    /// (e.g. no sleep window that night, samples pruned, metric not decoded).
+    public struct DailyPoint: Equatable, Sendable {
+        public let date: Date          // start-of-day (calendar day this represents)
+
+        // Activity
+        public let steps: Int?         // daily decoded step count
+
+        // Sleep
+        public let sleepMinutes: Int?  // total sleep (asleep minutes)
+        public let sleepScore: Int?    // composite 0–100 (nil / 0 = not computed)
+        public let stressScore: Int?   // overnight stress 0–100 (nil / 0 = not computed)
+        public let skinTempC: Double?  // nightly skin temp °C (nil / 0 = no data)
+
+        // Sleep-window vitals (from stored epoch samples within the night's window)
+        // These are the ONLY HR/HRV/SpO2/RR we can aggregate — daytime values need #93.
+        public let sleepHRAvg: Double?
+        public let sleepHRVAvg: Double?     // ms RMSSD
+        public let sleepSpO2Avg: Double?    // 0…1 fraction
+        public let sleepRRAvg: Double?      // breaths/min
+
+        public init(
+            date: Date,
+            steps: Int? = nil,
+            sleepMinutes: Int? = nil,
+            sleepScore: Int? = nil,
+            stressScore: Int? = nil,
+            skinTempC: Double? = nil,
+            sleepHRAvg: Double? = nil,
+            sleepHRVAvg: Double? = nil,
+            sleepSpO2Avg: Double? = nil,
+            sleepRRAvg: Double? = nil
+        ) {
+            self.date = date
+            self.steps = steps
+            self.sleepMinutes = sleepMinutes
+            self.sleepScore = sleepScore
+            self.stressScore = stressScore
+            self.skinTempC = skinTempC
+            self.sleepHRAvg = sleepHRAvg
+            self.sleepHRVAvg = sleepHRVAvg
+            self.sleepSpO2Avg = sleepSpO2Avg
+            self.sleepRRAvg = sleepRRAvg
+        }
+    }
+
+    // MARK: - 7-day rolling averages
+
+    /// 7-day rolling averages across a window of `DailyPoint`s.
+    public struct RollingAverages: Equatable, Sendable {
+        public let steps: Double?
+        public let sleepMinutes: Double?
+        public let sleepScore: Double?
+        public let stressScore: Double?
+        public let skinTempC: Double?
+        public let sleepHRAvg: Double?
+        public let sleepHRVAvg: Double?
+        public let sleepSpO2Avg: Double?
+        public let sleepRRAvg: Double?
+    }
+
+    /// The APK SQL guard: exclude readings ≤ 29 bpm (pp.txt:62996).
+    public static let minValidHR: Double = 29
+
+    /// Compute 7-day (or `window`-day) rolling averages from the TRAILING points.
+    /// Uses only non-nil and guard-passing values; nil when there's no valid data at all.
+    public static func rollingAverages(_ points: [DailyPoint],
+                                       window: Int = 7) -> RollingAverages {
+        let tail = Array(points.suffix(window))
+        return RollingAverages(
+            steps:          avgInt(tail.compactMap(\.steps)),
+            sleepMinutes:   avgInt(tail.compactMap(\.sleepMinutes)),
+            sleepScore:     avgInt(tail.compactMap(\.sleepScore).filter { $0 > 0 }),
+            stressScore:    avgInt(tail.compactMap(\.stressScore).filter { $0 > 0 }),
+            skinTempC:      avgDouble(tail.compactMap(\.skinTempC).filter { $0 > 0 }),
+            sleepHRAvg:     avgDouble(tail.compactMap(\.sleepHRAvg).filter { $0 > minValidHR }),
+            sleepHRVAvg:    avgDouble(tail.compactMap(\.sleepHRVAvg).filter { $0 > 0 }),
+            sleepSpO2Avg:   avgDouble(tail.compactMap(\.sleepSpO2Avg).filter { $0 > 0 }),
+            sleepRRAvg:     avgDouble(tail.compactMap(\.sleepRRAvg).filter { $0 > 0 })
+        )
+    }
+
+    // MARK: - Trend direction
+
+    public enum Trend: String, Equatable, Sendable {
+        case up, down, flat
+    }
+
+    /// Compare the trailing `window` days against the prior `window` days.
+    /// Returns nil if there's not enough data for both windows.
+    /// `minDeltaFraction` = minimum relative change to be considered non-flat.
+    public static func trend(
+        for points: [DailyPoint],
+        window: Int = 7,
+        minDeltaFraction: Double = 0.03,
+        extract: (DailyPoint) -> Double?
+    ) -> Trend? {
+        guard points.count >= 2 else { return nil }
+        let recent = Array(points.suffix(window))
+        let prior  = Array(points.dropLast(recent.count).suffix(window))
+        let recentVals = recent.compactMap(extract)
+        let priorVals  = prior.compactMap(extract)
+        guard !recentVals.isEmpty, !priorVals.isEmpty else { return nil }
+        let recentMean = recentVals.reduce(0, +) / Double(recentVals.count)
+        let priorMean  = priorVals.reduce(0, +) / Double(priorVals.count)
+        guard abs(priorMean) > 0 else { return .flat }
+        let delta = (recentMean - priorMean) / abs(priorMean)
+        if delta >  minDeltaFraction { return .up }
+        if delta < -minDeltaFraction { return .down }
+        return .flat
+    }
+
+    // MARK: - Sleep regularity
+
+    /// Sleep regularity score 0–100: how consistent bedtime and wake time are across
+    /// the `window` nights. Based on the variance of bedtime offsets (minutes from midnight).
+    /// A low-variance schedule scores near 100; a high-variance one scores near 0.
+    /// nil when fewer than 2 nights have valid window data.
+    public static func sleepRegularity(
+        bedtimeMinutes: [Int],   // minutes since midnight for each night
+        window: Int = 7
+    ) -> Int? {
+        let tail = Array(bedtimeMinutes.suffix(window))
+        guard tail.count >= 2 else { return nil }
+        let mean = Double(tail.reduce(0, +)) / Double(tail.count)
+        let variance = tail.map { pow(Double($0) - mean, 2) }.reduce(0, +) / Double(tail.count)
+        let stdDev = sqrt(variance)
+        // Map stdDev → score: 0 min SD = 100, 60+ min SD = 0.
+        let score = max(0, Int((1.0 - stdDev / 60.0) * 100.0))
+        return min(score, 100)
+    }
+
+    // MARK: - Private helpers
+
+    private static func avgDouble(_ vals: [Double]) -> Double? {
+        guard !vals.isEmpty else { return nil }
+        return vals.reduce(0, +) / Double(vals.count)
+    }
+
+    private static func avgInt(_ vals: [Int]) -> Double? {
+        guard !vals.isEmpty else { return nil }
+        return Double(vals.reduce(0, +)) / Double(vals.count)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/VitalsBaseline.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/VitalsBaseline.swift
@@ -1,0 +1,257 @@
+// Vitals baseline + acute anomaly detection (Vitals Status / fever) — #72.
+//
+// The app's "Vitals Status" engine compares each day's vitals to a PERSONAL rolling
+// baseline (the APK uses a 7–30 day window, pp.txt:47810) and flags Minor / Significant
+// outliers (pp.txt:47815), then cross-references HR + skin temperature for a suspected-fever
+// flag (pp.txt:48241 "exhibiting suspected fever symptoms"; `keyWBVitalSignFever`;
+// `feverAbnormal` = 0x14). This file holds the PURE detection math (no Apple frameworks) so
+// it unit-tests on the CLI.
+//
+// All baselines are PERSONAL (derived from the user's own trailing history) — never a
+// hardcoded "healthy" range. A value is only flagged relative to that person's own normal,
+// so we never fabricate a medical value. Skin temperature is NOT recomputed here: the
+// canonical nightly offset comes from `SkinTempBaseline` (#69) and is passed in, exactly as
+// the ticket requires ("consumes the canonical skin-temp value … does not re-compute temp").
+//
+// This OWNS fever detection. The skin-temp ticket only supplies the temperature input; the
+// notifications ticket (#85) only routes the resulting flags to local notifications.
+
+import Foundation
+
+public enum VitalsBaseline {
+
+    // MARK: Vitals
+
+    /// The per-metric vitals that carry a personal baseline. Skin temperature is folded into the
+    /// status via its canonical offset (see `report`), not as a re-derived baseline here.
+    public enum Vital: String, CaseIterable, Sendable {
+        case restingHR
+        case overnightSpO2     // percent (0…100)
+        case overnightHRV      // RMSSD ms
+
+        /// The direction that is CLINICALLY concerning for this vital — a deviation the other way
+        /// (e.g. an unusually high HRV, an unusually low resting HR) is healthy, not an anomaly.
+        public var concern: Concern {
+            switch self {
+            case .restingHR: return .high     // a rising resting HR is the concern
+            case .overnightSpO2: return .low  // desaturation is the concern
+            case .overnightHRV: return .low   // falling HRV (stress/illness) is the concern
+            }
+        }
+    }
+
+    public enum Concern: Sendable { case high, low, both }
+
+    /// How far today's value sits from the personal baseline.
+    public enum Severity: String, Sendable, Equatable, CaseIterable {
+        case normal, minor, significant
+    }
+
+    public enum Direction: String, Sendable, Equatable { case rise, drop }
+
+    // MARK: Config
+
+    /// Window + threshold knobs. Defaults follow the APK's 7–30 day window; the z-score cut-offs
+    /// and absolute noise floors are defensible heuristics (labeled estimates in the UI), and the
+    /// caller may override them. Never a person's data — only policy.
+    public struct Config: Equatable, Sendable {
+        public var minBaselineDays: Int
+        public var maxBaselineDays: Int
+        /// |z| at/above this (and past the absolute floor) is a Minor outlier; …
+        public var minorZ: Double
+        /// … |z| at/above this is a Significant outlier.
+        public var significantZ: Double
+        /// Absolute deviation a vital must exceed before ANY flag — so a person with a very tight
+        /// baseline (tiny SD) isn't flagged on trivially small, noise-level changes.
+        public var minDeltaRestingHR: Double
+        public var minDeltaSpO2: Double
+        public var minDeltaHRV: Double
+        /// Skin-temp offset bands (°C), using the canonical SkinTempBaseline offset. |offset|
+        /// beyond `tempSignificantC` is Significant; beyond `tempMinorC` is Minor.
+        public var tempMinorC: Double
+        public var tempSignificantC: Double
+        /// Suspected fever needs BOTH a skin-temp rise ≥ this AND a resting-HR rise ≥ the bpm below.
+        public var feverTempRiseC: Double
+        public var feverHRRiseBpm: Double
+
+        public init(minBaselineDays: Int = 7,
+                    maxBaselineDays: Int = 30,
+                    minorZ: Double = 1.5,
+                    significantZ: Double = 2.5,
+                    minDeltaRestingHR: Double = 5,
+                    minDeltaSpO2: Double = 2,
+                    minDeltaHRV: Double = 8,
+                    tempMinorC: Double = 0.5,
+                    tempSignificantC: Double = SkinTempBaseline.normalDeviationC,
+                    feverTempRiseC: Double = SkinTempBaseline.normalDeviationC,
+                    feverHRRiseBpm: Double = 8) {
+            self.minBaselineDays = minBaselineDays
+            self.maxBaselineDays = maxBaselineDays
+            self.minorZ = minorZ
+            self.significantZ = significantZ
+            self.minDeltaRestingHR = minDeltaRestingHR
+            self.minDeltaSpO2 = minDeltaSpO2
+            self.minDeltaHRV = minDeltaHRV
+            self.tempMinorC = tempMinorC
+            self.tempSignificantC = tempSignificantC
+            self.feverTempRiseC = feverTempRiseC
+            self.feverHRRiseBpm = feverHRRiseBpm
+        }
+
+        func minDelta(_ vital: Vital) -> Double {
+            switch vital {
+            case .restingHR: return minDeltaRestingHR
+            case .overnightSpO2: return minDeltaSpO2
+            case .overnightHRV: return minDeltaHRV
+            }
+        }
+    }
+
+    // MARK: Baseline statistics
+
+    /// Mean / standard deviation over the trailing `maxBaselineDays` PRIOR daily values. `prior`
+    /// is chronological (oldest→newest); we take the most-recent window. nil below
+    /// `minBaselineDays` (too little history to call an outlier).
+    public struct Stats: Equatable, Sendable {
+        public let mean: Double
+        public let sd: Double
+        public let n: Int
+    }
+
+    public static func stats(_ prior: [Double], config: Config = Config()) -> Stats? {
+        let window = Array(prior.suffix(config.maxBaselineDays))
+        guard window.count >= config.minBaselineDays else { return nil }
+        let mean = window.reduce(0, +) / Double(window.count)
+        let variance = window.reduce(0.0) { $0 + ($1 - mean) * ($1 - mean) } / Double(window.count)
+        return Stats(mean: mean, sd: variance.squareRoot(), n: window.count)
+    }
+
+    // MARK: Per-vital classification
+
+    /// One day's classification of a vital against its personal baseline.
+    public struct Classification: Equatable, Sendable {
+        public let severity: Severity
+        public let baseline: Stats?
+        public let delta: Double          // today − baseline mean (0 when no baseline)
+        public let direction: Direction   // sign of `delta`
+    }
+
+    /// Classify today's value of `vital` against the prior daily series. Only deviations in the
+    /// vital's `concern` direction, past both the z-score cut-off AND the absolute floor, are
+    /// flagged — so a healthy swing (high HRV, low resting HR) stays `.normal`.
+    public static func classify(today: Double, prior: [Double], vital: Vital,
+                                config: Config = Config()) -> Classification {
+        guard let stats = stats(prior, config: config) else {
+            return Classification(severity: .normal, baseline: nil, delta: 0, direction: .rise)
+        }
+        let delta = today - stats.mean
+        let direction: Direction = delta >= 0 ? .rise : .drop
+        guard isConcerning(delta, vital.concern), abs(delta) >= config.minDelta(vital) else {
+            return Classification(severity: .normal, baseline: stats, delta: delta, direction: direction)
+        }
+        let z = stats.sd > 1e-9 ? abs(delta) / stats.sd : .greatestFiniteMagnitude
+        let severity: Severity = z >= config.significantZ ? .significant
+            : z >= config.minorZ ? .minor : .normal
+        return Classification(severity: severity, baseline: stats, delta: delta, direction: direction)
+    }
+
+    /// Severity of a skin-temperature deviation from the CANONICAL baseline offset (#69) — both
+    /// directions are concerning (fever vs. illness/recovery drop), so it isn't direction-gated.
+    public static func tempSeverity(offsetC: Double, config: Config = Config()) -> Severity {
+        let a = abs(offsetC)
+        if a >= config.tempSignificantC { return .significant }
+        if a >= config.tempMinorC { return .minor }
+        return .normal
+    }
+
+    private static func isConcerning(_ delta: Double, _ concern: Concern) -> Bool {
+        switch concern {
+        case .high: return delta > 0
+        case .low: return delta < 0
+        case .both: return delta != 0
+        }
+    }
+
+    // MARK: Fever (HR + temperature cross-reference) — this ticket OWNS it.
+
+    /// Suspected fever fires ONLY on COMBINED elevation: a skin-temp rise (the canonical offset
+    /// from `SkinTempBaseline`, NOT recomputed here) AND a resting-HR rise above the personal HR
+    /// baseline. Either alone is not enough — exactly the APK's HR+temp cross-reference. nil/insufficient
+    /// inputs ⇒ false (never a false positive). This is the `feverAbnormal` (0x14) signal.
+    public static func suspectedFever(restingHRToday: Double?, restingHRPrior: [Double],
+                                      skinTempOffsetC: Double?, config: Config = Config()) -> Bool {
+        guard let offset = skinTempOffsetC, offset >= config.feverTempRiseC else { return false }
+        guard let hr = restingHRToday, let hrStats = stats(restingHRPrior, config: config) else { return false }
+        return (hr - hrStats.mean) >= config.feverHRRiseBpm
+    }
+
+    // MARK: Vitals Status report
+
+    /// One day's value of a vital plus the prior daily series it's judged against.
+    public struct VitalInput: Equatable, Sendable {
+        public let vital: Vital
+        public let today: Double
+        public let prior: [Double]
+        public init(vital: Vital, today: Double, prior: [Double]) {
+            self.vital = vital; self.today = today; self.prior = prior
+        }
+    }
+
+    /// A single contributing signal in the Vitals Status panel.
+    public struct Signal: Equatable, Sendable {
+        public let vital: Vital?          // nil = skin-temperature (carried by `isTemperature`)
+        public let isTemperature: Bool
+        public let severity: Severity
+        public let delta: Double
+        public let direction: Direction
+        public let baselineMean: Double?
+    }
+
+    /// Overall Vitals Status, mirroring the app's normal / watch / anomaly framing.
+    public enum Status: String, Sendable, Equatable { case normal, watch, anomaly }
+
+    public struct Report: Equatable, Sendable {
+        public let status: Status
+        public let signals: [Signal]      // only the non-normal contributors
+        public let feverSuspected: Bool
+    }
+
+    /// Build the Vitals Status report. `skinTempOffsetC` is the canonical nightly offset from
+    /// `SkinTempBaseline` (#69) — temperature is NOT re-derived here. Status escalates to
+    /// `.anomaly` on any Significant outlier or a suspected fever, `.watch` on any Minor outlier.
+    public static func report(_ inputs: [VitalInput], skinTempOffsetC: Double? = nil,
+                              config: Config = Config()) -> Report {
+        var signals: [Signal] = []
+
+        for input in inputs {
+            let c = classify(today: input.today, prior: input.prior, vital: input.vital, config: config)
+            if c.severity != .normal {
+                signals.append(Signal(vital: input.vital, isTemperature: false, severity: c.severity,
+                                      delta: c.delta, direction: c.direction,
+                                      baselineMean: c.baseline?.mean))
+            }
+        }
+
+        if let offset = skinTempOffsetC {
+            let sev = tempSeverity(offsetC: offset, config: config)
+            if sev != .normal {
+                signals.append(Signal(vital: nil, isTemperature: true, severity: sev, delta: offset,
+                                      direction: offset >= 0 ? .rise : .drop, baselineMean: nil))
+            }
+        }
+
+        let hr = inputs.first { $0.vital == .restingHR }
+        let fever = suspectedFever(restingHRToday: hr?.today, restingHRPrior: hr?.prior ?? [],
+                                   skinTempOffsetC: skinTempOffsetC, config: config)
+
+        let status: Status
+        if fever || signals.contains(where: { $0.severity == .significant }) {
+            status = .anomaly
+        } else if signals.contains(where: { $0.severity == .minor }) {
+            status = .watch
+        } else {
+            status = .normal
+        }
+        return Report(status: status, signals: signals, feverSuspected: fever)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/Analytics/WorkoutSession.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Analytics/WorkoutSession.swift
@@ -1,0 +1,352 @@
+// WorkoutSession.swift — Pure workout analytics: HR-zone classification, time-in-zone,
+// session aggregation. No HealthKit or CoreLocation imports; all app-framework concerns
+// stay in the app target.
+//
+// Zone boundaries match the APK's SportRecordModel / "Exercise Heart Rate" screen
+// (pp.txt:0x515c0, confirmed):
+//   Warm-up       50–60% of maxHR  (data below 50% not counted — APK note)
+//   Fat burning   61–70% of maxHR
+//   Aerobic       71–80% of maxHR
+//   Anaerobic     81–90% of maxHR
+//   Extreme       91–100% of maxHR
+//
+// maxHR = 220 − age  (APK pp.txt:0x515c0 calculation formula).
+//
+// Live-HR (#45) WARNING: The 0x95→0x15 live-HR path is best-effort — it has no
+// background-refresh and on-demand polling often misses updates. A long workout
+// session is the worst case. This code records only ACTUAL decoded readings; it
+// never fills gaps by interpolation or fabrication. Gaps are preserved and surfaced
+// to the user. See issue #45 for the underlying reliability constraint.
+
+import Foundation
+
+// MARK: - Sport types
+
+/// Sport types the app supports. Each maps to an HKWorkoutActivityType on the app side.
+/// Outdoor types (walking, running, cycling, hiking) enable GPS route capture via
+/// CoreLocation; indoor types (strength, yoga, other) do not.
+public enum WorkoutSportType: String, Codable, CaseIterable, Sendable {
+    case walkingOutdoor
+    case runningOutdoor
+    case cyclingOutdoor
+    case hiking
+    case strengthTraining
+    case yoga
+    case other
+
+    public var displayName: String {
+        switch self {
+        case .walkingOutdoor: return "Outdoor Walking"
+        case .runningOutdoor: return "Outdoor Running"
+        case .cyclingOutdoor: return "Outdoor Cycling"
+        case .hiking:         return "Hiking"
+        case .strengthTraining: return "Strength"
+        case .yoga:           return "Yoga"
+        case .other:          return "Other"
+        }
+    }
+
+    /// Whether this sport type benefits from GPS route capture (phone-side CoreLocation).
+    /// For indoor types, no route is captured even when location permission is granted.
+    public var isOutdoor: Bool {
+        switch self {
+        case .walkingOutdoor, .runningOutdoor, .cyclingOutdoor, .hiking: return true
+        case .strengthTraining, .yoga, .other: return false
+        }
+    }
+
+    public var systemImageName: String {
+        switch self {
+        case .walkingOutdoor:    return "figure.walk"
+        case .runningOutdoor:    return "figure.run"
+        case .cyclingOutdoor:    return "bicycle"
+        case .hiking:            return "mountain.2"
+        case .strengthTraining:  return "dumbbell"
+        case .yoga:              return "figure.yoga"
+        case .other:             return "heart.circle"
+        }
+    }
+}
+
+// MARK: - HR Zones
+
+/// Five HR zones matching the APK's SportRecordModel zone schema.
+/// "Below zone" (< 50% maxHR) is NOT counted per the APK description.
+public enum HRZone: Int, CaseIterable, Sendable {
+    case warmUp    = 1   // 50–60%
+    case fatBurn   = 2   // 61–70%
+    case aerobic   = 3   // 71–80%
+    case anaerobic = 4   // 81–90%
+    case extreme   = 5   // 91–100%
+
+    public var displayName: String {
+        switch self {
+        case .warmUp:    return "Warm-up"
+        case .fatBurn:   return "Fat Burning"
+        case .aerobic:   return "Aerobic"
+        case .anaerobic: return "Anaerobic"
+        case .extreme:   return "Extreme"
+        }
+    }
+
+    /// Color token names (used in the app UI; resolved in SwiftUI).
+    public var colorName: String {
+        switch self {
+        case .warmUp:    return "zoneBlue"
+        case .fatBurn:   return "zoneGreen"
+        case .aerobic:   return "zoneYellow"
+        case .anaerobic: return "zoneOrange"
+        case .extreme:   return "zoneRed"
+        }
+    }
+
+    /// Percentage LOWER bound (inclusive) of this zone, as a fraction of maxHR.
+    public var lowerFraction: Double {
+        switch self {
+        case .warmUp:    return 0.50
+        case .fatBurn:   return 0.61
+        case .aerobic:   return 0.71
+        case .anaerobic: return 0.81
+        case .extreme:   return 0.91
+        }
+    }
+
+    /// Percentage UPPER bound (inclusive) of this zone, as a fraction of maxHR.
+    public var upperFraction: Double {
+        switch self {
+        case .warmUp:    return 0.60
+        case .fatBurn:   return 0.70
+        case .aerobic:   return 0.80
+        case .anaerobic: return 0.90
+        case .extreme:   return 1.00
+        }
+    }
+}
+
+// MARK: - Zone classifier
+
+/// Pure functions for HR zone classification and time-in-zone accumulation.
+public enum HRZoneClassifier {
+
+    /// Classify a single BPM reading against maxHR, returning the zone (or nil if
+    /// below 50% of maxHR — per APK, sub-50% readings are not counted in zone distribution).
+    public static func zone(bpm: Int, maxHR: Int) -> HRZone? {
+        guard maxHR > 0, bpm > 0 else { return nil }
+        let frac = Double(bpm) / Double(maxHR)
+        for zone in HRZone.allCases.reversed() {
+            if frac >= zone.lowerFraction { return zone }
+        }
+        return nil   // below 50% — not counted
+    }
+
+    /// Accumulate time (seconds) spent in each zone from a list of timestamped HR samples.
+    /// Only actual decoded readings are counted — no gap filling, no interpolation.
+    /// Gaps between samples (e.g. polling misses due to #45 flakiness) are NOT attributed
+    /// to any zone; the duration used for each sample is the sample's own interval
+    /// (end - start), defaulting to 0 if end == start (instantaneous reading).
+    public static func timeInZones(
+        hrSamples: [HRSample],
+        maxHR: Int
+    ) -> WorkoutZoneBreakdown {
+        var seconds = [HRZone: Double]()
+        for z in HRZone.allCases { seconds[z] = 0 }
+        for sample in hrSamples {
+            let dur = sample.end.timeIntervalSince(sample.start)
+            guard dur > 0, let zone = zone(bpm: sample.bpm, maxHR: maxHR) else { continue }
+            seconds[zone, default: 0] += dur
+        }
+        return WorkoutZoneBreakdown(secondsInZone: seconds)
+    }
+}
+
+// MARK: - Zone breakdown
+
+/// Time-in-zone breakdown for one workout (seconds per zone).
+/// Flat struct (not a dictionary) so Codable synthesis works without custom CodingKey.
+public struct WorkoutZoneBreakdown: Equatable, Codable, Sendable {
+    public var warmUpSeconds: Double
+    public var fatBurnSeconds: Double
+    public var aerobicSeconds: Double
+    public var anaerobicSeconds: Double
+    public var extremeSeconds: Double
+
+    public init(warmUpSeconds: Double = 0, fatBurnSeconds: Double = 0,
+                aerobicSeconds: Double = 0, anaerobicSeconds: Double = 0,
+                extremeSeconds: Double = 0) {
+        self.warmUpSeconds = warmUpSeconds
+        self.fatBurnSeconds = fatBurnSeconds
+        self.aerobicSeconds = aerobicSeconds
+        self.anaerobicSeconds = anaerobicSeconds
+        self.extremeSeconds = extremeSeconds
+    }
+
+    /// Convenience initialiser from a zone → seconds dictionary (used internally).
+    init(secondsInZone: [HRZone: Double]) {
+        warmUpSeconds    = secondsInZone[.warmUp]    ?? 0
+        fatBurnSeconds   = secondsInZone[.fatBurn]   ?? 0
+        aerobicSeconds   = secondsInZone[.aerobic]   ?? 0
+        anaerobicSeconds = secondsInZone[.anaerobic] ?? 0
+        extremeSeconds   = secondsInZone[.extreme]   ?? 0
+    }
+
+    public func seconds(in zone: HRZone) -> Double {
+        switch zone {
+        case .warmUp:    return warmUpSeconds
+        case .fatBurn:   return fatBurnSeconds
+        case .aerobic:   return aerobicSeconds
+        case .anaerobic: return anaerobicSeconds
+        case .extreme:   return extremeSeconds
+        }
+    }
+
+    /// Total zone-counted seconds (excludes below-50% / not-in-zone intervals).
+    public var totalZoneSeconds: Double {
+        warmUpSeconds + fatBurnSeconds + aerobicSeconds + anaerobicSeconds + extremeSeconds
+    }
+
+    /// Fraction 0…1 for a zone's share of total zone time.
+    public func fraction(in zone: HRZone) -> Double {
+        let total = totalZoneSeconds
+        guard total > 0 else { return 0 }
+        return seconds(in: zone) / total
+    }
+}
+
+// MARK: - Workout summary
+
+/// Completed workout summary. Produced after the session ends; never contains fabricated values.
+/// HR stats derive solely from actual decoded samples — gaps from #45 polling flakiness are
+/// NOT filled or interpolated.
+public struct WorkoutSummary: Equatable, Codable, Sendable {
+    /// Sport type selected by the user.
+    public let sport: WorkoutSportType
+    /// Wall-clock start time of the session.
+    public let startDate: Date
+    /// Wall-clock end time of the session (when the user tapped Stop).
+    public let endDate: Date
+    /// Elapsed time in seconds (wall-clock duration, including periods with no HR readings).
+    public var durationSeconds: TimeInterval { endDate.timeIntervalSince(startDate) }
+    /// Average BPM across all actual decoded HR readings (nil if no readings were captured).
+    public let avgHR: Int?
+    /// Maximum BPM recorded during the session (nil if no readings).
+    public let maxHR: Int?
+    /// Estimated active calories from Edwards-TRIMP (ESTIMATE — labeled as such in the UI).
+    /// nil if insufficient HR data for a meaningful estimate.
+    public let estimatedActiveKcal: Double?
+    /// 5-zone HR breakdown from actual sample durations.
+    public let zoneBreakdown: WorkoutZoneBreakdown
+    /// GPS distance in meters (phone-side CoreLocation). nil for indoor sports or when
+    /// location permission was denied.
+    public let distanceMeters: Double?
+    /// Whether a GPS route was captured (and attached as HKWorkoutRoute in HealthKit).
+    public let hasRoute: Bool
+    /// Count of actual HR readings captured during the session.
+    public let hrSampleCount: Int
+    /// True when the user's max HR (220 − age) was used for zone calculations.
+    /// Always true for this implementation (formula from APK).
+    public let usedFormulaMaxHR: Bool
+
+    public init(
+        sport: WorkoutSportType,
+        startDate: Date,
+        endDate: Date,
+        avgHR: Int?,
+        maxHR: Int?,
+        estimatedActiveKcal: Double?,
+        zoneBreakdown: WorkoutZoneBreakdown,
+        distanceMeters: Double?,
+        hasRoute: Bool,
+        hrSampleCount: Int,
+        usedFormulaMaxHR: Bool = true
+    ) {
+        self.sport = sport
+        self.startDate = startDate
+        self.endDate = endDate
+        self.avgHR = avgHR
+        self.maxHR = maxHR
+        self.estimatedActiveKcal = estimatedActiveKcal
+        self.zoneBreakdown = zoneBreakdown
+        self.distanceMeters = distanceMeters
+        self.hasRoute = hasRoute
+        self.hrSampleCount = hrSampleCount
+        self.usedFormulaMaxHR = usedFormulaMaxHR
+    }
+}
+
+// MARK: - Session aggregator
+
+/// Builds a `WorkoutSummary` from accumulated HR samples. Call `add(sample:)` as readings
+/// arrive, then `finalize(sport:endDate:distanceMeters:hasRoute:profile:)` to produce the
+/// summary. Thread-safety: designed for @MainActor use (all calls from WorkoutSessionManager).
+public final class WorkoutSessionAggregator: @unchecked Sendable {
+
+    private var samples: [HRSample] = []
+    private let startDate: Date
+    private let formulaMaxHR: Int
+
+    /// - Parameters:
+    ///   - startDate: When the session started (wall clock).
+    ///   - userAge: Used to compute maxHR = 220 − age (APK formula). Must be > 0.
+    public init(startDate: Date, userAge: Int) {
+        self.startDate = startDate
+        self.formulaMaxHR = max(220 - max(userAge, 1), 1)
+    }
+
+    /// Record a decoded HR reading. `start` and `end` should bound the interval the
+    /// sample represents (so time-in-zone accounting is accurate). For instantaneous
+    /// poll results, pass end == start; the zone classifier will still classify the
+    /// BPM but contribute 0 s to the zone seconds (it is still counted in avg/max).
+    public func add(sample: HRSample) {
+        samples.append(sample)
+    }
+
+    /// Produce the final `WorkoutSummary`. Safe to call with zero samples — all HR
+    /// fields will be nil rather than fabricated.
+    public func finalize(
+        sport: WorkoutSportType,
+        endDate: Date,
+        distanceMeters: Double?,
+        hasRoute: Bool,
+        profile: UserProfile
+    ) -> WorkoutSummary {
+        let avgHR: Int?
+        let maxHRValue: Int?
+        let estimatedKcal: Double?
+
+        if samples.isEmpty {
+            avgHR = nil
+            maxHRValue = nil
+            estimatedKcal = nil
+        } else {
+            let sum = samples.reduce(0) { $0 + $1.bpm }
+            avgHR = sum / samples.count
+            maxHRValue = samples.map(\.bpm).max()
+            // Active calories: Edwards-TRIMP. Requires ≥ 600 samples (Strain.minReadings)
+            // to produce a meaningful estimate; returns nil otherwise. LABELED as estimate.
+            let trimp = Strain.edwardsTRIMP(
+                hrSamples: samples,
+                maxHR: formulaMaxHR,
+                restingHR: Calories.defaultRestingHR
+            )
+            estimatedKcal = trimp.map { $0 * Calories.trimpKcalFactor }
+        }
+
+        let zones = HRZoneClassifier.timeInZones(hrSamples: samples, maxHR: formulaMaxHR)
+        return WorkoutSummary(
+            sport: sport,
+            startDate: startDate,
+            endDate: endDate,
+            avgHR: avgHR,
+            maxHR: maxHRValue,
+            estimatedActiveKcal: estimatedKcal,
+            zoneBreakdown: zones,
+            distanceMeters: distanceMeters,
+            hasRoute: hasRoute,
+            hrSampleCount: samples.count,
+            usedFormulaMaxHR: true
+        )
+    }
+
+    /// All samples collected so far (for HealthKit HR series write).
+    public var collectedSamples: [HRSample] { samples }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/AutoMeasureGate.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/AutoMeasureGate.swift
@@ -1,0 +1,59 @@
+// Auto-measure wear gate (#56). The ring reports HR/SpO₂ only on demand, so the app
+// periodically enters a brief live read to refresh them (RingSession.startAutoMeasure). On
+// the charger / off the wrist the ring never locks a reading, so a fixed-cadence probe just
+// times out every ~10 min and drains both the ring and the phone. This infers "not worn"
+// from PROVEN proxies and backs the probe off exponentially, resuming the normal cadence the
+// instant a reading locks (or the skin temperature reads warm) again.
+//
+// Proxies, honest about confidence:
+//   • consecutive auto-measures that never lock a reading (🟢 — the absence of ANY lock over
+//     several attempts is strong evidence the ring isn't on a finger).
+//   • the raw skin-temperature descriptor (🟡 — a worn Gen-2 reads ≳28 °C; off-wrist it falls
+//     toward room ambient ~20–24 °C). Used only to ACCELERATE the inference and to clear it
+//     promptly on re-wear.
+// It deliberately consults NO charging-flag byte — that descriptor field is undecoded
+// (#61 / PROTOCOL.md §5.4 🔴), so we never CLAIM to know the ring is charging. Pure (no Apple
+// frameworks) so it unit-tests on the CLI, mirroring ReconnectBackoff / KeepaliveCadence.
+
+import Foundation
+
+public enum AutoMeasureGate {
+    /// Consecutive auto-measure cycles with no lock after which the ring is inferred NOT WORN
+    /// when there's no temperature signal to lean on (🟢 fallback). With a cold reading a
+    /// single miss already confirms it (see `appearsNotWorn`).
+    public static let notWornAfterFailures = 2
+
+    /// Hard ceiling on how many times the base interval is doubled while not worn (base ×2^n).
+    public static let maxBackoffDoublings = 4
+
+    /// Whether the ring appears NOT WORN, from the consecutive no-lock count and (optionally)
+    /// the most recent raw skin temperature:
+    ///   • a warm reading (≥ `wornMinC`) is direct evidence of wear → not-worn = false;
+    ///   • a cold reading needs only ONE failed lock to confirm not-worn (we never declare it
+    ///     on a cold reading alone — a worn-but-cool ring would have LOCKED that one probe);
+    ///   • with no temperature signal we fall back to `notWornAfterFailures` consecutive misses.
+    public static func appearsNotWorn(consecutiveNoLock: Int,
+                                      rawSkinTempC: Double? = nil,
+                                      wornMinC: Double = ActivityPeriod.wornMinTemperatureC) -> Bool {
+        if let t = rawSkinTempC {
+            if t >= wornMinC { return false }            // warm skin ⇒ worn (🟡, direct)
+            return consecutiveNoLock >= 1                 // cold + a missed lock ⇒ not worn
+        }
+        return consecutiveNoLock >= notWornAfterFailures  // no temp ⇒ 🟢 failed-lock fallback
+    }
+
+    /// Next interval between auto-measure cycles. While worn (or not yet inferred not-worn) this
+    /// is `base`; once not worn it doubles per additional consecutive miss, capped at both
+    /// `base × 2^maxBackoffDoublings` and `cap`. A lock (consecutiveNoLock → 0) or a warm
+    /// reading drops it straight back to `base`.
+    public static func interval(base: TimeInterval,
+                                cap: TimeInterval,
+                                consecutiveNoLock: Int,
+                                rawSkinTempC: Double? = nil,
+                                wornMinC: Double = ActivityPeriod.wornMinTemperatureC) -> TimeInterval {
+        guard appearsNotWorn(consecutiveNoLock: consecutiveNoLock,
+                             rawSkinTempC: rawSkinTempC, wornMinC: wornMinC) else { return base }
+        let doublings = min(max(consecutiveNoLock - 1, 0), maxBackoffDoublings)
+        return min(base * pow(2, Double(doublings)), cap)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
@@ -54,15 +54,26 @@ public struct BulkRecord: Equatable {
     }
 
     public var layout: Layout {
-        // A sleep-vitals epoch carries SpO2 in [8] even when motion is at baseline and
-        // the [15:22] payload is zero (common in deep sleep) — so check [8] FIRST, else
-        // those real epochs would be mistaken for the idle/unworn template and their
-        // HR/SpO2 dropped.
-        if (0x57...0x63).contains(raw[8]) { return .sleepVitals }
-        if raw[10..<15] == [1, 1, 1, 1, 1] && raw[15..<22] == [0, 0, 0, 0, 0, 0, 0] {
+        // Decide layout from STRUCTURE, not the SpO2 *value* (#39). The old code returned
+        // .sleepVitals only when [8] ∈ 0x57…0x63 (87–99 %), so a genuine desaturation
+        // (< 87 %, the clinically interesting apnea case) failed that gate, fell through to
+        // .activity, and the WHOLE epoch's HR/HRV/SpO2 was discarded. Decide instead by the
+        // two STRUCTURAL signatures and treat anything else as sleep-vitals:
+        //   • idle/unworn template (🟢 §5.3): [4:8]=05 00 0c 00, [9]=0a, motion 01×5,
+        //     [15:22]=00×7. The FULL template matters: a deep-sleep epoch is also still with
+        //     a zero [15:22] payload, but carries real HR/HRV in [4:8] — so matching only
+        //     "still + zero payload" would mistake deep sleep for idle and drop its vitals.
+        //   • activity/awake epoch (🟢 §5.3): [8] subtype tag 0x12 / 0x13.
+        // A low-SpO2 sleep epoch matches neither → .sleepVitals, so its vitals survive. The
+        // emitted SpO2 is range-guarded in `spo2Percent`, but the band no longer gates layout.
+        if raw[4] == 0x05 && raw[5] == 0x00 && raw[6] == 0x0c && raw[7] == 0x00
+            && raw[9] == 0x0a
+            && raw[10..<15] == [1, 1, 1, 1, 1]
+            && raw[15..<22] == [0, 0, 0, 0, 0, 0, 0] {
             return .idle
         }
-        return .activity
+        if raw[8] == 0x12 || raw[8] == 0x13 { return .activity }
+        return .sleepVitals
     }
 
     /// Heart rate in bpm — `[4]` on a sleep-vitals epoch (🟢). nil otherwise / when 0.
@@ -78,10 +89,14 @@ public struct BulkRecord: Equatable {
         return Int(raw[5])
     }
 
-    /// SpO2 percent — `[8]` on a sleep-vitals epoch (🟢, range 87…99 observed). nil otherwise.
+    /// SpO2 percent — `[8]` on a sleep-vitals epoch (🟢). nil otherwise. Guarded to a
+    /// clinically plausible band (70…100): unlike the old layout gate this admits genuine
+    /// desaturations below the healthy 87…99 range (#39) while rejecting noise. The HR/HRV
+    /// of a sub-70 epoch still decode — only the implausible SpO2 reading is dropped.
     public var spo2Percent: Int? {
         guard layout == .sleepVitals else { return nil }
-        return Int(raw[8])
+        let v = Int(raw[8])
+        return (70...100).contains(v) ? v : nil
     }
 
     /// Respiratory rate in breaths/min — `[7]` on a sleep-vitals epoch, scaled ÷8 (🟢,
@@ -152,11 +167,15 @@ public enum BulkSleep {
 
     /// The main sleep block (in-bed window) detected from the motion channel, or nil.
     /// Pass `within:` to bound detection to the user's scheduled sleep window (optional).
+    /// Pass `temperatures:` (the night's persisted skin-temp samples) to exclude
+    /// off-wrist / charging blocks from sleep (#41); empty = motion-only (unchanged).
     public static func mainSleep(from records: [BulkRecord],
                                  within hint: DateInterval? = nil,
+                                 temperatures: [TemperatureSample] = [],
                                  epoch: Int = Command.syncEpoch) -> ActivityPeriod? {
         let scoped = Self.records(records, within: hint, epoch: epoch)
-        var periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch))
+        var periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch),
+                                                      temperatureSamples: temperatures)
         return ActivityPeriod.findSleep(&periods)
     }
 
@@ -164,11 +183,14 @@ public enum BulkSleep {
     /// `asleepCore`/`awake` sub-segments from the stillness detection. Finer
     /// Light/Deep/REM staging needs an HR-based model (TODO) — the ring doesn't
     /// send a hypnogram (PROTOCOL.md §5.3), so all "asleep" is reported as core.
+    /// Pass `temperatures:` to drop off-wrist / charging blocks from the night (#41).
     public static func sleepSegments(from records: [BulkRecord],
                                      within hint: DateInterval? = nil,
+                                     temperatures: [TemperatureSample] = [],
                                      epoch: Int = Command.syncEpoch) -> [SleepSegment] {
         let scoped = Self.records(records, within: hint, epoch: epoch)
-        let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch))
+        let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch),
+                                                      temperatureSamples: temperatures)
         // Main in-bed block = longest sleep period over the minimum duration (1 h).
         guard let block = periods
             .filter({ $0.activity == .sleep })

--- a/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
@@ -84,6 +84,15 @@ public struct BulkRecord: Equatable {
         return Int(raw[8])
     }
 
+    /// Respiratory rate in breaths/min — `[7]` on a sleep-vitals epoch, scaled ÷8 (🟢,
+    /// ground-truthed 2026-06-15): per-epoch `[7]/8` matches the RingConn app's nightly
+    /// average 15.1 and its low/high 14.5–16.1 at the p5–p95 of the asleep epochs. (The
+    /// raw field is RR×8; exact divisor ≈8.07, but 8 is the natural 1/8-brpm fixed point.)
+    public var respiratoryRate: Double? {
+        guard layout == .sleepVitals, raw[7] > 0 else { return nil }
+        return Double(raw[7]) / 8.0
+    }
+
     /// `[10:15]` — 5 per-30 s motion/activity counts (🟢 role). `01` baseline = still.
     public var motion: [UInt8] { Array(raw[10..<15]) }
 }
@@ -193,6 +202,9 @@ public enum BulkSleep {
             }
             if let spo2 = r.spo2Percent {
                 out.append(QuantitySample(kind: .spo2, start: t, value: Double(spo2) / 100.0))
+            }
+            if let rr = r.respiratoryRate {
+                out.append(QuantitySample(kind: .respiratoryRate, start: t, value: rr))
             }
         }
         return out

--- a/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
@@ -54,10 +54,15 @@ public struct BulkRecord: Equatable {
     }
 
     public var layout: Layout {
+        // A sleep-vitals epoch carries SpO2 in [8] even when motion is at baseline and
+        // the [15:22] payload is zero (common in deep sleep) — so check [8] FIRST, else
+        // those real epochs would be mistaken for the idle/unworn template and their
+        // HR/SpO2 dropped.
+        if (0x57...0x63).contains(raw[8]) { return .sleepVitals }
         if raw[10..<15] == [1, 1, 1, 1, 1] && raw[15..<22] == [0, 0, 0, 0, 0, 0, 0] {
             return .idle
         }
-        return (0x57...0x63).contains(raw[8]) ? .sleepVitals : .activity
+        return .activity
     }
 
     /// Heart rate in bpm — `[4]` on a sleep-vitals epoch (🟢). nil otherwise / when 0.
@@ -153,6 +158,88 @@ public enum BulkSleep {
                                      stage: p.activity == .sleep ? .asleepCore : .awake))
         }
         return segs
+    }
+
+    // MARK: - Experimental Deep/REM staging
+    //
+    // ⚠️ HEURISTIC, NOT VALIDATED PER-EPOCH. The ring sends no hypnogram (§5.3), so
+    // this estimates stages from HR + motion only: Awake = motion, Deep = HR in the
+    // lowest band, REM = HR in the highest band, else Light (≥5-min runs). Tuned on
+    // the 2026-06-13 night: it matches the app's stage TOTALS to ~13% (Awake 8 vs 13,
+    // REM 142 vs 115, Light 222 vs 242, Deep 100 vs 90 min) BUT does NOT reproduce the
+    // sleep ARCHITECTURE — that night it put Deep late / REM early (inverted vs the
+    // normal Deep-early/REM-late pattern), because HR alone can't place the cycles and
+    // the deepest HR fell just before sleep-onset. Treat output as approximate stage
+    // proportions, not trustworthy per-segment timing. `sleepSegments` (coarse
+    // asleep/awake) remains the non-experimental default.
+
+    public static let deepPercentile = 0.20
+    public static let remPercentile = 0.70
+    public static let awakeMotionThreshold = 15
+    public static let minStageRunEpochs = 2   // ~5 min
+
+    /// Experimental Light/Deep/REM/Awake staging of the detected sleep block.
+    /// See the caveat above — this is an approximation, not the ring's own staging.
+    public static func stagedSegments(from records: [BulkRecord],
+                                      epoch: Int = Command.syncEpoch) -> [SleepSegment] {
+        guard let block = mainSleep(from: records, epoch: epoch) else { return [] }
+        // Epochs inside the block, with forward-filled HR and motion magnitude.
+        let inBlock = records
+            .filter { $0.date(epoch: epoch) >= block.start && $0.date(epoch: epoch) <= block.end }
+            .sorted { $0.counter < $1.counter }
+        guard !inBlock.isEmpty else { return [] }
+
+        var lastHR: Int?
+        var rows: [(time: Date, hr: Int, motion: Int)] = []
+        for r in inBlock {
+            if let hr = r.heartRate { lastHR = hr }
+            guard let hr = lastHR else { continue }   // skip until first HR
+            let motion = r.motion.reduce(0) { $0 + ($1 == 1 ? 0 : Int($1)) }
+            rows.append((r.date(epoch: epoch), hr, motion))
+        }
+        guard rows.count >= 2 else { return [] }
+
+        // HR percentiles over "calm" (non-moving) epochs => the asleep HR distribution.
+        let calm = rows.filter { $0.motion <= awakeMotionThreshold }.map(\.hr).sorted()
+        let pool = calm.count >= 2 ? calm : rows.map(\.hr).sorted()
+        func pct(_ q: Double) -> Int { pool[Int(q * Double(pool.count - 1))] }
+        let deepHR = pct(deepPercentile), remHR = pct(remPercentile)
+
+        var stages: [SleepStage] = rows.map { row in
+            if row.motion > awakeMotionThreshold { return .awake }
+            if row.hr <= deepHR { return .asleepDeep }
+            if row.hr >= remHR { return .asleepREM }
+            return .asleepCore
+        }
+        // Drop too-short Deep/REM runs to Light (smoothing).
+        smoothShortRuns(&stages)
+
+        // Merge consecutive same-stage epochs into segments; each epoch spans to the next.
+        var segs = [SleepSegment(start: block.start, end: block.end, stage: .inBed)]
+        var i = 0
+        while i < rows.count {
+            var j = i
+            while j + 1 < rows.count && stages[j + 1] == stages[i] { j += 1 }
+            let end = j + 1 < rows.count ? rows[j + 1].time
+                : rows[j].time.addingTimeInterval(Double(BulkRecord.epochSeconds))
+            segs.append(SleepSegment(start: rows[i].time, end: min(end, block.end), stage: stages[i]))
+            i = j + 1
+        }
+        return segs
+    }
+
+    private static func smoothShortRuns(_ stages: inout [SleepStage]) {
+        let n = stages.count
+        var i = 0
+        while i < n {
+            var j = i
+            while j + 1 < n && stages[j + 1] == stages[i] { j += 1 }
+            let runLen = j - i + 1
+            if (stages[i] == .asleepDeep || stages[i] == .asleepREM) && runLen < minStageRunEpochs {
+                for k in i ... j { stages[k] = .asleepCore }
+            }
+            i = j + 1
+        }
     }
 
     /// HR / HRV / SpO2 samples from sleep-vitals epochs, with device timestamps.

--- a/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
@@ -160,86 +160,21 @@ public enum BulkSleep {
         return segs
     }
 
-    // MARK: - Experimental Deep/REM staging
+    // MARK: - Light/Deep/REM staging
     //
-    // ⚠️ HEURISTIC, NOT VALIDATED PER-EPOCH. The ring sends no hypnogram (§5.3), so
-    // this estimates stages from HR + motion only: Awake = motion, Deep = HR in the
-    // lowest band, REM = HR in the highest band, else Light (≥5-min runs). Tuned on
-    // the 2026-06-13 night: it matches the app's stage TOTALS to ~13% (Awake 8 vs 13,
-    // REM 142 vs 115, Light 222 vs 242, Deep 100 vs 90 min) BUT does NOT reproduce the
-    // sleep ARCHITECTURE — that night it put Deep late / REM early (inverted vs the
-    // normal Deep-early/REM-late pattern), because HR alone can't place the cycles and
-    // the deepest HR fell just before sleep-onset. Treat output as approximate stage
-    // proportions, not trustworthy per-segment timing. `sleepSegments` (coarse
-    // asleep/awake) remains the non-experimental default.
+    // ⚠️ APPROXIMATION, NOT VALIDATED PER-EPOCH. The ring sends no hypnogram (§5.3), so
+    // stages are estimated from the per-epoch HR/HRV/motion signals. The model now lives
+    // in `SleepStaging` (Analytics/SleepStaging.swift): HR bands are drawn from the
+    // night's OWN asleep HR distribution, and REM is separated from Light by HR/HRV
+    // variability (not just absolute HR). Validated only against the app's night TOTALS,
+    // never per-segment timing — treat output as approximate stage proportions.
+    // `sleepSegments` (coarse asleep/awake) remains the non-experimental default.
 
-    public static let deepPercentile = 0.20
-    public static let remPercentile = 0.70
-    public static let awakeMotionThreshold = 15
-    public static let minStageRunEpochs = 2   // ~5 min
-
-    /// Experimental Light/Deep/REM/Awake staging of the detected sleep block.
-    /// See the caveat above — this is an approximation, not the ring's own staging.
+    /// Light/Deep/REM/Awake staging of the detected sleep block. Thin wrapper over
+    /// `SleepStaging.classify` (kept for source compatibility with existing callers).
     public static func stagedSegments(from records: [BulkRecord],
                                       epoch: Int = Command.syncEpoch) -> [SleepSegment] {
-        guard let block = mainSleep(from: records, epoch: epoch) else { return [] }
-        // Epochs inside the block, with forward-filled HR and motion magnitude.
-        let inBlock = records
-            .filter { $0.date(epoch: epoch) >= block.start && $0.date(epoch: epoch) <= block.end }
-            .sorted { $0.counter < $1.counter }
-        guard !inBlock.isEmpty else { return [] }
-
-        var lastHR: Int?
-        var rows: [(time: Date, hr: Int, motion: Int)] = []
-        for r in inBlock {
-            if let hr = r.heartRate { lastHR = hr }
-            guard let hr = lastHR else { continue }   // skip until first HR
-            let motion = r.motion.reduce(0) { $0 + ($1 == 1 ? 0 : Int($1)) }
-            rows.append((r.date(epoch: epoch), hr, motion))
-        }
-        guard rows.count >= 2 else { return [] }
-
-        // HR percentiles over "calm" (non-moving) epochs => the asleep HR distribution.
-        let calm = rows.filter { $0.motion <= awakeMotionThreshold }.map(\.hr).sorted()
-        let pool = calm.count >= 2 ? calm : rows.map(\.hr).sorted()
-        func pct(_ q: Double) -> Int { pool[Int(q * Double(pool.count - 1))] }
-        let deepHR = pct(deepPercentile), remHR = pct(remPercentile)
-
-        var stages: [SleepStage] = rows.map { row in
-            if row.motion > awakeMotionThreshold { return .awake }
-            if row.hr <= deepHR { return .asleepDeep }
-            if row.hr >= remHR { return .asleepREM }
-            return .asleepCore
-        }
-        // Drop too-short Deep/REM runs to Light (smoothing).
-        smoothShortRuns(&stages)
-
-        // Merge consecutive same-stage epochs into segments; each epoch spans to the next.
-        var segs = [SleepSegment(start: block.start, end: block.end, stage: .inBed)]
-        var i = 0
-        while i < rows.count {
-            var j = i
-            while j + 1 < rows.count && stages[j + 1] == stages[i] { j += 1 }
-            let end = j + 1 < rows.count ? rows[j + 1].time
-                : rows[j].time.addingTimeInterval(Double(BulkRecord.epochSeconds))
-            segs.append(SleepSegment(start: rows[i].time, end: min(end, block.end), stage: stages[i]))
-            i = j + 1
-        }
-        return segs
-    }
-
-    private static func smoothShortRuns(_ stages: inout [SleepStage]) {
-        let n = stages.count
-        var i = 0
-        while i < n {
-            var j = i
-            while j + 1 < n && stages[j + 1] == stages[i] { j += 1 }
-            let runLen = j - i + 1
-            if (stages[i] == .asleepDeep || stages[i] == .asleepREM) && runLen < minStageRunEpochs {
-                for k in i ... j { stages[k] = .asleepCore }
-            }
-            i = j + 1
-        }
+        SleepStaging.classify(from: records, epoch: epoch)
     }
 
     /// HR / HRV / SpO2 samples from sleep-vitals epochs, with device timestamps.

--- a/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
@@ -139,10 +139,24 @@ public enum BulkSleep {
         return out
     }
 
+    /// Restrict `records` to those whose epoch falls within `hint`, or return them
+    /// unchanged when no hint is given. Extension point for the sleep-schedule abstraction:
+    /// the app can pass the user's bedtime→wake window (see ios/OpenRingConn/SleepSchedule)
+    /// so detection ignores stray daytime/charging motion outside the expected night.
+    public static func records(_ records: [BulkRecord],
+                               within hint: DateInterval?,
+                               epoch: Int = Command.syncEpoch) -> [BulkRecord] {
+        guard let hint else { return records }
+        return records.filter { hint.contains($0.date(epoch: epoch)) }
+    }
+
     /// The main sleep block (in-bed window) detected from the motion channel, or nil.
+    /// Pass `within:` to bound detection to the user's scheduled sleep window (optional).
     public static func mainSleep(from records: [BulkRecord],
+                                 within hint: DateInterval? = nil,
                                  epoch: Int = Command.syncEpoch) -> ActivityPeriod? {
-        var periods = ActivityPeriod.detectFromMotion(motionTimeline(from: records, epoch: epoch))
+        let scoped = Self.records(records, within: hint, epoch: epoch)
+        var periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch))
         return ActivityPeriod.findSleep(&periods)
     }
 
@@ -151,8 +165,10 @@ public enum BulkSleep {
     /// Light/Deep/REM staging needs an HR-based model (TODO) — the ring doesn't
     /// send a hypnogram (PROTOCOL.md §5.3), so all "asleep" is reported as core.
     public static func sleepSegments(from records: [BulkRecord],
+                                     within hint: DateInterval? = nil,
                                      epoch: Int = Command.syncEpoch) -> [SleepSegment] {
-        let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: records, epoch: epoch))
+        let scoped = Self.records(records, within: hint, epoch: epoch)
+        let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch))
         // Main in-bed block = longest sleep period over the minimum duration (1 h).
         guard let block = periods
             .filter({ $0.activity == .sleep })
@@ -182,8 +198,9 @@ public enum BulkSleep {
     /// Light/Deep/REM/Awake staging of the detected sleep block. Thin wrapper over
     /// `SleepStaging.classify` (kept for source compatibility with existing callers).
     public static func stagedSegments(from records: [BulkRecord],
+                                      within hint: DateInterval? = nil,
                                       epoch: Int = Command.syncEpoch) -> [SleepSegment] {
-        SleepStaging.classify(from: records, epoch: epoch)
+        SleepStaging.classify(from: Self.records(records, within: hint, epoch: epoch), epoch: epoch)
     }
 
     /// HR / HRV / SpO2 samples from sleep-vitals epochs, with device timestamps.

--- a/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
@@ -1,0 +1,130 @@
+// Bulk activity/sleep decode — the `0x4c` history stream (docs/PROTOCOL.md §5.3).
+//
+// Confirmed on FW FR02.018 by aligning captures/sleep_sync_btsnoop.log
+// (2026-06-13 overnight sync) to the RingConn app's own readout for that night
+// (avg HR 68 / HRV 65 ms / SpO2 98 %, low 93 % ~02:30–03:00). The decisive anchor:
+// the decoded SpO2 low-cluster lands at 02:32–03:07, matching the app exactly.
+//
+// A 0x4c page is `[0x4c][0x00][countdown][N × 23-byte record][xor]`. The counter
+// is seconds since `Command.syncEpoch`; records step +0x96 = 150 s, so each record
+// is one 2.5-min epoch. Records align to page boundaries (each page body is a whole
+// number of records — they do not span pages).
+//
+// Two record layouts, keyed on byte [8]:
+//   • Sleep-vitals epoch ([8] in 0x57…0x63): [4]=HR bpm 🟢, [5]=HRV/RMSSD ms 🟢,
+//     [8]=SpO2 % 🟢, [10:15]=motion. [6]/[7] unresolved 🟡.
+//   • Activity/awake epoch ([8]=0x12/0x13): activity payload in [15:22] 🟡.
+// Respiratory rate + skin temp are NOT per-epoch (derived/summary). Sleep stages are
+// not on the wire — compute them in Swift (Analytics/SleepDetection), per Phase 5.
+//
+// Do not add behavior that isn't in PROTOCOL.md. New facts go into the spec (and
+// desktop/decode_bulk.py) first, then get ported here.
+
+import Foundation
+
+/// One 23-byte record from a `0x4c` bulk activity/sleep page (PROTOCOL.md §5.3).
+public struct BulkRecord: Equatable {
+    /// Bytes per record (🟢).
+    public static let length = 23
+    /// Counter step between consecutive records: 0x96 = 150 s (🟢).
+    public static let epochSeconds = 150
+
+    /// The raw 23 bytes.
+    public let raw: [UInt8]
+
+    public init?(_ bytes: [UInt8]) {
+        guard bytes.count == Self.length else { return nil }
+        self.raw = bytes
+    }
+
+    /// `[0:4]` big-endian counter — seconds since `Command.syncEpoch`.
+    public var counter: UInt32 {
+        (UInt32(raw[0]) << 24) | (UInt32(raw[1]) << 16) | (UInt32(raw[2]) << 8) | UInt32(raw[3])
+    }
+
+    /// Wall-clock time of this epoch (counter + epoch offset).
+    public func date(epoch: Int = Command.syncEpoch) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(Int(counter) + epoch))
+    }
+
+    public enum Layout: Equatable {
+        case idle          // unworn / no measurement: motion 01×5 and zero payload
+        case sleepVitals   // [8] is an SpO2 %; HR/HRV/SpO2 live in [4:9]
+        case activity      // awake/active epoch; payload in [15:22]
+    }
+
+    public var layout: Layout {
+        if raw[10..<15] == [1, 1, 1, 1, 1] && raw[15..<22] == [0, 0, 0, 0, 0, 0, 0] {
+            return .idle
+        }
+        return (0x57...0x63).contains(raw[8]) ? .sleepVitals : .activity
+    }
+
+    /// Heart rate in bpm — `[4]` on a sleep-vitals epoch (🟢). nil otherwise / when 0.
+    public var heartRate: Int? {
+        guard layout == .sleepVitals, raw[4] > 0 else { return nil }
+        return Int(raw[4])
+    }
+
+    /// HRV in ms — `[5]` on a sleep-vitals epoch (🟢). The ring reports RMSSD; HealthKit
+    /// only has SDNN (different statistic, same unit) — see HEALTHKIT_MAPPING.md.
+    public var hrvRMSSD: Int? {
+        guard layout == .sleepVitals, raw[5] > 0 else { return nil }
+        return Int(raw[5])
+    }
+
+    /// SpO2 percent — `[8]` on a sleep-vitals epoch (🟢, range 87…99 observed). nil otherwise.
+    public var spo2Percent: Int? {
+        guard layout == .sleepVitals else { return nil }
+        return Int(raw[8])
+    }
+
+    /// `[10:15]` — 5 per-30 s motion/activity counts (🟢 role). `01` baseline = still.
+    public var motion: [UInt8] { Array(raw[10..<15]) }
+}
+
+/// Reassembles `0x4c` pages into records and maps sleep-vitals epochs to samples.
+public enum BulkSleep {
+
+    /// Records carried by ONE 0x4c page frame (full notification incl. opcode + XOR).
+    /// Returns [] if the XOR trailer is invalid or the opcode isn't 0x4c.
+    public static func records(fromPage frame: [UInt8]) -> [BulkRecord] {
+        guard let p = Frame.parse(frame), p.opcode == Frame.responseID(Opcode.page4C) else { return [] }
+        // body = [00][countdown][records…]; records begin at body index 2.
+        return records(fromStream: Array(p.body.dropFirst(2)))
+    }
+
+    /// Split a raw record stream (no page header/trailer) into whole 23-byte records.
+    /// A trailing partial chunk is dropped.
+    public static func records(fromStream bytes: [UInt8]) -> [BulkRecord] {
+        guard bytes.count >= BulkRecord.length else { return [] }
+        return stride(from: 0, through: bytes.count - BulkRecord.length, by: BulkRecord.length)
+            .compactMap { BulkRecord(Array(bytes[$0 ..< $0 + BulkRecord.length])) }
+    }
+
+    /// Reassemble a multi-page bulk transfer into one ordered record list.
+    public static func records(fromPages frames: [[UInt8]]) -> [BulkRecord] {
+        frames.flatMap { records(fromPage: $0) }
+    }
+
+    /// HR / HRV / SpO2 samples from sleep-vitals epochs, with device timestamps.
+    /// SpO2 is emitted as a 0…1 fraction (HealthKit oxygenSaturation). HRV is the
+    /// ring's RMSSD value written to the SDNN type (unit-compatible; see mapping).
+    public static func samples(from records: [BulkRecord],
+                               epoch: Int = Command.syncEpoch) -> [QuantitySample] {
+        var out: [QuantitySample] = []
+        for r in records where r.layout == .sleepVitals {
+            let t = r.date(epoch: epoch)
+            if let hr = r.heartRate {
+                out.append(QuantitySample(kind: .heartRate, start: t, value: Double(hr)))
+            }
+            if let hrv = r.hrvRMSSD {
+                out.append(QuantitySample(kind: .hrvSDNN, start: t, value: Double(hrv)))
+            }
+            if let spo2 = r.spo2Percent {
+                out.append(QuantitySample(kind: .spo2, start: t, value: Double(spo2) / 100.0))
+            }
+        }
+        return out
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/BulkSleep.swift
@@ -107,6 +107,54 @@ public enum BulkSleep {
         frames.flatMap { records(fromPage: $0) }
     }
 
+    /// Expand 0x4c records into a per-30 s motion timeline (5 sub-samples per
+    /// 150 s epoch from the [10:15] channel) for `SleepDetection.detectFromMotion`.
+    /// Motion counts are passed through directly (baseline `01` = still); callers
+    /// should scope `records` to a worn period (charging data reads as still too).
+    public static func motionTimeline(from records: [BulkRecord],
+                                      epoch: Int = Command.syncEpoch) -> [MotionSample] {
+        var out: [MotionSample] = []
+        out.reserveCapacity(records.count * 5)
+        for r in records {
+            let base = r.date(epoch: epoch)
+            for k in 0 ..< 5 {
+                out.append(MotionSample(time: base.addingTimeInterval(Double(k) * 30),
+                                        movement: Float(r.raw[10 + k])))
+            }
+        }
+        return out
+    }
+
+    /// The main sleep block (in-bed window) detected from the motion channel, or nil.
+    public static func mainSleep(from records: [BulkRecord],
+                                 epoch: Int = Command.syncEpoch) -> ActivityPeriod? {
+        var periods = ActivityPeriod.detectFromMotion(motionTimeline(from: records, epoch: epoch))
+        return ActivityPeriod.findSleep(&periods)
+    }
+
+    /// HealthKit sleep segments for the detected night: an `inBed` span plus
+    /// `asleepCore`/`awake` sub-segments from the stillness detection. Finer
+    /// Light/Deep/REM staging needs an HR-based model (TODO) — the ring doesn't
+    /// send a hypnogram (PROTOCOL.md §5.3), so all "asleep" is reported as core.
+    public static func sleepSegments(from records: [BulkRecord],
+                                     epoch: Int = Command.syncEpoch) -> [SleepSegment] {
+        let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: records, epoch: epoch))
+        // Main in-bed block = longest sleep period over the minimum duration (1 h).
+        guard let block = periods
+            .filter({ $0.activity == .sleep })
+            .max(by: { $0.duration < $1.duration }),
+            block.duration > 60 * 60 else { return [] }
+
+        var segs = [SleepSegment(start: block.start, end: block.end, stage: .inBed)]
+        for p in periods where p.start < block.end && p.end > block.start {
+            let s = max(p.start, block.start), e = min(p.end, block.end)
+            if e <= s { continue }
+            segs.append(SleepSegment(start: s, end: e,
+                                     stage: p.activity == .sleep ? .asleepCore : .awake))
+        }
+        return segs
+    }
+
     /// HR / HRV / SpO2 samples from sleep-vitals epochs, with device timestamps.
     /// SpO2 is emitted as a 0…1 fraction (HealthKit oxygenSaturation). HRV is the
     /// ring's RMSSD value written to the SDNN type (unit-compatible; see mapping).

--- a/ios/OpenRingKit/Sources/OpenRingKit/ChargingInference.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/ChargingInference.swift
@@ -1,0 +1,30 @@
+// Charging-state inference from the battery % trend (#60).
+//
+// The ring's charging state is NOT on the wire in any confirmed byte (PROTOCOL.md §5).
+// The closest 🟢 proxy is the battery % in the 0x10/0x87 descriptor: if a short window of
+// consecutive readings is strictly rising the ring is *inferred* to be charging. This is
+// deliberately conservative — "inferred" only fires when we hold ≥ 2 readings that are ALL
+// strictly rising; a single-reading window or any non-monotone pattern returns false.
+//
+// Rule: never claim CERTAINTY from this signal. Callers label the result "inferred".
+
+import Foundation
+
+public enum ChargingInference {
+
+    /// True when `trend` is a strictly rising sequence — every consecutive pair increases —
+    /// suggesting the ring may be charging (🟢 proxy). Requires ≥ 2 readings.
+    ///
+    /// Examples:
+    ///   - []          → false  (no data)
+    ///   - [75]        → false  (single reading)
+    ///   - [74, 76]    → true   (two rising readings)
+    ///   - [74, 76, 78]→ true   (three rising readings)
+    ///   - [75, 75]    → false  (flat — discharging or noise)
+    ///   - [80, 78]    → false  (falling — discharging)
+    ///   - [74, 76, 75]→ false  (not all rising)
+    public static func inferred(from trend: [Int]) -> Bool {
+        guard trend.count >= 2 else { return false }
+        return zip(trend, trend.dropFirst()).allSatisfy { $0 < $1 }
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/CumulativeMetrics.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/CumulativeMetrics.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+public extension MetricKind {
+    /// Metrics emitted by the ring as monotonic counters rather than per-epoch values.
+    var isCumulativeCounter: Bool {
+        switch self {
+        case .steps, .activeEnergy:
+            return true
+        case .heartRate, .restingHeartRate, .hrvSDNN, .spo2, .temperature, .respiratoryRate, .sleep:
+            return false
+        }
+    }
+}
+
+public struct CumulativeMetricState: Equatable, Sendable {
+    public var previousRawValue: Double?
+    public var dailyTotal: Double
+
+    public init(previousRawValue: Double? = nil, dailyTotal: Double = 0) {
+        self.previousRawValue = previousRawValue
+        self.dailyTotal = dailyTotal
+    }
+}
+
+public struct CumulativeMetricResult: Equatable, Sendable {
+    public let sample: QuantitySample
+    public let rawValue: Double
+    public let deltaValue: Double
+    public let dailyTotal: Double
+}
+
+public enum CumulativeMetricAccumulator {
+    public static func accumulate(
+        _ sample: QuantitySample,
+        state: CumulativeMetricState
+    ) -> CumulativeMetricResult {
+        let raw = sample.value
+        let delta: Double
+        if let previous = state.previousRawValue {
+            delta = raw >= previous ? raw - previous : raw
+        } else {
+            delta = raw
+        }
+
+        let dailyTotal = state.dailyTotal + delta
+        let accumulated = QuantitySample(
+            kind: sample.kind,
+            start: sample.start,
+            end: sample.end,
+            value: dailyTotal
+        )
+        return CumulativeMetricResult(
+            sample: accumulated,
+            rawValue: raw,
+            deltaValue: delta,
+            dailyTotal: dailyTotal
+        )
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/CumulativeMetrics.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/CumulativeMetrics.swift
@@ -6,7 +6,10 @@ public extension MetricKind {
         switch self {
         case .steps, .activeEnergy:
             return true
-        case .heartRate, .restingHeartRate, .hrvSDNN, .spo2, .temperature, .respiratoryRate, .sleep:
+        case .heartRate, .restingHeartRate, .hrvSDNN, .spo2, .temperature, .respiratoryRate, .sleep,
+             .distance, .exerciseMinutes:
+            // distance + exerciseMinutes are derived values written directly by HealthKitWriter,
+            // NOT raw ring samples — they never flow through the cumulative-counter ingest path.
             return false
         }
     }

--- a/ios/OpenRingKit/Sources/OpenRingKit/DeviceStatus.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/DeviceStatus.swift
@@ -1,0 +1,18 @@
+// Device-status decode — the 0x10 / 0x87 fixed 19-byte descriptor (PROTOCOL.md §5.4).
+//
+// The ring emits this frame spontaneously (~30–60 s) and as the `0x07`/`0xd0` response.
+// `[4:6]` is the ring's onboard **step count** (16-bit big-endian) 🟢 — confirmed by a
+// from-scratch sync: the app showed 81 steps and `[4:6]` read exactly 81, `0` when idle.
+// This is the ring's own count; the official app normally shows a cloud-aggregated daily
+// total that can differ.
+
+import Foundation
+
+public enum DeviceStatus {
+    /// The ring's onboard step count from a 0x10/0x87 descriptor frame, or nil if the
+    /// frame isn't one. The value can legitimately be 0 (no steps yet).
+    public static func steps(_ frame: [UInt8]) -> Int? {
+        guard frame.count >= 19, frame[0] == 0x10 || frame[0] == 0x87 else { return nil }
+        return (Int(frame[4]) << 8) | Int(frame[5])
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/DeviceStatus.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/DeviceStatus.swift
@@ -8,11 +8,33 @@
 
 import Foundation
 
+/// Skin temperature decoded from a 0x10/0x87 descriptor (PROTOCOL.md §5.4 🟢).
+/// Two near-equal 16-bit channels (skin + reference); `celsius` is their mean.
+public struct SkinTemperature: Equatable, Sendable {
+    public let channelA: Double   // [6:8], °C
+    public let channelB: Double   // [8:10], °C
+    public var celsius: Double { (channelA + channelB) / 2 }
+    public var fahrenheit: Double { celsius * 9 / 5 + 32 }
+}
+
 public enum DeviceStatus {
     /// The ring's onboard step count from a 0x10/0x87 descriptor frame, or nil if the
     /// frame isn't one. The value can legitimately be 0 (no steps yet).
     public static func steps(_ frame: [UInt8]) -> Int? {
         guard frame.count >= 19, frame[0] == 0x10 || frame[0] == 0x87 else { return nil }
         return (Int(frame[4]) << 8) | Int(frame[5])
+    }
+
+    /// Skin temperature from a 0x10/0x87 descriptor: two 0.1 °C big-endian channels at
+    /// `[6:8]`/`[8:10]` (§5.4 🟢, ground-truthed 2026-06-15). The descriptor streams live
+    /// while connected — temperature is NOT in the 0x4c sleep sync. Returns nil if the
+    /// frame isn't a descriptor or the reading is outside a plausible band (filters
+    /// zero/garbage frames); a cold/just-donned ring still reads ~28 °C and is returned.
+    public static func skinTemperature(_ frame: [UInt8]) -> SkinTemperature? {
+        guard frame.count >= 19, frame[0] == 0x10 || frame[0] == 0x87 else { return nil }
+        let a = (Int(frame[6]) << 8) | Int(frame[7])
+        let b = (Int(frame[8]) << 8) | Int(frame[9])
+        guard (150...500).contains(a), (150...500).contains(b) else { return nil }  // 15–50 °C
+        return SkinTemperature(channelA: Double(a) / 10, channelB: Double(b) / 10)
     }
 }

--- a/ios/OpenRingKit/Sources/OpenRingKit/DeviceStatus.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/DeviceStatus.swift
@@ -25,6 +25,15 @@ public enum DeviceStatus {
         return (Int(frame[4]) << 8) | Int(frame[5])
     }
 
+    /// Battery percentage from a 0x10/0x87 descriptor: **byte[1]** (§5.4 🟢, ground-truthed
+    /// 2026-06-15: `0x4c`=76 matched the app's 76% exactly at capture time; the buffer showed
+    /// a clean 92→76 discharge curve). Returns nil if not a descriptor or out of the 1…100 band.
+    public static func battery(_ frame: [UInt8]) -> Int? {
+        guard frame.count >= 19, frame[0] == 0x10 || frame[0] == 0x87 else { return nil }
+        let pct = Int(frame[1])
+        return (1...100).contains(pct) ? pct : nil
+    }
+
     /// Skin temperature from a 0x10/0x87 descriptor: two 0.1 °C big-endian channels at
     /// `[6:8]`/`[8:10]` (§5.4 🟢, ground-truthed 2026-06-15). The descriptor streams live
     /// while connected — temperature is NOT in the 0x4c sleep sync. Returns nil if the

--- a/ios/OpenRingKit/Sources/OpenRingKit/EpochRecord.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/EpochRecord.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Timestamp-only decoder for epoch sync records.
+///
+/// This namespace intentionally exposes only byte-structure facts confirmed by
+/// captures: record splitting, cursor-space timestamp reconstruction, subtype
+/// tags, and raw payload bytes for future metric decoding.
+public enum EpochRecord {
+    public static let syncEpoch = Command.syncEpoch
+    public static let marker: UInt8 = 0x0C
+    public static let ppgOpcode: UInt8 = 0x47
+    public static let activityOpcode: UInt8 = 0x4C
+    public static let endOfHistoryOpcode: UInt8 = 0x50
+    public static let ppgRecordSize = 47
+    public static let activityRecordSize = 23
+
+    // 0x4C activity/sleep record - 23 bytes.
+    public struct ActivityRecord: Equatable, Sendable {
+        public let timestamp: Date
+        public let subtype: UInt8
+        public let rawPayload: Data
+
+        public init(timestamp: Date, subtype: UInt8, rawPayload: Data) {
+            self.timestamp = timestamp
+            self.subtype = subtype
+            self.rawPayload = rawPayload
+        }
+    }
+
+    // 0x47 PPG/waveform record - 47 bytes.
+    public struct PPGRecord: Equatable, Sendable {
+        public let timestamp: Date
+        public let rawPayload: Data
+
+        public init(timestamp: Date, rawPayload: Data) {
+            self.timestamp = timestamp
+            self.rawPayload = rawPayload
+        }
+    }
+
+    public struct EndOfHistoryFrame: Equatable, Sendable {
+        public let subtype: UInt8
+        public let cursorFrom: UInt32
+        public let cursorTo: UInt32
+
+        public init(subtype: UInt8, cursorFrom: UInt32, cursorTo: UInt32) {
+            self.subtype = subtype
+            self.cursorFrom = cursorFrom
+            self.cursorTo = cursorTo
+        }
+
+        public var streamHighByte: UInt8 {
+            UInt8((cursorTo >> 24) & 0xFF)
+        }
+    }
+
+    /// Parse all activity records out of a 0x4C page frame.
+    /// `streamHighByte` is the high byte of the 4-byte cursor, reconstructed
+    /// from the 0x50 end-of-sync frame or the sync-open cursor.
+    public static func parseActivityPage(_ data: Data, streamHighByte: UInt8 = 0) -> [ActivityRecord] {
+        let bytes = [UInt8](data)
+        guard let payload = pagePayload(bytes, opcode: activityOpcode),
+              payload.count % activityRecordSize == 0 else { return [] }
+
+        return stride(from: 0, to: payload.count, by: activityRecordSize).compactMap { offset in
+            let record = Array(payload[offset..<(offset + activityRecordSize)])
+            guard record[0] == marker else { return nil }
+            return ActivityRecord(
+                timestamp: timestamp(record, streamHighByte: streamHighByte),
+                subtype: record[8],
+                rawPayload: Data(record[15..<22])
+            )
+        }
+    }
+
+    public static func parsePPGPage(_ data: Data, streamHighByte: UInt8 = 0) -> [PPGRecord] {
+        let bytes = [UInt8](data)
+        guard let payload = pagePayload(bytes, opcode: ppgOpcode),
+              payload.count % ppgRecordSize == 0 else { return [] }
+
+        return stride(from: 0, to: payload.count, by: ppgRecordSize).compactMap { offset in
+            let record = Array(payload[offset..<(offset + ppgRecordSize)])
+            guard record[0] == marker else { return nil }
+            return PPGRecord(
+                timestamp: timestamp(record, streamHighByte: streamHighByte),
+                rawPayload: Data(record[9..<47])
+            )
+        }
+    }
+
+    public static func remainingRecordCountdown(_ data: Data) -> UInt8? {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 3,
+              (bytes[0] == ppgOpcode || bytes[0] == activityOpcode) else { return nil }
+        return bytes[2]
+    }
+
+    /// Parse the no-XOR 0x50 end-of-history cursor report.
+    ///
+    /// The confirmed capture shape is a 6-byte cursor entry after `50 00 00`.
+    /// Newer issue notes describe a compact from/to form. Both are accepted so
+    /// the session can recover the high cursor byte without blocking the drain.
+    public static func parseEndOfHistory(_ data: Data) -> EndOfHistoryFrame? {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 8,
+              bytes[0] == endOfHistoryOpcode,
+              bytes[1] == 0x00,
+              bytes[2] == 0x00 else { return nil }
+
+        if bytes.count == 12 {
+            let from = uint32BE(bytes, offset: 4)
+            let to = uint32BE(bytes, offset: 8)
+            return EndOfHistoryFrame(subtype: bytes[3], cursorFrom: from, cursorTo: to)
+        }
+
+        if bytes.count == 9, bytes[3] == 0x15 {
+            let cursor = uint32BE(bytes, offset: 5)
+            return EndOfHistoryFrame(subtype: bytes[4], cursorFrom: cursor, cursorTo: cursor)
+        }
+
+        if bytes.count == 8 {
+            let cursor = uint32BE(bytes, offset: 4)
+            return EndOfHistoryFrame(subtype: bytes[3], cursorFrom: cursor, cursorTo: cursor)
+        }
+
+        return nil
+    }
+
+    private static func pagePayload(_ bytes: [UInt8], opcode: UInt8) -> [UInt8]? {
+        guard bytes.first == opcode,
+              let parsed = Frame.parse(bytes),
+              parsed.opcode == opcode,
+              parsed.body.count >= 2,
+              parsed.body[0] == 0x00 else { return nil }
+        return Array(parsed.body.dropFirst(2))
+    }
+
+    private static func timestamp(_ record: [UInt8], streamHighByte: UInt8) -> Date {
+        let low3 = UInt32(record[1]) << 16 | UInt32(record[2]) << 8 | UInt32(record[3])
+        let full = UInt32(streamHighByte) << 24 | low3
+        let unixSeconds = Double(full) + Double(syncEpoch)
+        return Date(timeIntervalSince1970: unixSeconds)
+    }
+
+    private static func uint32BE(_ bytes: [UInt8], offset: Int) -> UInt32 {
+        UInt32(bytes[offset]) << 24
+            | UInt32(bytes[offset + 1]) << 16
+            | UInt32(bytes[offset + 2]) << 8
+            | UInt32(bytes[offset + 3])
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/EpochSyncSession.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/EpochSyncSession.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Accumulates raw epoch pages across one sync drain and reparses them once the
+/// end-of-history cursor report reveals the stream high byte.
+public struct EpochSyncSession: Equatable, Sendable {
+    public private(set) var streamHighByte: UInt8
+    public private(set) var activityRecords: [EpochRecord.ActivityRecord]
+    public private(set) var ppgRecords: [EpochRecord.PPGRecord]
+    public private(set) var endOfHistory: EpochRecord.EndOfHistoryFrame?
+
+    private var activityPages: [Data]
+    private var ppgPages: [Data]
+
+    public init(syncOpenCursor: UInt32? = nil) {
+        if let syncOpenCursor, syncOpenCursor != UInt32.max {
+            self.streamHighByte = UInt8((syncOpenCursor >> 24) & 0xFF)
+        } else {
+            self.streamHighByte = 0
+        }
+        self.activityRecords = []
+        self.ppgRecords = []
+        self.endOfHistory = nil
+        self.activityPages = []
+        self.ppgPages = []
+    }
+
+    @discardableResult
+    public mutating func appendActivityPage(_ data: Data) -> [EpochRecord.ActivityRecord] {
+        activityPages.append(data)
+        let records = EpochRecord.parseActivityPage(data, streamHighByte: streamHighByte)
+        activityRecords.append(contentsOf: records)
+        return records
+    }
+
+    @discardableResult
+    public mutating func appendPPGPage(_ data: Data) -> [EpochRecord.PPGRecord] {
+        ppgPages.append(data)
+        let records = EpochRecord.parsePPGPage(data, streamHighByte: streamHighByte)
+        ppgRecords.append(contentsOf: records)
+        return records
+    }
+
+    @discardableResult
+    public mutating func complete(with data: Data) -> EpochRecord.EndOfHistoryFrame? {
+        guard let frame = EpochRecord.parseEndOfHistory(data) else { return nil }
+        endOfHistory = frame
+        streamHighByte = frame.streamHighByte
+        reparseBufferedPages()
+        return frame
+    }
+
+    public var isComplete: Bool {
+        endOfHistory != nil
+    }
+
+    public func placeholderQuantitySamples() -> [QuantitySample] {
+        activityRecords
+            .filter { $0.rawPayload.contains { $0 != 0 } }
+            .map {
+                QuantitySample(
+                    kind: .heartRate,
+                    start: $0.timestamp,
+                    value: 0.0
+                )
+            }
+    }
+
+    private mutating func reparseBufferedPages() {
+        activityRecords = activityPages.flatMap {
+            EpochRecord.parseActivityPage($0, streamHighByte: streamHighByte)
+        }
+        ppgRecords = ppgPages.flatMap {
+            EpochRecord.parsePPGPage($0, streamHighByte: streamHighByte)
+        }
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/ExportEngine.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/ExportEngine.swift
@@ -1,0 +1,147 @@
+// Pure export serialization — no SwiftData dependency (#80). Callers fetch from the
+// store and pass plain structs here, so these functions are unit-testable on the CLI.
+//
+// Three formats:
+//   • samplesCSV   — one row per QuantitySample-equivalent (HR / SpO2 / temp / HRV / RR)
+//   • sleepCSV     — one row per persisted nightly sleep summary
+//   • dailyCSV     — one row per day's step rollup
+//   • toJSON       — all three tables as a single JSON bundle with an exportedAt timestamp
+//
+// Timestamps: ISO 8601 with millisecond precision for sample start/end; yyyy-MM-dd for
+// date-only fields (sleep night, daily rollup day) to keep the file readable.
+
+import Foundation
+
+public enum ExportEngine {
+
+    // MARK: - Row types
+
+    public struct SampleRow: Equatable, Sendable {
+        public let kind: String
+        public let start: Date
+        public let end: Date
+        public let value: Double
+        public init(kind: String, start: Date, end: Date, value: Double) {
+            self.kind = kind; self.start = start; self.end = end; self.value = value
+        }
+    }
+
+    public struct SleepRow: Equatable, Sendable {
+        public let night: Date
+        public let asleepMin: Int
+        public let deepMin: Int
+        public let lightMin: Int
+        public let remMin: Int
+        public let awakeMin: Int
+        public let efficiency: Double
+        public let skinTempC: Double
+        public let sleepScore: Int
+        public let stressScore: Int
+        public init(night: Date, asleepMin: Int, deepMin: Int, lightMin: Int,
+                    remMin: Int, awakeMin: Int, efficiency: Double,
+                    skinTempC: Double, sleepScore: Int, stressScore: Int) {
+            self.night = night; self.asleepMin = asleepMin; self.deepMin = deepMin
+            self.lightMin = lightMin; self.remMin = remMin; self.awakeMin = awakeMin
+            self.efficiency = efficiency; self.skinTempC = skinTempC
+            self.sleepScore = sleepScore; self.stressScore = stressScore
+        }
+    }
+
+    public struct DailyRow: Equatable, Sendable {
+        public let day: Date
+        public let steps: Int
+        public init(day: Date, steps: Int) { self.day = day; self.steps = steps }
+    }
+
+    // MARK: - Date formatters
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let dateOnly: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
+
+    // MARK: - CSV
+
+    /// CSV for QuantitySample-equivalent rows. Header: `kind,start,end,value`
+    public static func samplesCSV(_ rows: [SampleRow]) -> String {
+        var lines = ["kind,start,end,value"]
+        for r in rows {
+            let v = r.value.truncatingRemainder(dividingBy: 1) == 0
+                ? String(format: "%.0f", r.value)
+                : String(r.value)
+            lines.append("\(r.kind),\(iso8601.string(from: r.start)),\(iso8601.string(from: r.end)),\(v)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// CSV for nightly sleep summaries. Header includes all stored columns.
+    public static func sleepCSV(_ rows: [SleepRow]) -> String {
+        var lines = ["night,asleepMin,deepMin,lightMin,remMin,awakeMin,efficiency,skinTempC,sleepScore,stressScore"]
+        for r in rows {
+            lines.append([
+                dateOnly.string(from: r.night),
+                "\(r.asleepMin)", "\(r.deepMin)", "\(r.lightMin)",
+                "\(r.remMin)", "\(r.awakeMin)",
+                String(format: "%.4f", r.efficiency),
+                String(format: "%.2f", r.skinTempC),
+                "\(r.sleepScore)", "\(r.stressScore)"
+            ].joined(separator: ","))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// CSV for daily step rollups. Header: `day,steps`
+    public static func dailyCSV(_ rows: [DailyRow]) -> String {
+        var lines = ["day,steps"]
+        for r in rows {
+            lines.append("\(dateOnly.string(from: r.day)),\(r.steps)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - JSON bundle
+
+    /// All three tables as a single JSON blob with an `exportedAt` timestamp.
+    /// Returns nil only if JSON serialization fails (should never happen in practice).
+    public static func toJSON(samples: [SampleRow], sleep: [SleepRow],
+                              daily: [DailyRow], now: Date = Date()) -> String? {
+        let root: [String: Any] = [
+            "exportedAt": iso8601.string(from: now),
+            "samples": samples.map { [
+                "kind": $0.kind,
+                "start": iso8601.string(from: $0.start),
+                "end": iso8601.string(from: $0.end),
+                "value": $0.value
+            ] as [String: Any] },
+            "sleep": sleep.map { [
+                "night": dateOnly.string(from: $0.night),
+                "asleepMin": $0.asleepMin,
+                "deepMin": $0.deepMin,
+                "lightMin": $0.lightMin,
+                "remMin": $0.remMin,
+                "awakeMin": $0.awakeMin,
+                "efficiency": $0.efficiency,
+                "skinTempC": $0.skinTempC,
+                "sleepScore": $0.sleepScore,
+                "stressScore": $0.stressScore
+            ] as [String: Any] },
+            "daily": daily.map { [
+                "day": dateOnly.string(from: $0.day),
+                "steps": $0.steps
+            ] as [String: Any] }
+        ]
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: root, options: [.prettyPrinted, .sortedKeys]),
+              let str = String(data: data, encoding: .utf8) else { return nil }
+        return str
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/FirmwareInfo.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/FirmwareInfo.swift
@@ -1,0 +1,63 @@
+// Firmware version parsing + generation detection for the device-info screen (#79).
+// The RingConn firmware prefix encodes the hardware generation (pp.txt:97512-97514):
+//   FR01 → Gen 1
+//   FR02 → Gen 2
+//   FR04 → Gen 2 Air
+//
+// `hasFirmwareMismatch`: the version is non-empty AND doesn't start with the pinned
+// string — a mismatch means we reverse-engineered on a different FW build and certain
+// packet offsets may differ. Non-alarming: the ring still operates; it's a transparency
+// note for technical users.
+
+import Foundation
+
+// MARK: - Generation
+
+/// Hardware generation derived from the DIS Firmware-Revision-String prefix.
+public enum RingGeneration: String, Equatable, Sendable {
+    case gen1    = "Gen 1"
+    case gen2    = "Gen 2"
+    case gen2Air = "Gen 2 Air"
+    case unknown = "Unknown"
+}
+
+// MARK: - FirmwareInfo
+
+/// Collects the Device Information Service fields from a connected ring (#79).
+/// Populated incrementally as each DIS characteristic is read (GATT reads arrive
+/// asynchronously); unread fields stay at their empty defaults.
+public struct FirmwareInfo: Equatable, Sendable {
+    public var version: String = ""
+    public var modelName: String = ""
+    public var manufacturer: String = ""
+    public var hardwareRevision: String?
+    /// Ring MAC recovered from the System ID (0x2A23) characteristic (§1).
+    public var mac: String?
+
+    /// The FW version this build was reverse-engineered and tested against.
+    public static let pinnedVersion = "FR02.018"
+
+    /// True when a version string is known AND doesn't start with the pinned version.
+    /// Non-empty guard prevents false positives before the DIS read completes.
+    public var hasFirmwareMismatch: Bool {
+        !version.isEmpty && !version.hasPrefix(Self.pinnedVersion)
+    }
+
+    /// Generation decoded from the four-character FW prefix (FR01/FR02/FR04).
+    public var generation: RingGeneration {
+        if version.hasPrefix("FR01") { return .gen1 }
+        if version.hasPrefix("FR02") { return .gen2 }
+        if version.hasPrefix("FR04") { return .gen2Air }
+        return .unknown
+    }
+
+    public init(version: String = "", modelName: String = "",
+                manufacturer: String = "", hardwareRevision: String? = nil,
+                mac: String? = nil) {
+        self.version = version
+        self.modelName = modelName
+        self.manufacturer = manufacturer
+        self.hardwareRevision = hardwareRevision
+        self.mac = mac
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/GoalDefaults.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/GoalDefaults.swift
@@ -1,0 +1,107 @@
+// Daily goal settings — UserDefaults keys, defaults, and progress math (#77).
+//
+// Goals are APP-SIDE display only — no value is written to the ring. The ring's
+// `TargetSyncModel` (type=0 step / 1 calorie / 2 sleep / 3 bedSchedule) and
+// `watchStepTargetData` are out of scope (require the write-channel capture, #88).
+//
+// APK evidence: `workday_step_goal` / `weekend_step_goal` (pp.txt:111295);
+// `calTarget`; `keySettingActivityDurationGoal`; `workdaySleepGoal` /
+// `weekendSleepGoal`. WHO framing: 150–300 min/week activity.
+
+import Foundation
+
+// MARK: - Keys & defaults
+
+public enum GoalDefaults {
+
+    // Steps — weekday / weekend split
+    public static let workdaySteps    = "goals.workdaySteps"
+    public static let weekendSteps    = "goals.weekendSteps"
+
+    // Active calories — single goal (no weekday/weekend in APK data)
+    public static let activeKcal      = "goals.activeKcal"
+
+    // Activity / exercise duration minutes — single goal
+    public static let activityMinutes = "goals.activityMinutes"
+
+    // Sleep duration — weekday / weekend split (minutes)
+    public static let workdaySleepMin = "goals.workdaySleepMin"
+    public static let weekendSleepMin = "goals.weekendSleepMin"
+
+    // Defaults
+    public static let defaultWorkdaySteps    = 8_000
+    public static let defaultWeekendSteps    = 10_000
+    public static let defaultActiveKcal      = 300.0
+    public static let defaultActivityMinutes = 30.0          // WHO: 150 min/week ÷ 5
+    public static let defaultWorkdaySleepMin = 7 * 60        // 7 h
+    public static let defaultWeekendSleepMin = 8 * 60        // 8 h
+
+    // MARK: Calendar helper
+
+    /// Whether `date` is a weekend (Saturday or Sunday) in `calendar`.
+    /// Sunday = weekday 1, Saturday = weekday 7 in Calendar.
+    public static func isWeekend(_ date: Date = Date(), calendar: Calendar = .current) -> Bool {
+        let wd = calendar.component(.weekday, from: date)
+        return wd == 1 || wd == 7
+    }
+
+    // MARK: UserDefaults readers (shared between GoalsCardView + UserProfileSettingsView)
+
+    public static func stepsGoal(for date: Date = Date(),
+                                 calendar: Calendar = .current,
+                                 defaults: UserDefaults = .standard) -> Int {
+        let key = isWeekend(date, calendar: calendar) ? weekendSteps : workdaySteps
+        return defaults.object(forKey: key) as? Int
+            ?? (isWeekend(date, calendar: calendar) ? defaultWeekendSteps : defaultWorkdaySteps)
+    }
+
+    public static func sleepGoalMinutes(for date: Date = Date(),
+                                        calendar: Calendar = .current,
+                                        defaults: UserDefaults = .standard) -> Int {
+        let key = isWeekend(date, calendar: calendar) ? weekendSleepMin : workdaySleepMin
+        return defaults.object(forKey: key) as? Int
+            ?? (isWeekend(date, calendar: calendar) ? defaultWeekendSleepMin : defaultWorkdaySleepMin)
+    }
+}
+
+// MARK: - Progress
+
+/// One metric's current value vs. its goal.
+public struct GoalProgress: Equatable, Sendable {
+    public let current: Double
+    public let goal: Double
+
+    public init(current: Double, goal: Double) {
+        self.current = current
+        self.goal = max(goal, 0)
+    }
+
+    /// Fraction towards the goal, clamped to [0, 1].
+    public var fraction: Double {
+        guard goal > 0 else { return 0 }
+        return min(current / goal, 1.0)
+    }
+
+    /// True when the goal is fully met (current ≥ goal).
+    public var met: Bool { current >= goal && goal > 0 }
+}
+
+/// Today's progress across all four tracked goals.
+public struct DailyGoalProgress: Equatable, Sendable {
+    public let steps: GoalProgress
+    public let activeKcal: GoalProgress
+    public let activityMinutes: GoalProgress
+    public let sleepMinutes: GoalProgress   // last night's sleep vs. tonight's goal
+
+    public init(
+        steps: GoalProgress,
+        activeKcal: GoalProgress,
+        activityMinutes: GoalProgress,
+        sleepMinutes: GoalProgress
+    ) {
+        self.steps = steps
+        self.activeKcal = activeKcal
+        self.activityMinutes = activityMinutes
+        self.sleepMinutes = sleepMinutes
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/HealthAlerts.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/HealthAlerts.swift
@@ -16,8 +16,9 @@
 
 import Foundation
 
-/// Every user-facing health notification, across #73 (HR/SpO2) and #85 (temp/fever). One enum =
-/// one de-dupe namespace, so the same condition can't re-fire from two code paths.
+/// Every user-facing health notification, across #73 (HR/SpO2), #85 (temp/fever),
+/// #84 (reminders), and #86 (charging complete). One enum = one de-dupe namespace,
+/// so the same condition can't re-fire from two code paths.
 public enum HealthNotification: String, CaseIterable, Codable, Sendable {
     // #73 — heart rate & blood oxygen
     case highHR
@@ -29,6 +30,12 @@ public enum HealthNotification: String, CaseIterable, Codable, Sendable {
     case skinTempFluctuationRise // 0x10 skinTempFluctuationRise
     case skinTempFluctuationDrop // 0x11 skinTempFluctuationDrop
     case fever                   // 0x14 feverAbnormal (HR + temp cross-reference, #72)
+    // #84 — app-side reminders
+    case sedentaryReminder = "reminder.sedentary"
+    case wearReminder      = "reminder.wear"
+    case bedtimeReminder   = "reminder.bedtime"
+    // #86 — battery charging complete
+    case chargingComplete  = "battery.chargingComplete"
 }
 
 // MARK: - Quiet hours (shared DND window)

--- a/ios/OpenRingKit/Sources/OpenRingKit/HealthAlerts.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/HealthAlerts.swift
@@ -1,0 +1,220 @@
+// Local health-alert policy — the PURE decision layer shared by the high-HR / low-SpO2 /
+// elevated-HR-while-inactive alerts (#73) AND the skin-temp / fever notifications (#85).
+//
+// The ring has NO vibration motor, so every alert is a phone notification (pp.txt:46223
+// "App can receive the following notifications only when connected to the ring"). This file
+// holds only the THRESHOLD + DE-DUPE + DND (quiet-hours) math — no Apple frameworks — so it
+// unit-tests on the CLI. The `UNUserNotificationCenter` glue + UserDefaults persistence live
+// in the app target (HealthNotificationCenter.swift), which routes BOTH tickets through this
+// ONE engine (a single quiet-hours window, a single de-dupe namespace).
+//
+// Thresholds are user-configurable with sensible defaults — never a hardcoded reading of a
+// person's data. Evidence: `highHrRemind`/`highHrRemindEnable`, `keyHeartRateReminderValue`;
+// `lowSpo2Value`, `keyLowSpO2Detected` (SpO2 severity ≥95 / 90-95 / 75-90 / <75); 10-min
+// sustained-while-non-exercising HR trigger (pp.txt:45915). Fever (0x14) + the four skin-temp
+// flags (0x10–0x13) come from `SkinTempBaseline` (#69) and `VitalsBaseline` (#72).
+
+import Foundation
+
+/// Every user-facing health notification, across #73 (HR/SpO2) and #85 (temp/fever). One enum =
+/// one de-dupe namespace, so the same condition can't re-fire from two code paths.
+public enum HealthNotification: String, CaseIterable, Codable, Sendable {
+    // #73 — heart rate & blood oxygen
+    case highHR
+    case lowSpO2
+    case elevatedHRInactive
+    // #85 — skin temperature (the four SkinTempBaseline flags) + fever
+    case skinTempRise            // 0x12 skinTempAbnormalRise
+    case skinTempDrop            // 0x13 skinTempAbnormalDrop
+    case skinTempFluctuationRise // 0x10 skinTempFluctuationRise
+    case skinTempFluctuationDrop // 0x11 skinTempFluctuationDrop
+    case fever                   // 0x14 feverAbnormal (HR + temp cross-reference, #72)
+}
+
+// MARK: - Quiet hours (shared DND window)
+
+/// A single nightly quiet-hours window, shared by every alert. Minutes are since-midnight (the
+/// same timezone-free convention as `SleepWindow`), so a window may wrap past midnight.
+public struct QuietHours: Equatable, Sendable {
+    public var enabled: Bool
+    public var startMinutes: Int
+    public var endMinutes: Int
+
+    public init(enabled: Bool = false, startMinutes: Int = 22 * 60, endMinutes: Int = 7 * 60) {
+        self.enabled = enabled
+        self.startMinutes = startMinutes
+        self.endMinutes = endMinutes
+    }
+
+    /// Whether `date` falls inside the quiet window. Disabled ⇒ never. Handles a window that wraps
+    /// past midnight (e.g. 22:00 → 07:00). A zero-length window (start == end) is treated as empty.
+    public func contains(_ date: Date, calendar: Calendar = .current) -> Bool {
+        guard enabled, startMinutes != endMinutes else { return false }
+        let c = calendar.dateComponents([.hour, .minute], from: date)
+        let m = (c.hour ?? 0) * 60 + (c.minute ?? 0)
+        if startMinutes < endMinutes {           // same-day window
+            return m >= startMinutes && m < endMinutes
+        }
+        return m >= startMinutes || m < endMinutes // wraps past midnight
+    }
+}
+
+// MARK: - De-dupe / DND gate
+
+/// Decides whether a notification may fire NOW given quiet hours + an anti-spam backoff. Pure so
+/// the routing is fully testable; the app persists `lastFired` and posts the survivors.
+public struct NotificationGate: Equatable, Sendable {
+    /// Minimum spacing between repeats of the SAME notification (anti-spam backoff).
+    public var renotifyInterval: TimeInterval
+    public init(renotifyInterval: TimeInterval = 2 * 3600) {
+        self.renotifyInterval = renotifyInterval
+    }
+
+    public func shouldFire(_ n: HealthNotification, now: Date,
+                           lastFired: [HealthNotification: Date],
+                           quietHours: QuietHours, calendar: Calendar = .current) -> Bool {
+        if quietHours.contains(now, calendar: calendar) { return false }
+        if let fired = lastFired[n], now.timeIntervalSince(fired) < renotifyInterval { return false }
+        return true
+    }
+
+    /// The subset of `candidates` allowed to fire now, in stable `HealthNotification.allCases` order.
+    public func filter(_ candidates: [HealthNotification], now: Date,
+                       lastFired: [HealthNotification: Date],
+                       quietHours: QuietHours, calendar: Calendar = .current) -> [HealthNotification] {
+        let set = Set(candidates)
+        return HealthNotification.allCases.filter {
+            set.contains($0) && shouldFire($0, now: now, lastFired: lastFired,
+                                           quietHours: quietHours, calendar: calendar)
+        }
+    }
+}
+
+// MARK: - #73 thresholds + evaluator
+
+/// One blood-oxygen reading (percent) with its time. SpO2 is stored as a 0…1 fraction elsewhere;
+/// callers convert to whole percent so the threshold reads in the same units the user configures.
+public struct SpO2Reading: Equatable, Sendable {
+    public let percent: Int
+    public let time: Date
+    public init(percent: Int, time: Date) { self.percent = percent; self.time = time }
+}
+
+/// User-configurable thresholds for the HR/SpO2 alerts (#73). Defaults are conservative and
+/// documented; each rule has its own enable flag so a user can opt out per-rule.
+public struct HealthAlertThresholds: Equatable, Sendable {
+    public var highHREnabled: Bool
+    public var highHRBpm: Int
+    public var lowSpO2Enabled: Bool
+    public var lowSpO2Percent: Int
+    public var elevatedHREnabled: Bool
+    public var elevatedHRBpm: Int
+    public var elevatedSustained: TimeInterval
+    /// Max gap between consecutive readings still counted as one continuous elevated run (so a
+    /// lone spike hours apart isn't "sustained").
+    public var elevatedMaxGap: TimeInterval
+
+    public init(highHREnabled: Bool = true,
+                highHRBpm: Int = 120,
+                lowSpO2Enabled: Bool = true,
+                lowSpO2Percent: Int = 90,
+                elevatedHREnabled: Bool = true,
+                elevatedHRBpm: Int = 100,
+                elevatedSustained: TimeInterval = 10 * 60,
+                elevatedMaxGap: TimeInterval = 5 * 60) {
+        self.highHREnabled = highHREnabled
+        self.highHRBpm = highHRBpm
+        self.lowSpO2Enabled = lowSpO2Enabled
+        self.lowSpO2Percent = lowSpO2Percent
+        self.elevatedHREnabled = elevatedHREnabled
+        self.elevatedHRBpm = elevatedHRBpm
+        self.elevatedSustained = elevatedSustained
+        self.elevatedMaxGap = elevatedMaxGap
+    }
+}
+
+/// One fired alert with the reading that triggered it (for the "… detected at [time]" copy).
+public struct HealthAlertHit: Equatable, Sendable {
+    public let notification: HealthNotification
+    public let value: Double   // bpm for HR alerts, percent for SpO2
+    public let time: Date
+    public init(notification: HealthNotification, value: Double, time: Date) {
+        self.notification = notification; self.value = value; self.time = time
+    }
+}
+
+public enum HealthAlertEvaluator {
+
+    /// The worst (highest) HR reading at/above the threshold, or nil. "High heart rate detected at
+    /// [time]" (pp.txt:48405) — an instantaneous crossing.
+    public static func highHR(_ samples: [HRSample], thresholdBpm: Int) -> HRSample? {
+        samples.filter { $0.bpm >= thresholdBpm }.max { $0.bpm < $1.bpm }
+    }
+
+    /// The worst (lowest) SpO2 reading at/below the threshold, or nil. "Low blood oxygen detected
+    /// at [time]" (pp.txt:48398).
+    public static func lowSpO2(_ readings: [SpO2Reading], thresholdPercent: Int) -> SpO2Reading? {
+        readings.filter { $0.percent > 0 && $0.percent <= thresholdPercent }.min { $0.percent < $1.percent }
+    }
+
+    /// The reading that COMPLETES a continuous run of HR ≥ threshold spanning ≥ `minDuration`,
+    /// or nil. Mirrors the APK's "HR exceeds the set maximum for a continuous 10 minutes while in a
+    /// non-exercising state" (pp.txt:45915). The caller is responsible for passing only inactive /
+    /// non-exercising samples (#61 sharpens that gate); the sustained-window math is here.
+    public static func elevatedHRInactive(_ samples: [HRSample], thresholdBpm: Int,
+                                          minDuration: TimeInterval,
+                                          maxGap: TimeInterval = 5 * 60) -> HRSample? {
+        let sorted = samples.sorted { $0.start < $1.start }
+        var runStart: Date?
+        var prev: Date?
+        for s in sorted {
+            guard s.bpm >= thresholdBpm else { runStart = nil; prev = nil; continue }
+            if let p = prev, s.start.timeIntervalSince(p) > maxGap {
+                runStart = s.start            // gap too big — start a fresh run here
+            } else if runStart == nil {
+                runStart = s.start
+            }
+            prev = s.start
+            if let rs = runStart, s.start.timeIntervalSince(rs) >= minDuration { return s }
+        }
+        return nil
+    }
+
+    /// Evaluate all three #73 rules and return the hits (disabled rules are skipped). `inactiveHR`
+    /// is the HR series for the sustained-while-inactive rule; the instantaneous rules use `hr`.
+    public static func evaluate(hr: [HRSample], spo2: [SpO2Reading], inactiveHR: [HRSample],
+                                thresholds: HealthAlertThresholds) -> [HealthAlertHit] {
+        var hits: [HealthAlertHit] = []
+        if thresholds.highHREnabled, let s = highHR(hr, thresholdBpm: thresholds.highHRBpm) {
+            hits.append(HealthAlertHit(notification: .highHR, value: Double(s.bpm), time: s.start))
+        }
+        if thresholds.lowSpO2Enabled, let s = lowSpO2(spo2, thresholdPercent: thresholds.lowSpO2Percent) {
+            hits.append(HealthAlertHit(notification: .lowSpO2, value: Double(s.percent), time: s.time))
+        }
+        if thresholds.elevatedHREnabled,
+           let s = elevatedHRInactive(inactiveHR, thresholdBpm: thresholds.elevatedHRBpm,
+                                      minDuration: thresholds.elevatedSustained,
+                                      maxGap: thresholds.elevatedMaxGap) {
+            hits.append(HealthAlertHit(notification: .elevatedHRInactive, value: Double(s.bpm), time: s.start))
+        }
+        return hits
+    }
+}
+
+// MARK: - #85 routing (temp flags + fever → notifications)
+
+public enum TempFeverNotifications {
+    /// Map the four `SkinTempBaseline` anomaly flags (#69) + the suspected-fever flag (#72) to the
+    /// notifications they should raise. Pure flag→notification routing; the de-dupe/DND gate and
+    /// posting happen in the shared app-side center. (#85)
+    public static func notifications(flags: SkinTempBaseline.AnomalyFlags,
+                                     feverSuspected: Bool) -> [HealthNotification] {
+        var out: [HealthNotification] = []
+        if flags.abnormalRise { out.append(.skinTempRise) }
+        if flags.abnormalDrop { out.append(.skinTempDrop) }
+        if flags.fluctuationRise { out.append(.skinTempFluctuationRise) }
+        if flags.fluctuationDrop { out.append(.skinTempFluctuationDrop) }
+        if feverSuspected { out.append(.fever) }
+        return out
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/KeepaliveCadence.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/KeepaliveCadence.swift
@@ -1,0 +1,22 @@
+// Adaptive idle-keepalive cadence (#31). The 0x10/0x87 descriptor (steps/temp/battery)
+// is solicited by a `07 00 00` heartbeat; polling it every 30 s around the clock measurably
+// drains both the ring and the phone. Freshness only matters in two windows — the nightly
+// temp capture and an active live measurement — so this picks a slow daytime cadence and
+// tightens only when it counts. Pure (no Apple frameworks) so it unit-tests on the CLI.
+
+import Foundation
+
+public enum KeepaliveCadence {
+    /// Seconds between idle descriptor heartbeats.
+    /// - `isNight`: inside the nightly sleep/temp window (skin temp streams then — keep it fresh).
+    /// - `activeMeasurement`: a live HR/SpO₂ read (or its prep) is in flight — re-check often so
+    ///   the keepalive resumes promptly when it ends (the heartbeat itself is suppressed meanwhile).
+    /// - `batterySaver`: user opted into the battery-saver toggle — stretch the idle cadences.
+    public static func interval(isNight: Bool,
+                                activeMeasurement: Bool,
+                                batterySaver: Bool) -> TimeInterval {
+        if activeMeasurement { return 30 }              // a live read owns the link — re-check fast
+        if isNight { return batterySaver ? 90 : 60 }    // overnight temp matters — tighten to ~1 min
+        return batterySaver ? 300 : 180                 // daytime idle: 3 min (5 min in battery saver)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/LiveHR.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/LiveHR.swift
@@ -1,9 +1,10 @@
-// Live heart-rate decode — ported from desktop/openringconn/framing.py.
+// Live-sample decode — ported from desktop/openringconn/framing.py.
 //
-// 🟢 CONFIRMED (docs/PROTOCOL.md §5). A `0x95`-poll response is shaped
-// `15 00 <hr> 0a b0 <xor>`; **byte[2] = HR in bpm**. Verified by a targeted
-// HR-only capture that settled to a stable 61 bpm resting pulse. The first sample
-// after entering live mode is a warm-up sentinel (byte[2] ≈ 8) before the PPG locks.
+// The `0x95` poll yields a `0x15` frame in one of two shapes (PROTOCOL.md §5.1):
+//   • HR mode (`06 01 00`):   `15 00 <hr> 0a b0 <xor>`  → byte[2] = HR bpm 🟢
+//   • SpO2 mode (`06 02 00`): `15 01 … <spo2> …`        → byte[14] = SpO2 % 🟡
+// HR is verified (HR-only capture settled to 61 bpm resting); the first HR sample is
+// a warm-up sentinel (byte[2] ≈ 8). SpO2 byte[14] matches the app's 96–97% live.
 
 import Foundation
 
@@ -11,9 +12,10 @@ public enum LiveHR {
     /// Below this, the sensor hasn't locked on (warm-up); treat as not-yet-valid.
     public static let minValidBPM = 30
 
-    /// HR in bpm from a 0x15 live frame, or nil if not a valid live frame.
+    /// HR in bpm from a SHORT `15 00 <hr> …` frame, or nil (incl. long `15 01` frames,
+    /// whose byte[2] is 0 — they carry SpO2, not HR).
     public static func decode(_ payload: [UInt8]) -> Int? {
-        guard payload.count >= 4, payload[0] == 0x15 else { return nil }
+        guard payload.count >= 4, payload[0] == 0x15, payload[1] == 0x00 else { return nil }
         return Int(payload[2])
     }
 
@@ -21,5 +23,12 @@ public enum LiveHR {
     public static func decodeLocked(_ payload: [UInt8]) -> Int? {
         guard let hr = decode(payload), hr >= minValidBPM else { return nil }
         return hr
+    }
+
+    /// SpO2 % from a long SpO2-mode frame `15 01 … <spo2> …` (byte[14]), or nil. 🟡
+    public static func decodeSpO2(_ payload: [UInt8]) -> Int? {
+        guard payload.count >= 15, payload[0] == 0x15, payload[1] == 0x01 else { return nil }
+        let spo2 = Int(payload[14])
+        return (70...100).contains(spo2) ? spo2 : nil
     }
 }

--- a/ios/OpenRingKit/Sources/OpenRingKit/LiveHR.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/LiveHR.swift
@@ -26,6 +26,8 @@ public enum LiveHR {
     }
 
     /// SpO2 % from a long SpO2-mode frame `15 01 … <spo2> …` (byte[14]), or nil. 🟡
+    /// Note: single-window measurement, not multi-sample ground-truthed — render with
+    /// "est." caveat in UI to indicate lower confidence (#59).
     public static func decodeSpO2(_ payload: [UInt8]) -> Int? {
         guard payload.count >= 15, payload[0] == 0x15, payload[1] == 0x01 else { return nil }
         let spo2 = Int(payload[14])

--- a/ios/OpenRingKit/Sources/OpenRingKit/Metrics.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Metrics.swift
@@ -64,4 +64,6 @@ public struct SleepSegment: Equatable, Codable, Sendable {
         self.end = end
         self.stage = stage
     }
+
+    public var duration: TimeInterval { end.timeIntervalSince(start) }
 }

--- a/ios/OpenRingKit/Sources/OpenRingKit/Metrics.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Metrics.swift
@@ -30,6 +30,21 @@ public enum MetricKind: String, Codable, CaseIterable, Sendable {
         case .sleep: return "category"
         }
     }
+
+    /// Human-readable label for dashboards.
+    public var displayName: String {
+        switch self {
+        case .heartRate: return "Heart Rate"
+        case .restingHeartRate: return "Resting HR"
+        case .hrvSDNN: return "HRV"
+        case .spo2: return "SpO₂"
+        case .temperature: return "Skin Temp"
+        case .respiratoryRate: return "Respiratory Rate"
+        case .steps: return "Steps"
+        case .activeEnergy: return "Active Energy"
+        case .sleep: return "Sleep"
+        }
+    }
 }
 
 /// A scalar metric sample carrying the device's own timestamps so history

--- a/ios/OpenRingKit/Sources/OpenRingKit/Metrics.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Metrics.swift
@@ -16,6 +16,14 @@ public enum MetricKind: String, Codable, CaseIterable, Sendable {
     case steps
     case activeEnergy
     case sleep            // modeled as SleepSegment, not QuantitySample
+    /// Estimated walking/running distance derived from steps × stride (#81).
+    /// ESTIMATE only — NOT GPS distance. Written to HealthKit `.distanceWalkingRunning`.
+    /// Replaced by decoded device distance once 0x4c activity-epoch [15:22] is decoded (#93).
+    case distance
+    /// Estimated Apple Exercise Time from elevated-HR minutes (#82).
+    /// ESTIMATE only — basic threshold model. Full 4-level intensity follows #93 decode.
+    /// Written to HealthKit `.appleExerciseTime`.
+    case exerciseMinutes
 
     /// Canonical unit each `QuantitySample.value` is expressed in, matching the
     /// HealthKit type it maps to in docs/HEALTHKIT_MAPPING.md.
@@ -28,6 +36,8 @@ public enum MetricKind: String, Codable, CaseIterable, Sendable {
         case .steps: return "count"
         case .activeEnergy: return "kcal"
         case .sleep: return "category"
+        case .distance: return "m"           // meters
+        case .exerciseMinutes: return "min"  // minutes
         }
     }
 
@@ -43,6 +53,8 @@ public enum MetricKind: String, Codable, CaseIterable, Sendable {
         case .steps: return "Steps"
         case .activeEnergy: return "Active Energy"
         case .sleep: return "Sleep"
+        case .distance: return "Distance (est.)"
+        case .exerciseMinutes: return "Exercise Time (est.)"
         }
     }
 }

--- a/ios/OpenRingKit/Sources/OpenRingKit/Opcodes.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Opcodes.swift
@@ -39,6 +39,12 @@ public enum Command {
     public static let poll: [UInt8] = [0x95, 0x00, 0x00]
     public static let pageAck47: [UInt8] = [0xC7, 0x00, 0x00]
     public static let pageAck4C: [UInt8] = [0xCC, 0x00, 0x00]
+    /// Reply to the ring's unsolicited `0x11` heartbeat (ring→host `11 00 <ctr> <tok> <xor>`).
+    /// The official app answers every heartbeat with a constant `91 00 00` (0x11+0x80, same
+    /// +0x80 response convention as 0x47→0xC7) — it does NOT echo the counter/token. 🟢 confirmed
+    /// `ppg_align_20260616` (§5.8). The ring's `0x10` telemetry streams on its own timer
+    /// regardless, but we ACK promptly so an activated ring has no reason to throttle us.
+    public static let heartbeatAck: [UInt8] = [0x91, 0x00, 0x00]
 
     /// Steps to enter live-HR mode, in the order the official app sends them (verified
     /// in the FR02.018 capture: open+drain history, then `d0 00 00` → `06 01 00` → fetch,
@@ -74,6 +80,35 @@ public enum Command {
     public static func syncUpToNow(now: Date = Date()) -> [UInt8] {
         syncSince(unixSeconds: Int(now.timeIntervalSince1970))
     }
+
+    /// Per-connection auth response: the ring challenges with `byte[2]` of its `81 00` reply, and
+    /// the official app answers `01 01 <f(challenge)> 00` where `f` is a deterministic 256-entry
+    /// keyed table (🟡 §5.7: e.g. `b0→31 82 67`, `86→db 2b 80`, `80→a9 a3 ef`, `52→27 7d 7f`).
+    /// The ring does NOT appear to strictly enforce it (our fixed `status1` = `f(0xb0)` has worked),
+    /// so this is informational until `f` is recovered from the APK. Returns the known nonce for a
+    /// challenge, else nil (caller falls back to `status1`). Bytes confirmed via challenge-response
+    /// correlation across 22 capture pairs; the full table needs the APK (issue #54).
+    public static func authNonce(forChallenge c: UInt8) -> [UInt8]? {
+        knownAuthNonces[c]
+    }
+    static let knownAuthNonces: [UInt8: [UInt8]] = [
+        0x0f: [0x4b, 0xcc, 0xe6], 0x1f: [0x9b, 0xc9, 0x31], 0x3b: [0x4b, 0xee, 0x0c],
+        0x3f: [0x67, 0x97, 0xa8], 0x49: [0x0b, 0x20, 0x6f], 0x52: [0x27, 0x7d, 0x7f],
+        0x78: [0xda, 0x5d, 0x57], 0x80: [0xa9, 0xa3, 0xef], 0x81: [0x4c, 0xc4, 0xae],
+        0x86: [0xdb, 0x2b, 0x80], 0x94: [0x71, 0xe9, 0x59], 0x96: [0x08, 0x60, 0xce],
+        0x9d: [0x6b, 0x6e, 0x2c], 0xa3: [0x5e, 0xb6, 0x1e], 0xb0: [0x31, 0x82, 0x67],
+        0xbc: [0x12, 0x52, 0xf2], 0xc2: [0x05, 0x33, 0x17], 0xc4: [0xa2, 0xf8, 0x27],
+        0xcb: [0x09, 0x88, 0x9c], 0xd8: [0x9c, 0x61, 0x91], 0xda: [0xf0, 0x1e, 0x88],
+        0xe3: [0x1b, 0xe9, 0x85], 0xe5: [0x52, 0x0b, 0xe1], 0xf9: [0x36, 0x09, 0xb2],
+    ]   // 24/256 entries from captures (incl. 2026-06-16 login e5→52 0b e1). Full f() needs the APK.
+
+    /// 🔴 UNKNOWN — the one-time login/activation command (if any) the official app sends so the
+    /// ring starts streaming to a fresh client. NOT present in any steady-state capture; reverse-
+    /// engineer from a first-time-provisioning / login btsnoop (issue #54), then fill + wire at the
+    /// discovery handler. Current evidence (§0/§5.8) points to the LE-SC bond itself being the gate
+    /// (local LTK, no cloud key) — in which case there is no app-layer command to send, only the
+    /// CoreBluetooth auto-bond. Placeholder so the call site can land before the bytes are known:
+    // public static func activate(/* token from login */) -> [UInt8] { … }
 }
 
 /// BLE transport handles (🟢). The ring is driven through this pair, not discrete

--- a/ios/OpenRingKit/Sources/OpenRingKit/Opcodes.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Opcodes.swift
@@ -28,14 +28,21 @@ public enum Command {
     public static let status1: [UInt8] = [0x01, 0x01, 0x31, 0x82, 0x67, 0x00]
     /// Open the data session. Cursor 0xFFFFFFFF = "sync everything" (always accepted).
     public static let syncAll: [UInt8] = [0x02, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x01, 0x00]
-    public static let liveHRMode: [UInt8] = [0x06, 0x01, 0x00]
+    public static let statusQuery: [UInt8] = [0xD0, 0x00, 0x00]   // → 0x50; precedes live mode
+    public static let liveHRMode: [UInt8] = [0x06, 0x01, 0x00]    // 06 01 = HR; 06 02 = SpO2
+    public static let liveSpO2Mode: [UInt8] = [0x06, 0x02, 0x00]
     public static let fetch: [UInt8] = [0x07, 0x00, 0x00]
     public static let poll: [UInt8] = [0x95, 0x00, 0x00]
     public static let pageAck47: [UInt8] = [0xC7, 0x00, 0x00]
     public static let pageAck4C: [UInt8] = [0xCC, 0x00, 0x00]
 
-    /// Steps to enter live-HR mode, in order (drain history between fetch/acks).
-    public static let liveHRStart: [[UInt8]] = [status0, status1, syncAll, liveHRMode, fetch]
+    /// Steps to enter live-HR mode, in the order the official app sends them (verified
+    /// in the FR02.018 capture: open+drain history, then `d0 00 00` → `06 01 00` → fetch,
+    /// then poll `95 00 00` for `15 00 <hr>` frames). The `d0 00 00` is REQUIRED — without
+    /// it the ring never switches to HR mode. Pages from the drain are acked in the BLE
+    /// layer; poll after this sequence.
+    public static let liveHRStart: [[UInt8]] = [status0, status1, syncAll, fetch,
+                                                statusQuery, liveHRMode, fetch]
 
     /// Sync-cursor epoch: seconds since 2019-12-31 12:00:00 UTC (🟢 confirmed,
     /// PROTOCOL.md §5.6 — derived from 3 capture (time,cursor) pairs to <0.34 s).

--- a/ios/OpenRingKit/Sources/OpenRingKit/Opcodes.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/Opcodes.swift
@@ -26,7 +26,11 @@ public enum Opcode {
 public enum Command {
     public static let status0: [UInt8] = [0x01, 0x00, 0x00]
     public static let status1: [UInt8] = [0x01, 0x01, 0x31, 0x82, 0x67, 0x00]
-    /// Open the data session. Cursor 0xFFFFFFFF = "sync everything" (always accepted).
+    /// Open the data session at cursor 0xFFFFFFFF — a far-FUTURE cursor. Believed to return an
+    /// EMPTY history (the LIVE path's "skip the backlog, fast HR" open) — ⚠️ 🟡 NOT ground-truthed
+    /// (§3): the official app never sends it, and whether it ADVANCES the ring's resume pointer is
+    /// untested (if it does, the every-10-min auto-measure would shred the backlog). For history
+    /// use `syncUpToNow` (cursor ≈ now → ring drains its backlog up to now). See §3 "Load-bearing".
     public static let syncAll: [UInt8] = [0x02, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x01, 0x00]
     public static let statusQuery: [UInt8] = [0xD0, 0x00, 0x00]   // → 0x50; precedes live mode
     public static let liveHRMode: [UInt8] = [0x06, 0x01, 0x00]    // 06 01 = HR; 06 02 = SpO2
@@ -48,14 +52,27 @@ public enum Command {
     /// PROTOCOL.md §5.6 — derived from 3 capture (time,cursor) pairs to <0.34 s).
     public static let syncEpoch = 1_577_793_600
 
-    /// Build `02 00 <cursor BE4> 00 01 00` to open a sync session for data since
-    /// `unixSeconds` (cursor = unixSeconds − syncEpoch, big-endian). For "everything
-    /// pending" use `syncAll` (0xFFFFFFFF) — the reliable choice for live HR.
+    /// Build `02 00 <cursor BE4> 00 01 00` with `cursor = unixSeconds − syncEpoch` (big-endian).
+    /// A plausible-recent cursor acts as a "drain up to ≈now" trigger (§3) — NOT a hard bound
+    /// (records can overshoot it): the ring streams everything it hasn't handed off, from its own
+    /// internal resume point up to its current time, then self-advances that point.
     public static func syncSince(unixSeconds: Int) -> [UInt8] {
-        let c = UInt32(truncatingIfNeeded: max(0, unixSeconds - syncEpoch))
+        // `clamping` (not `truncatingIfNeeded`): a pre-2020 clock clamps to 0, and a far-future
+        // clock clamps to 0xFFFFFFFF (fails safe to the empty/skip-backlog open) instead of
+        // silently WRAPPING to a small value that would look like a valid recent cursor.
+        let c = UInt32(clamping: unixSeconds - syncEpoch)
         return [0x02, 0x00,
                 UInt8(c >> 24), UInt8((c >> 16) & 0xFF), UInt8((c >> 8) & 0xFF), UInt8(c & 0xFF),
                 0x00, 0x01, 0x00]
+    }
+
+    /// Open a HISTORY sync "up to NOW" — cursor ≈ current wall-clock (🟢 the official app's history
+    /// behaviour, PROTOCOL.md §3: it opens at ≈now every sync). This triggers a drain up to the
+    /// ring's current time and advances its OWN resume pointer, so there is nothing to persist on
+    /// our side. Use this — NOT `syncAll` (0xFFFFFFFF, far-future, which does NOT pull history) —
+    /// for sleep/vitals history. `now` is injectable for tests.
+    public static func syncUpToNow(now: Date = Date()) -> [UInt8] {
+        syncSince(unixSeconds: Int(now.timeIntervalSince1970))
     }
 }
 

--- a/ios/OpenRingKit/Sources/OpenRingKit/ReconnectBackoff.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/ReconnectBackoff.swift
@@ -1,0 +1,35 @@
+// Auto-reconnect backoff policy (#35). RingScanner re-issues `central.connect` on every
+// disconnect; left unbounded, a ring on the charger (it accepts a connect then immediately
+// drops it) keeps the radio armed in a tight reconnect loop for hours. This grows the delay
+// between consecutive failed reconnects and tells the UI when to stop saying "Connecting…"
+// and surface a calm "ring unreachable / charging" note instead. Pure (no CoreBluetooth) so
+// it unit-tests on the CLI; the scanner owns the attempt counter and resets it on a real,
+// frame-delivering connection.
+//
+// NOTE: the calm state is derived from elapsed *attempts*, NOT a decoded charging-flag byte —
+// that descriptor bit is protocol-blocked (#41), so we never claim to know the ring is charging.
+
+import Foundation
+
+public enum ReconnectBackoff {
+    /// Delay (seconds) before the next reconnect, indexed by consecutive failed attempts:
+    /// 1 s → 5 s → 30 s, then capped at 30 s. Reset the attempt counter on a successful,
+    /// frame-delivering connect.
+    public static let delays: [TimeInterval] = [1, 5, 30]
+
+    /// Backoff delay before reconnect attempt `attempt` (1-based). Attempt 0 (or less) means
+    /// "no failures yet" → reconnect immediately. Past the table it stays at the cap.
+    public static func delay(forAttempt attempt: Int) -> TimeInterval {
+        guard attempt > 0 else { return 0 }
+        return delays[min(attempt - 1, delays.count - 1)]
+    }
+
+    /// After this many consecutive failed reconnect attempts, the UI should swap the permanent
+    /// "Connecting…" for a calm "ring unreachable / charging — will reconnect automatically".
+    public static let calmStateAttemptThreshold = 3
+
+    /// Whether enough reconnects have failed to surface the calm state (vs. "Connecting…").
+    public static func shouldSurfaceCalmState(attempts: Int) -> Bool {
+        attempts >= calmStateAttemptThreshold
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/ReminderEngine.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/ReminderEngine.swift
@@ -1,0 +1,105 @@
+// Pure reminder-firing predicates (#84). Three kinds: sedentary/move, ring-not-worn,
+// and bedtime wind-down. All logic is side-effect-free — callers route survivors through
+// the shared `NotificationGate` (DND + backoff) in `HealthNotificationCenter`.
+//
+// "Activity" for the sedentary rule is a nonzero step delta from the ring. The caller
+// supplies `lastActivityAt` (from UserDefaults). nil → false (never a cold-launch nag).
+
+import Foundation
+
+// MARK: - Reminder kinds
+
+/// Stable identifiers for each reminder type. The raw value is used as the
+/// `UNUserNotificationRequest` identifier AND as the de-dupe key in the shared
+/// `HealthNotificationStore` — must stay stable across launches.
+public enum ReminderKind: String, CaseIterable, Sendable {
+    case sedentary = "reminder.sedentary"
+    case wear      = "reminder.wear"
+    case bedtime   = "reminder.bedtime"
+}
+
+// MARK: - Sedentary / move reminder
+
+/// Fire if the user has been physically inactive for longer than `interval` and we're
+/// inside the daily active window. "Activity" = a nonzero step delta from the ring;
+/// `lastActivityAt` is nil until the first step arrives so the rule stays silent on a
+/// fresh session / day the ring isn't worn (never a false positive).
+public struct SedentaryReminder: Equatable, Sendable {
+    /// Inactivity threshold before firing.
+    public var interval: TimeInterval
+    /// Minutes-since-midnight window within which the reminder may fire. Default 08:00–21:00.
+    public var activeStartMinutes: Int
+    public var activeEndMinutes: Int
+
+    public init(interval: TimeInterval = 50 * 60,
+                activeStartMinutes: Int = 8 * 60,
+                activeEndMinutes: Int = 21 * 60) {
+        self.interval = interval
+        self.activeStartMinutes = activeStartMinutes
+        self.activeEndMinutes = activeEndMinutes
+    }
+
+    /// True when inactive for ≥ `interval` AND inside the active window.
+    public func shouldFire(lastActivityAt: Date?, now: Date,
+                           calendar: Calendar = .current) -> Bool {
+        guard let last = lastActivityAt else { return false }
+        guard now.timeIntervalSince(last) >= interval else { return false }
+        let c = calendar.dateComponents([.hour, .minute], from: now)
+        let m = (c.hour ?? 0) * 60 + (c.minute ?? 0)
+        return m >= activeStartMinutes && m < activeEndMinutes
+    }
+}
+
+// MARK: - Wear reminder
+
+/// Fire if we have ever connected to the ring but ring data has gone silent for
+/// longer than `noDataInterval`. Opt-in (default off) — never fires before the first
+/// connection (`everConnected = false`).
+public struct WearReminder: Equatable, Sendable {
+    /// Gap without ring data that triggers the reminder.
+    public var noDataInterval: TimeInterval
+
+    public init(noDataInterval: TimeInterval = 20 * 60) {
+        self.noDataInterval = noDataInterval
+    }
+
+    /// True when data from the ring has been absent for ≥ `noDataInterval` and the ring
+    /// has been connected at least once in this session.
+    public func shouldFire(lastRingDataAt: Date?, now: Date, everConnected: Bool) -> Bool {
+        guard everConnected else { return false }
+        guard let last = lastRingDataAt else { return true }   // ever connected but no data
+        return now.timeIntervalSince(last) >= noDataInterval
+    }
+}
+
+// MARK: - Bedtime reminder
+
+/// Fire once inside the window [bedMinutes − minutesBefore, bedMinutes) to give the
+/// user a heads-up before their configured bedtime. The window is in minutes-since-
+/// midnight and wraps past midnight correctly. Returns false when bed == wake (schedule
+/// not configured), matching `SleepWindow`'s convention.
+public struct BedtimeReminder: Equatable, Sendable {
+    /// How many minutes before the bedtime the window opens.
+    public var minutesBefore: Int
+
+    public init(minutesBefore: Int = 30) {
+        self.minutesBefore = minutesBefore
+    }
+
+    /// True when the current time-of-day falls inside [bed − minutesBefore, bed).
+    public func shouldFire(now: Date, bedMinutes: Int, wakeMinutes: Int,
+                           calendar: Calendar = .current) -> Bool {
+        guard bedMinutes != wakeMinutes else { return false }   // not configured
+        let windowStart = (bedMinutes - minutesBefore + 1440) % 1440
+        let windowEnd   = bedMinutes
+        let c = calendar.dateComponents([.hour, .minute], from: now)
+        let m = (c.hour ?? 0) * 60 + (c.minute ?? 0)
+        return minuteInWindow(m, start: windowStart, end: windowEnd)
+    }
+
+    private func minuteInWindow(_ m: Int, start: Int, end: Int) -> Bool {
+        if start == end { return false }
+        if start < end  { return m >= start && m < end }
+        return m >= start || m < end   // wraps past midnight
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/RingAuth.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/RingAuth.swift
@@ -1,0 +1,131 @@
+// RingConn per-connection auth — the "activation" handshake (PROTOCOL.md §5.8, issue #54).
+//
+// 🟢 Reverse-engineered 2026-06-16 from the official app's Dart AOT (`libapp.so`, disassembled
+// after blutter-decompiling the v3.2.1 build) and VERIFIED against 24 captured challenge→response
+// pairs + the canonical SM3 test vector. The ring will not stream data until it receives a correct
+// auth response each connection; this is what previously required opening the official app.
+//
+// Sequence every connect: host `01 00 00` → ring `81 00 <challenge> <xor>`; host must reply
+//   `01 01 <r0> <r1> <r2> 00`   where (r0,r1,r2) = SM3( [V, challenge] )[29..31]   (last 3 bytes)
+//   and  V = mac[3] ^ mac[4] ^ mac[5]   (XOR of the ring's last 3 BLE-MAC bytes).
+//
+// The only key material is the ring's own MAC (no cloud key, no app secret), so this is computable
+// offline for any RingConn. iOS can't read the MAC via CoreBluetooth, but the ring exposes it via
+// the Device Information System ID characteristic (0x2a23, §1) — see `macFromSystemID`.
+
+import Foundation
+
+public enum RingAuth {
+
+    /// Build the `01 01 …` auth response for a ring challenge, given the ring's 6-byte MAC.
+    public static func authCommand(challenge: UInt8, mac: [UInt8]) -> [UInt8] {
+        let r = response(challenge: challenge, mac: mac)
+        return [0x01, 0x01, r[0], r[1], r[2], 0x00]
+    }
+
+    /// The 3 response bytes = last 3 bytes of SM3([V, challenge]), V = XOR of the last 3 MAC bytes.
+    public static func response(challenge: UInt8, mac: [UInt8]) -> [UInt8] {
+        let v = macTailXor(mac)
+        let digest = SM3.hash([v, challenge])
+        return Array(digest.suffix(3))
+    }
+
+    /// V = mac[3] ^ mac[4] ^ mac[5] (XOR of the 3 least-significant / NIC MAC bytes). Returns 0 for
+    /// a short array (caller should not auth without a real MAC).
+    public static func macTailXor(_ mac: [UInt8]) -> UInt8 {
+        guard mac.count >= 6 else { return 0 }
+        return mac[3] ^ mac[4] ^ mac[5]
+    }
+
+    /// Extract the 6-byte MAC from a Device-Information System ID (0x2a23) value. The BLE System ID
+    /// is an 8-byte EUI-64: OUI(3) + `FF FE` + NIC(3), but vendors/stacks may store it reversed, so
+    /// we normalise both. Returns nil if we can't recognise a layout. (iOS-only path — CoreBluetooth
+    /// hides the raw MAC; this characteristic is how we recover it.)
+    public static func macFromSystemID(_ sysid: [UInt8]) -> [UInt8]? {
+        // 8-byte EUI-64 with the FF FE marker in the middle (forward order).
+        if sysid.count == 8, sysid[3] == 0xFF, sysid[4] == 0xFE {
+            return [sysid[0], sysid[1], sysid[2], sysid[5], sysid[6], sysid[7]]
+        }
+        // Reversed EUI-64 (FF FE in the middle, counting from the end).
+        if sysid.count == 8, sysid[4] == 0xFE, sysid[3] == 0xFF {
+            return [sysid[0], sysid[1], sysid[2], sysid[5], sysid[6], sysid[7]]
+        }
+        if sysid.count == 8 {
+            let rev = Array(sysid.reversed())
+            if rev[3] == 0xFF, rev[4] == 0xFE {
+                return [rev[0], rev[1], rev[2], rev[5], rev[6], rev[7]]
+            }
+        }
+        // Raw 6-byte MAC, or take the trailing 6 bytes as a last resort.
+        if sysid.count == 6 { return sysid }
+        if sysid.count > 6 { return Array(sysid.suffix(6)) }
+        return nil
+    }
+}
+
+/// SM3 — the Chinese national 256-bit cryptographic hash (GB/T 32905-2016). Self-contained; the
+/// only crypto OpenRingConn needs (the RingConn auth uses SM3, not SHA/MD5). Verified against the
+/// `SM3("abc")` KAT in tests.
+public enum SM3 {
+    private static let IV: [UInt32] = [
+        0x7380166f, 0x4914b2b9, 0x172442d7, 0xda8a0600,
+        0xa96f30bc, 0x163138aa, 0xe38dee4d, 0xb0fb0e4e,
+    ]
+
+    @inline(__always) private static func rotl(_ x: UInt32, _ n: UInt32) -> UInt32 {
+        let n = n & 31
+        return n == 0 ? x : (x << n) | (x >> (32 - n))
+    }
+    @inline(__always) private static func T(_ j: Int) -> UInt32 { j < 16 ? 0x79cc4519 : 0x7a879d8a }
+    @inline(__always) private static func FF(_ x: UInt32, _ y: UInt32, _ z: UInt32, _ j: Int) -> UInt32 {
+        j < 16 ? (x ^ y ^ z) : ((x & y) | (x & z) | (y & z))
+    }
+    @inline(__always) private static func GG(_ x: UInt32, _ y: UInt32, _ z: UInt32, _ j: Int) -> UInt32 {
+        j < 16 ? (x ^ y ^ z) : ((x & y) | (~x & z))
+    }
+    @inline(__always) private static func P0(_ x: UInt32) -> UInt32 { x ^ rotl(x, 9) ^ rotl(x, 17) }
+    @inline(__always) private static func P1(_ x: UInt32) -> UInt32 { x ^ rotl(x, 15) ^ rotl(x, 23) }
+
+    public static func hash(_ input: [UInt8]) -> [UInt8] {
+        var msg = input
+        let bitLen = UInt64(input.count) * 8
+        msg.append(0x80)
+        while msg.count % 64 != 56 { msg.append(0) }
+        for i in stride(from: 56, through: 0, by: -8) { msg.append(UInt8((bitLen >> UInt64(i)) & 0xff)) }
+
+        var V = IV
+        var blk = 0
+        while blk < msg.count {
+            var W = [UInt32](repeating: 0, count: 68)
+            for j in 0..<16 {
+                let o = blk + j * 4
+                W[j] = (UInt32(msg[o]) << 24) | (UInt32(msg[o+1]) << 16) | (UInt32(msg[o+2]) << 8) | UInt32(msg[o+3])
+            }
+            for j in 16..<68 {
+                W[j] = P1(W[j-16] ^ W[j-9] ^ rotl(W[j-3], 15)) ^ rotl(W[j-13], 7) ^ W[j-6]
+            }
+            var W1 = [UInt32](repeating: 0, count: 64)
+            for j in 0..<64 { W1[j] = W[j] ^ W[j+4] }
+
+            var a = V[0], b = V[1], c = V[2], d = V[3], e = V[4], f = V[5], g = V[6], h = V[7]
+            for j in 0..<64 {
+                let ss1 = rotl((rotl(a, 12) &+ e &+ rotl(T(j), UInt32(j % 32))) & 0xffffffff, 7)
+                let ss2 = ss1 ^ rotl(a, 12)
+                let tt1 = (FF(a, b, c, j) &+ d &+ ss2 &+ W1[j]) & 0xffffffff
+                let tt2 = (GG(e, f, g, j) &+ h &+ ss1 &+ W[j]) & 0xffffffff
+                d = c; c = rotl(b, 9); b = a; a = tt1
+                h = g; g = rotl(f, 19); f = e; e = P0(tt2)
+            }
+            V[0] ^= a; V[1] ^= b; V[2] ^= c; V[3] ^= d; V[4] ^= e; V[5] ^= f; V[6] ^= g; V[7] ^= h
+            blk += 64
+        }
+
+        var out = [UInt8]()
+        out.reserveCapacity(32)
+        for word in V {
+            out.append(UInt8((word >> 24) & 0xff)); out.append(UInt8((word >> 16) & 0xff))
+            out.append(UInt8((word >> 8) & 0xff));  out.append(UInt8(word & 0xff))
+        }
+        return out
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/SleepWindow.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/SleepWindow.swift
@@ -1,0 +1,57 @@
+// Pure, platform-agnostic sleep-window date math.
+//
+// This lives in OpenRingKit (no Apple-UI dependencies) so it can be unit-tested with
+// `swift test`. The app layer (ios/OpenRingConn) wraps it in a `SleepScheduleProviding`
+// implementation that pulls the user's bedtime/wake from `@AppStorage`, and a HealthKit
+// implementation that reads the real iOS Sleep schedule. See `SleepSchedule.swift`.
+
+import Foundation
+
+/// Builds a concrete bedtime→wake `DateInterval` from a *time-of-day* schedule
+/// (minutes-since-midnight for bed and wake), correctly handling a window that crosses
+/// midnight (e.g. bed 22:30 → wake 06:30).
+public enum SleepWindow {
+
+    /// Minutes in a day.
+    public static let minutesPerDay = 1440
+
+    /// The sleep window whose **wake** time falls nearest to `date`.
+    ///
+    /// - Parameters:
+    ///   - bedMinutes: bedtime as minutes since local midnight (e.g. 22:30 → 1350).
+    ///   - wakeMinutes: wake time as minutes since local midnight (e.g. 06:30 → 390).
+    ///   - date: the reference instant; the night *ending near* this is chosen.
+    ///   - calendar: calendar used to resolve local midnight (default `.current`).
+    /// - Returns: a `DateInterval` from bedtime to wake. When the schedule crosses
+    ///   midnight (`bedMinutes >= wakeMinutes`) the bedtime lands on the previous day.
+    ///   Returns `nil` only for a degenerate zero-length schedule (`bed == wake`).
+    public static func interval(bedMinutes: Int,
+                                wakeMinutes: Int,
+                                nightEndingNear date: Date,
+                                calendar: Calendar = .current) -> DateInterval? {
+        let bed = ((bedMinutes % minutesPerDay) + minutesPerDay) % minutesPerDay
+        let wake = ((wakeMinutes % minutesPerDay) + minutesPerDay) % minutesPerDay
+
+        // Sleep duration, wrapping across midnight. bed==wake → 0 (degenerate; no window).
+        let duration = ((wake - bed) + minutesPerDay) % minutesPerDay
+        guard duration > 0 else { return nil }
+
+        // Candidate wake instants on the day before / of / after `date`; pick the nearest.
+        let midnight = calendar.startOfDay(for: date)
+        let candidates: [Date] = (-1...1).compactMap { dayOffset in
+            calendar.date(byAdding: .day, value: dayOffset, to: midnight)
+                .map { $0.addingTimeInterval(TimeInterval(wake * 60)) }
+        }
+        guard let wakeDate = candidates.min(by: {
+            abs($0.timeIntervalSince(date)) < abs($1.timeIntervalSince(date))
+        }) else { return nil }
+
+        let bedDate = wakeDate.addingTimeInterval(TimeInterval(-duration * 60))
+        return DateInterval(start: bedDate, end: wakeDate)
+    }
+
+    /// Convenience: minutes-since-midnight from an `hour`/`minute` pair.
+    public static func minutes(hour: Int, minute: Int) -> Int {
+        (hour * 60 + minute + minutesPerDay) % minutesPerDay
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/SleepWindow.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/SleepWindow.swift
@@ -54,4 +54,25 @@ public enum SleepWindow {
     public static func minutes(hour: Int, minute: Int) -> Int {
         (hour * 60 + minute + minutesPerDay) % minutesPerDay
     }
+
+    /// Whether a detected sleep block looks like OVERNIGHT sleep (as opposed to a daytime nap or
+    /// a long sedentary daytime period). Used to gate the persistent nightly sleep summary so a
+    /// worn-but-still daytime block (a long meeting, a movie, an afternoon nap > 1 h) that a sync
+    /// happens to drain isn't staged as "last night" and allowed to overwrite the real night.
+    ///
+    /// Rule: the block is overnight when its MIDPOINT falls between 21:00 and 09:00 local — i.e. the
+    /// middle of the sleep is at night. A real night's midpoint always lands in the small hours
+    /// (whether onset is pre- or post-midnight), so a genuine night is never rejected; a midday nap
+    /// or a long daytime block has a daytime midpoint and is rejected. Using the midpoint (rather
+    /// than an interval-overlap test) avoids fragile behaviour at the window boundaries. This only
+    /// decides ACCEPTANCE — the FULL detected block is kept when accepted, so totals are never
+    /// clipped.
+    public static func isOvernightBlock(start: Date, end: Date,
+                                        calendar: Calendar = .current) -> Bool {
+        let safeEnd = max(end, start)
+        let mid = start.addingTimeInterval(safeEnd.timeIntervalSince(start) / 2)
+        let c = calendar.dateComponents([.hour, .minute], from: mid)
+        let minutes = (c.hour ?? 0) * 60 + (c.minute ?? 0)
+        return minutes < 9 * 60 || minutes >= 21 * 60   // before 09:00 or at/after 21:00
+    }
 }

--- a/ios/OpenRingKit/Sources/OpenRingKit/StepAccumulator.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/StepAccumulator.swift
@@ -1,0 +1,70 @@
+// Step accumulation (#34). The ring's onboard step count (0x10/0x87 descriptor `[4:6]`,
+// 16-bit big-endian, DeviceStatus.steps) is a SINCE-HANDOFF delta, not a daily total: the
+// official app sums it in local memory and periodically RESETS the ring's counter. If the
+// official app isn't running, the ring's counter just keeps climbing (it does NOT reset at
+// midnight on its own). So a usable daily total has to be reconstructed by folding the
+// incremental deltas between successive raw readings — reset-aware, and stamped to the day
+// the reading was sampled.
+//
+// This type is the pure, unit-tested core of that fold. `RingSession` persists the last raw
+// counter + its day across sessions (UserDefaults) and `LocalStore` upserts the resulting
+// delta into the per-day rollup; both stay thin callers so the tricky reset/midnight cases
+// live here where they can be tested without CoreBluetooth or SwiftData.
+//
+// Pure (no Apple frameworks beyond Foundation) so it runs on the SwiftPM CLI.
+
+import Foundation
+
+/// Outcome of folding one raw counter observation into the running daily total.
+public struct StepUpdate: Equatable, Sendable {
+    /// Steps to add to the SAMPLE day's running total. Always `>= 0` — never negative, so a
+    /// caller can add it blindly without re-checking for a drop.
+    public let deltaToAdd: Int
+    /// The raw counter dropped below the last reading: the official app reset / took over the
+    /// since-handoff counter (or the ring rebooted, or the 16-bit counter wrapped). When true,
+    /// `newRaw` itself is taken as the post-reset count (`deltaToAdd == newRaw`), not
+    /// `newRaw - previousRaw`.
+    public let isReset: Bool
+    /// A reset that is NOT explained by a day rollover — i.e. the counter dropped *mid-day*.
+    /// A drop across midnight is the official app's expected daily reset; a drop within the
+    /// same day is unexpected (handoff/reboot/wrap) and worth logging (#34). Always false when
+    /// `isReset` is false.
+    public let isAnomalousReset: Bool
+
+    public init(deltaToAdd: Int, isReset: Bool, isAnomalousReset: Bool) {
+        self.deltaToAdd = deltaToAdd
+        self.isReset = isReset
+        self.isAnomalousReset = isAnomalousReset
+    }
+}
+
+public enum StepAccumulator {
+    /// Fold a freshly observed raw counter against the last one we recorded.
+    ///
+    /// - Parameters:
+    ///   - previousRaw: the last raw counter we persisted, or `nil` when there is no prior
+    ///     reading (first run ever / no persisted state). With no baseline we cannot know how
+    ///     many of the raw steps are "ours" vs. taken before we ever connected, so we count
+    ///     none and just adopt `newRaw` as the baseline (`deltaToAdd == 0`).
+    ///   - newRaw: the counter just observed (`DeviceStatus.steps`, 0…65535).
+    ///   - dayChanged: the sample's calendar day differs from the day `previousRaw` was
+    ///     observed. Only affects whether a reset is flagged as anomalous — the delta math is
+    ///     identical across midnight because the ring's counter is monotonic between resets, so
+    ///     the incremental delta is always the correct amount to credit the new (sample) day.
+    public static func update(previousRaw: Int?, newRaw: Int, dayChanged: Bool) -> StepUpdate {
+        guard let previous = previousRaw else {
+            // No baseline — adopt this reading as the baseline, count nothing.
+            return StepUpdate(deltaToAdd: 0, isReset: false, isAnomalousReset: false)
+        }
+        if newRaw >= previous {
+            // Monotonic climb (same day, or across midnight with the official app not running):
+            // the incremental delta is the steps taken since the last reading.
+            return StepUpdate(deltaToAdd: newRaw - previous, isReset: false, isAnomalousReset: false)
+        }
+        // Counter dropped: the official app reset/handed-off the since-handoff counter (or the
+        // ring rebooted, or the 16-bit counter wrapped). `newRaw` is the post-reset count. A
+        // mid-day drop is unexpected and surfaced as anomalous; a drop across midnight is the
+        // official app's normal daily reset.
+        return StepUpdate(deltaToAdd: newRaw, isReset: true, isAnomalousReset: !dayChanged)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/SyncCursor.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/SyncCursor.swift
@@ -36,4 +36,22 @@ public struct SyncCursor: Equatable, Codable, Sendable {
         for s in fresh { advance(s.kind, to: s.start) }
         return fresh
     }
+
+    /// Non-mutating `selectNew` for callers that must only advance the cursor AFTER a durable
+    /// store commit: returns the to-write subset together with the cursor state to persist
+    /// *once the save succeeds*. Staging the advance means a failed/rolled-back save leaves the
+    /// cursor where it was, so the same decoded samples are retried next time rather than being
+    /// skipped — decoded frames must always end up stored (#22).
+    public func selectNewStaged(_ samples: [QuantitySample]) -> (fresh: [QuantitySample], advanced: SyncCursor) {
+        var advanced = self
+        let fresh = advanced.selectNew(samples)
+        return (fresh, advanced)
+    }
+
+    /// Kinds whose high-water mark differs from `previous` — i.e. the cursors that actually
+    /// moved. Lets the store persist only the changed rows instead of re-writing every kind on
+    /// every ingest (#33).
+    public func advancedKinds(since previous: SyncCursor) -> [MetricKind] {
+        MetricKind.allCases.filter { last($0) != previous.last($0) }
+    }
 }

--- a/ios/OpenRingKit/Sources/OpenRingKit/SyncObservability.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/SyncObservability.swift
@@ -1,0 +1,97 @@
+// Observability/alerting policy (#44). As an always-on tracker the app can fail silently —
+// a throttled background task, a revoked Health grant, a ring left off the charger. This holds
+// the PURE decision logic for when to warn the user (staleness + low-battery thresholds and the
+// per-condition debounce) plus a bounded ring-buffer helper, so the policy unit-tests on the CLI
+// without any Apple frameworks. The UserDefaults persistence + UNUserNotificationCenter glue
+// lives in the app target (Observability/ObservabilityStore.swift).
+
+import Foundation
+
+/// The silent-failure conditions worth a local notification.
+public enum SyncAlert: String, CaseIterable, Codable, Sendable {
+    case notSynced       // no successful ring sync in > staleSyncThreshold
+    case lowBattery      // ring battery at/under lowBatteryThreshold
+    case healthAuthLost  // Health share access was granted before and is now off
+}
+
+/// Thresholds + debounce for the silent-failure alerts. Pure value type: the app feeds it the
+/// current observed state and the last time each alert fired, and it returns which alerts should
+/// fire now — never firing the same condition twice inside `renotifyInterval`.
+public struct SyncAlertPolicy: Sendable, Equatable {
+    /// No successful sync in this long → `notSynced`.
+    public var staleSyncThreshold: TimeInterval
+    /// Ring battery at/under this percent → `lowBattery`.
+    public var lowBatteryThreshold: Int
+    /// Minimum spacing between repeat notifications of the SAME condition (anti-spam).
+    public var renotifyInterval: TimeInterval
+
+    public init(staleSyncThreshold: TimeInterval = 6 * 3600,
+                lowBatteryThreshold: Int = 15,
+                renotifyInterval: TimeInterval = 6 * 3600) {
+        self.staleSyncThreshold = staleSyncThreshold
+        self.lowBatteryThreshold = lowBatteryThreshold
+        self.renotifyInterval = renotifyInterval
+    }
+
+    /// The conditions currently true, ignoring debounce.
+    /// - `lastSuccessfulSync == nil` is treated as "no baseline yet" (a brand-new user who has
+    ///   never synced is NOT nagged) — staleness only fires relative to a prior success.
+    /// - `batteryPercent == nil` (e.g. the background session is torn down) skips the battery
+    ///   check rather than firing a false low-battery alert.
+    /// - `healthAuthLost` only fires when Health was authorized before (`healthEverAuthorized`)
+    ///   and is now off — so a user who simply never opted into Health isn't told it "broke".
+    public func activeConditions(now: Date,
+                                 lastSuccessfulSync: Date?,
+                                 batteryPercent: Int?,
+                                 healthAuthorized: Bool,
+                                 healthEverAuthorized: Bool) -> Set<SyncAlert> {
+        var conditions: Set<SyncAlert> = []
+        if let last = lastSuccessfulSync, now.timeIntervalSince(last) > staleSyncThreshold {
+            conditions.insert(.notSynced)
+        }
+        if let battery = batteryPercent, battery <= lowBatteryThreshold {
+            conditions.insert(.lowBattery)
+        }
+        if healthEverAuthorized && !healthAuthorized {
+            conditions.insert(.healthAuthLost)
+        }
+        return conditions
+    }
+
+    /// Which alerts to actually post now: an active condition whose last notification is older
+    /// than `renotifyInterval` (or never sent). Returned in a stable `SyncAlert.allCases` order.
+    public func alertsToFire(now: Date,
+                             lastSuccessfulSync: Date?,
+                             batteryPercent: Int?,
+                             healthAuthorized: Bool,
+                             healthEverAuthorized: Bool,
+                             lastFired: [SyncAlert: Date]) -> [SyncAlert] {
+        let active = activeConditions(now: now,
+                                      lastSuccessfulSync: lastSuccessfulSync,
+                                      batteryPercent: batteryPercent,
+                                      healthAuthorized: healthAuthorized,
+                                      healthEverAuthorized: healthEverAuthorized)
+        return SyncAlert.allCases.filter { alert in
+            guard active.contains(alert) else { return false }
+            if let fired = lastFired[alert], now.timeIntervalSince(fired) < renotifyInterval {
+                return false
+            }
+            return true
+        }
+    }
+}
+
+/// Append-and-cap helper for a fixed-size ring buffer (the background-task outcome log, #44).
+/// Trims from the FRONT so the newest `limit` entries survive. Pure so the app's JSON-in-
+/// UserDefaults log stays trivially testable.
+public enum BoundedLog {
+    public static func appendCapped<Element>(_ element: Element,
+                                             to list: [Element],
+                                             limit: Int) -> [Element] {
+        guard limit > 0 else { return [] }
+        var out = list
+        out.append(element)
+        if out.count > limit { out.removeFirst(out.count - limit) }
+        return out
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/UnitPreferences.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/UnitPreferences.swift
@@ -1,0 +1,91 @@
+// User-configurable display units for temperature and distance (#83).
+//
+// All ring sensor values are STORED in SI (Celsius, metres). Only the display layer
+// converts. Both enum types are `RawRepresentable` with a String raw value so they can
+// be stored directly in `@AppStorage` without a custom binding.
+//
+// `localeDefault` uses `Locale.current.measurementSystem` (iOS 16+, which the app
+// requires via its iOS 17 deployment target) to pick a sane out-of-box default.
+
+import Foundation
+
+// MARK: - Temperature
+
+public enum TemperatureUnit: String, CaseIterable, Codable, Sendable {
+    case celsius    = "celsius"
+    case fahrenheit = "fahrenheit"
+
+    /// Convert a Celsius value to this unit.
+    public func convert(fromCelsius c: Double) -> Double {
+        switch self {
+        case .celsius:    return c
+        case .fahrenheit: return c * 9 / 5 + 32
+        }
+    }
+
+    /// The unit abbreviation shown next to a formatted value.
+    public var symbol: String {
+        switch self {
+        case .celsius:    return "°C"
+        case .fahrenheit: return "°F"
+        }
+    }
+
+    /// Sensible default inferred from the current locale (US → °F, everything else → °C).
+    public static var localeDefault: TemperatureUnit {
+        if #available(iOS 16, macOS 13, *) {
+            return Locale.current.measurementSystem == .us ? .fahrenheit : .celsius
+        }
+        // Fallback for older OS versions: region-code heuristic.
+        return Locale.current.regionCode == "US" ? .fahrenheit : .celsius
+    }
+}
+
+// MARK: - Distance
+
+public enum DistanceUnit: String, CaseIterable, Codable, Sendable {
+    case metric   = "metric"    // kilometres
+    case imperial = "imperial"  // miles
+
+    /// Convert metres to this unit.
+    public func convert(fromMeters m: Double) -> Double {
+        switch self {
+        case .metric:   return m / 1_000
+        case .imperial: return m / 1_609.344
+        }
+    }
+
+    public var symbol: String {
+        switch self {
+        case .metric:   return "km"
+        case .imperial: return "mi"
+        }
+    }
+
+    public static var localeDefault: DistanceUnit {
+        if #available(iOS 16, macOS 13, *) {
+            return Locale.current.measurementSystem == .us ? .imperial : .metric
+        }
+        return Locale.current.regionCode == "US" ? .imperial : .metric
+    }
+}
+
+// MARK: - Formatter
+
+/// Stateless helpers that turn raw SI values into localised display strings.
+public enum UnitsFormatter {
+
+    /// Format a Celsius value in the requested unit, e.g. "36.5 °C" or "97.7 °F".
+    public static func temperature(_ celsius: Double, unit: TemperatureUnit,
+                                   fractionDigits: Int = 1) -> String {
+        let v = unit.convert(fromCelsius: celsius)
+        return String(format: "%.\(fractionDigits)f \(unit.symbol)", v)
+    }
+
+    /// Format a metres value in the requested unit, e.g. "3.2 km" or "2.0 mi".
+    public static func distance(_ meters: Double, unit: DistanceUnit,
+                                fractionDigits: Int = 1) -> String {
+        let v = unit.convert(fromMeters: meters)
+        return String(format: "%.\(fractionDigits)f \(unit.symbol)", v)
+    }
+}

--- a/ios/OpenRingKit/Sources/OpenRingKit/UserProfile.swift
+++ b/ios/OpenRingKit/Sources/OpenRingKit/UserProfile.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public enum BiologicalSex: String, Codable, CaseIterable, Sendable {
+    case male
+    case female
+}
+
+public struct UserProfile: Equatable, Codable, Sendable {
+    public let age: Int
+    public let weightKg: Double
+    public let heightCm: Double
+    public let sex: BiologicalSex
+
+    public init(age: Int, weightKg: Double, heightCm: Double, sex: BiologicalSex) {
+        self.age = age
+        self.weightKg = weightKg
+        self.heightCm = heightCm
+        self.sex = sex
+    }
+}

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -163,6 +163,25 @@ check(cursor.last(.heartRate) == t2, "cursor advanced to t2; never backward")
 cursor.advance(.heartRate, to: t0)
 check(cursor.last(.heartRate) == t2, "advance() never moves cursor backward")
 
+// --- Cumulative counters ---
+check(MetricKind.steps.isCumulativeCounter, "steps are treated as cumulative counters")
+check(MetricKind.activeEnergy.isCumulativeCounter, "active energy is treated as cumulative counter")
+let stepsFirst = CumulativeMetricAccumulator.accumulate(
+    QuantitySample(kind: .steps, start: t0, value: 100),
+    state: CumulativeMetricState()
+)
+let stepsSecond = CumulativeMetricAccumulator.accumulate(
+    QuantitySample(kind: .steps, start: t1, value: 140),
+    state: CumulativeMetricState(previousRawValue: stepsFirst.rawValue, dailyTotal: stepsFirst.dailyTotal)
+)
+check(stepsFirst.deltaValue == 100 && stepsFirst.dailyTotal == 100, "first cumulative sample uses raw as delta")
+check(stepsSecond.deltaValue == 40 && stepsSecond.dailyTotal == 140, "cumulative sample stores delta and running total")
+let rolledSteps = CumulativeMetricAccumulator.accumulate(
+    QuantitySample(kind: .steps, start: t2, value: 12),
+    state: CumulativeMetricState(previousRawValue: 250, dailyTotal: 250)
+)
+check(rolledSteps.deltaValue == 12 && rolledSteps.dailyTotal == 262, "counter rollover uses raw value as delta")
+
 // --- Analytics (ported from openwhoop-algos) ---
 // HRV / RMSSD
 check(HRV.rmssd([800, 900, 1000]) == 100, "rmssd([800,900,1000]) = 100")

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -47,6 +47,11 @@ check(Array(Command.syncAll[2...5]) == [0xFF, 0xFF, 0xFF, 0xFF], "syncAll cursor
 check(Command.syncSince(unixSeconds: Command.syncEpoch + 0x0c2298c3)
       == [0x02, 0x00, 0x0c, 0x22, 0x98, 0xc3, 0x00, 0x01, 0x00],
       "syncSince builds 02 00 <cursor BE4> 00 01 00 (epoch 1577793600)")
+// History sync opens at cursor ≈ NOW (official app's behaviour §3) — never syncAll (0xFFFFFFFF,
+// far-future → empty backlog, the bug that dropped overnight sleep/HRV/RR).
+let nowOpen = Command.syncUpToNow(now: Date(timeIntervalSince1970: 1_750_000_000))
+check(nowOpen == Command.syncSince(unixSeconds: 1_750_000_000), "syncUpToNow = syncSince(now)")
+check(nowOpen != Command.syncAll, "syncUpToNow is NOT syncAll (0xFFFFFFFF)")
 for f in realFrames { check(Frame.isValid(hex(f)), "real frame validates: \(f)") }
 
 var bad = hex("8100b031"); bad[1] ^= 0xFF
@@ -236,9 +241,9 @@ let calorieSamples = (0..<600).map { offset in
 }
 check(abs(Calories.activeKcal(hrSamples: calorieSamples, maxHR: 180) - 150.0) < 0.001, "TRIMP 30 -> 150 kcal")
 
-// Sleep score (integer-ratio model, faithful to openwhoop)
+// Sleep score (graded floating-point ratio, #28 — NOT the openwhoop integer step)
 check(SleepScore.score(durationSeconds: 8 * 3600) == 100.0, "8h sleep -> 100")
-check(SleepScore.score(durationSeconds: 4 * 3600) == 0.0, "4h sleep -> 0 (integer ratio)")
+check(SleepScore.score(durationSeconds: 4 * 3600) == 50.0, "4h sleep -> 50 (graded ratio, #28)")
 check(SleepScore.score(durationSeconds: 24 * 3600) == 100.0, "24h sleep -> clamped 100")
 
 // Sleep detection (activity.rs)

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -138,6 +138,22 @@ check(strain.calculate(bpms: Array(repeating: 80, count: 500)) == nil, "too few 
 check(Strain(maxHR: 60, restingHR: 60).calculate(bpms: Array(repeating: 80, count: 600)) == nil,
       "maxHR<=restingHR -> nil")
 
+// Calories (Mifflin-St Jeor BMR + Edwards TRIMP kcal)
+let maleProfile = UserProfile(age: 30, weightKg: 80, heightCm: 180, sex: .male)
+check(Calories.bmrKcalPerDay(profile: maleProfile) == 1780.0, "male BMR Mifflin-St Jeor")
+check(abs(Calories.bmrKcalPerHour(profile: maleProfile) - 74.166_666) < 0.001, "male BMR hourly")
+let femaleProfile = UserProfile(age: 40, weightKg: 65, heightCm: 165, sex: .female)
+check(Calories.bmrKcalPerDay(profile: femaleProfile) == 1320.25, "female BMR Mifflin-St Jeor")
+let hrStart = Date(timeIntervalSince1970: 0)
+let calorieSamples = (0..<600).map { offset in
+    HRSample(
+        bpm: 150,
+        start: hrStart.addingTimeInterval(Double(offset)),
+        end: hrStart.addingTimeInterval(Double(offset + 1))
+    )
+}
+check(abs(Calories.activeKcal(hrSamples: calorieSamples, maxHR: 180) - 150.0) < 0.001, "TRIMP 30 -> 150 kcal")
+
 // Sleep score (integer-ratio model, faithful to openwhoop)
 check(SleepScore.score(durationSeconds: 8 * 3600) == 100.0, "8h sleep -> 100")
 check(SleepScore.score(durationSeconds: 4 * 3600) == 0.0, "4h sleep -> 0 (integer ratio)")

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -74,6 +74,15 @@ check(decodedSpO2 == [96, 96, 97], "real SpO2 frames -> byte[14] %")
 print("    => live SpO2 from real frames: \(decodedSpO2.compactMap { $0 })")
 check(LiveHR.decodeSpO2(hex("15005b0ab0f4")) == nil, "short HR frame yields no SpO2")
 
+// --- Step count from the 0x10/0x87 descriptor [4:6] (real frames, §5.4) ---
+check(DeviceStatus.steps(hex("105402000051011f012500000000105400ff96")) == 81,
+      "descriptor [4:6] -> 81 steps (🟢 app-confirmed via from-scratch sync)")
+check(DeviceStatus.steps(hex("8754020000000157015700000000105800ff66")) == 0,
+      "descriptor with no steps -> 0")
+check(DeviceStatus.steps(hex("8754030000510138013a00000000105402ff3a")) == 81,
+      "step count also in 0x87 descriptor")
+check(DeviceStatus.steps(hex("15005b0ab0f4")) == nil, "non-descriptor frame -> nil steps")
+
 // --- Metric models + SyncCursor ---
 check(MetricKind.spo2.unit == "fraction", "spo2 unit is fraction (HealthKit 0…1)")
 check(MetricKind.heartRate.unit == "count/min", "heartRate unit count/min")

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -328,5 +328,47 @@ let zeroPayloadSleep = BulkRecord(hex("0c22cd8b38520973620a010101010100000000000
 check(zeroPayloadSleep.layout == .sleepVitals && zeroPayloadSleep.heartRate == 0x38,
       "zero-payload sleep epoch keeps HR (not mistaken for idle)")
 
+// --- Sleep-stage classifier (SleepStaging, §5.3) ---------------------------------
+// stagedSegments now delegates to SleepStaging.classify; it must produce the same output.
+check(BulkSleep.stagedSegments(from: staged) == SleepStaging.classify(from: staged),
+      "BulkSleep.stagedSegments delegates to SleepStaging.classify")
+
+// Calm flat low HR (still) -> predominantly Deep, no REM.
+var deepNight: [BulkRecord] = []
+var dc: UInt32 = 0x0c220000
+for _ in 0..<12 { deepNight.append(bulkRec(dc, motion: 0x14, sub: 0x12)); dc += 150 }
+for _ in 0..<120 { deepNight.append(vrec(dc, motion: 0x01, hr: 50)); dc += 150 }
+for _ in 0..<12 { deepNight.append(bulkRec(dc, motion: 0x14, sub: 0x12)); dc += 150 }
+let deepSegs = SleepStaging.classify(from: deepNight)
+let deepTotals = SleepStaging.stageTotals(deepSegs)
+let deepAsleep = (deepTotals[.asleepDeep] ?? 0) + (deepTotals[.asleepCore] ?? 0) + (deepTotals[.asleepREM] ?? 0)
+check(deepAsleep > 0 && (deepTotals[.asleepDeep] ?? 0) / deepAsleep > 0.8,
+      "calm flat low HR -> mostly Deep")
+check((deepTotals[.asleepREM] ?? 0) == 0, "calm flat HR -> no REM")
+
+// Constructed multi-cycle night partitions like a tracker: Light ≫ REM > Deep, modest awake.
+func vrecHRV(_ c: UInt32, hr: UInt8, hrv: UInt8) -> BulkRecord {
+    var b = vrec(c, motion: 0x01, hr: hr).raw; b[5] = hrv; return BulkRecord(b)!
+}
+var night2: [BulkRecord] = []
+var nc: UInt32 = 0x0c220000
+for _ in 0..<8 { night2.append(bulkRec(nc, motion: 0x14, sub: 0x12)); nc += 150 }
+for cycle in 0..<5 {
+    for _ in 0..<10 { night2.append(vrecHRV(nc, hr: 56, hrv: 60)); nc += 150 }   // Light
+    for _ in 0..<8  { night2.append(vrecHRV(nc, hr: 50, hrv: 70)); nc += 150 }   // Deep
+    for _ in 0..<8  { night2.append(vrecHRV(nc, hr: 56, hrv: 60)); nc += 150 }   // Light
+    for _ in 0..<10 { night2.append(vrecHRV(nc, hr: 62, hrv: 45)); nc += 150 }   // REM
+    if cycle < 4 { for _ in 0..<2 { night2.append(bulkRec(nc, motion: 0x15, sub: 0x12)); nc += 150 } }
+}
+for _ in 0..<8 { night2.append(bulkRec(nc, motion: 0x14, sub: 0x12)); nc += 150 }
+let s = SleepStaging.summary(SleepStaging.classify(from: night2))
+check(s.deep > 0 && s.rem > 0 && s.light > 0 && s.awake > 0, "constructed night has all 4 stages")
+check(s.light > s.rem && s.rem > s.deep, "architecture sanity: Light ≫ REM > Deep")
+check(abs(s.inBed - (s.totalAsleep + s.awake)) < 150, "inBed ≈ asleep + awake (partition)")
+check(s.efficiency > 0.6 && s.efficiency <= 1.0, "plausible sleep efficiency")
+let m = s.minutes
+print("    => constructed night (min): inBed \(m.inBed), asleep \(m.asleep), "
+      + "awake \(m.awake), light \(m.light), deep \(m.deep), rem \(m.rem), eff \(Int(s.efficiency * 100))%")
+
 print(failures == 0 ? "\nALL CHECKS PASSED" : "\n\(failures) CHECK(S) FAILED")
 exit(failures == 0 ? 0 : 1)

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -246,6 +246,20 @@ check(SleepScore.score(durationSeconds: 8 * 3600) == 100.0, "8h sleep -> 100")
 check(SleepScore.score(durationSeconds: 4 * 3600) == 50.0, "4h sleep -> 50 (graded ratio, #28)")
 check(SleepScore.score(durationSeconds: 24 * 3600) == 100.0, "24h sleep -> clamped 100")
 
+// RingConn per-connection auth (#54): response = SM3([V, challenge])[-3:], V = XOR of last 3 MAC bytes.
+check(SM3.hash(Array("abc".utf8)).map { String(format: "%02x", $0) }.joined()
+      == "66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0", "SM3('abc') KAT")
+let authMac: [UInt8] = [0xf8, 0x79, 0x99, 0xf7, 0x03, 0xad]   // F8:79:99:F7:03:AD → V=0x59
+check(RingAuth.macTailXor(authMac) == 0x59, "RingAuth V = 0x59")
+for (ch, exp) in [(UInt8(0x0f), "4bcce6"), (0xb0, "318267"), (0xe5, "520be1"), (0xf9, "3609b2"), (0x52, "277d7f")] {
+    let got = RingAuth.response(challenge: ch, mac: authMac).map { String(format: "%02x", $0) }.joined()
+    check(got == exp, "RingAuth f(\(String(format: "%02x", ch)))=\(exp)")
+}
+check(RingAuth.authCommand(challenge: 0xb0, mac: authMac) == [0x01, 0x01, 0x31, 0x82, 0x67, 0x00],
+      "RingAuth.authCommand = 01 01 31 82 67 00 for challenge 0xb0")
+check(RingAuth.macFromSystemID([0xf8, 0x79, 0x99, 0xff, 0xfe, 0xf7, 0x03, 0xad]) == authMac,
+      "macFromSystemID parses EUI-64")
+
 // Sleep detection (activity.rs)
 let base = Date(timeIntervalSince1970: 1_700_000_000)
 func reading(_ minutes: Int, _ g: SIMD3<Float>?) -> GravitySample {

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -190,5 +190,24 @@ check(BulkSleep.sleepSegments(from: night).contains { $0.stage == .inBed },
 check(BulkSleep.mainSleep(from: night.prefix(20).map { $0 }) == nil,
       "all-active -> no sleep block")
 
+// Experimental staging: low-HR region -> Deep, high-HR -> REM (sleep-vitals sub 0x62).
+func vrec(_ c: UInt32, motion: UInt8, hr: UInt8) -> BulkRecord {
+    var b = bulkRec(c, motion: motion, sub: 0x62).raw; b[4] = hr; return BulkRecord(b)!
+}
+var staged: [BulkRecord] = []
+var sc: UInt32 = 0x0c220000
+for _ in 0..<20 { staged.append(bulkRec(sc, motion: 0x14, sub: 0x12)); sc += 150 }
+for _ in 0..<60 { staged.append(vrec(sc, motion: 0x01, hr: 72)); sc += 150 }   // REM band
+for _ in 0..<60 { staged.append(vrec(sc, motion: 0x01, hr: 50)); sc += 150 }   // Deep band
+for _ in 0..<60 { staged.append(vrec(sc, motion: 0x01, hr: 60)); sc += 150 }   // Light
+for _ in 0..<20 { staged.append(bulkRec(sc, motion: 0x14, sub: 0x12)); sc += 150 }
+let stages = Set(BulkSleep.stagedSegments(from: staged).map { $0.stage })
+check(stages.contains(.asleepDeep) && stages.contains(.asleepREM) && stages.contains(.asleepCore),
+      "staging separates Deep/REM/Light by HR band (experimental)")
+// Regression: a sleep-vitals epoch with baseline motion + zero payload is NOT idle.
+let zeroPayloadSleep = BulkRecord(hex("0c22cd8b38520973620a01010101010000000000000004"))!
+check(zeroPayloadSleep.layout == .sleepVitals && zeroPayloadSleep.heartRate == 0x38,
+      "zero-payload sleep epoch keeps HR (not mistaken for idle)")
+
 print(failures == 0 ? "\nALL CHECKS PASSED" : "\n\(failures) CHECK(S) FAILED")
 exit(failures == 0 ? 0 : 1)

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -95,6 +95,17 @@ check(DeviceStatus.steps(hex("8754030000510138013a00000000105402ff3a")) == 81,
       "step count also in 0x87 descriptor")
 check(DeviceStatus.steps(hex("15005b0ab0f4")) == nil, "non-descriptor frame -> nil steps")
 
+// --- Skin temperature from the 0x10/0x87 descriptor [6:8]/[8:10] (real frames, §5.4 🟢) ---
+let temp = DeviceStatus.skinTemperature(hex("104e0300000001630165000000001019 02ffaf".replacingOccurrences(of: " ", with: "")))
+check(temp?.channelA == 35.5 && temp?.channelB == 35.7,
+      "descriptor [6:10] -> 35.5/35.7 °C (🟢 morning, app avg 96.40 °F)")
+check(temp.map { abs($0.fahrenheit - 96.08) < 0.01 } == true, "skin temp -> 96.08 °F mean")
+check(DeviceStatus.skinTemperature(hex("105402000051011f012500000000105400ff96"))?.channelA == 28.7,
+      "just-donned ring reads ~28.7 °C (warming curve)")
+check(DeviceStatus.skinTemperature(hex("15005b0ab0f4")) == nil, "non-descriptor frame -> nil temp")
+check(DeviceStatus.skinTemperature(hex("104e0300000000000000000000001019 02ffaf".replacingOccurrences(of: " ", with: ""))) == nil,
+      "zero-temp descriptor -> nil (out of band)")
+
 // --- Epoch sync Layer A ---
 var ppgA = makeEpochRecord(size: EpochRecord.ppgRecordSize, counter: 0x000100)
 ppgA.replaceSubrange(9..<47, with: Array(repeating: UInt8(0xAA), count: 38))

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -279,10 +279,12 @@ let dsr = BulkRecord(hex("0c22d5bf444d057a620a01010101012aa0000090000004"))!
 check(dsr.heartRate == 68, "sleep-vitals [4] -> HR 68 bpm (🟢 app-confirmed)")
 check(dsr.hrvRMSSD == 77, "sleep-vitals [5] -> HRV 77 ms (🟢)")
 check(dsr.spo2Percent == 98, "sleep-vitals [8] -> SpO2 98% (🟢)")
+check(dsr.respiratoryRate == 15.25, "sleep-vitals [7] 0x7a/8 -> RR 15.25 brpm (🟢, app avg 15.1)")
 check(dsr.counter == 0x0c22d5bf, "record [0:4] -> BE counter")
 let dsSamples = BulkSleep.samples(from: [dsr])
-check(dsSamples.count == 3, "sleep-vitals -> HR + HRV + SpO2 samples")
+check(dsSamples.count == 4, "sleep-vitals -> HR + HRV + SpO2 + RR samples")
 check(dsSamples.first(where: { $0.kind == .spo2 })?.value == 0.98, "SpO2 emitted as 0…1 fraction")
+check(dsSamples.first(where: { $0.kind == .respiratoryRate })?.value == 15.25, "RR sample emitted")
 let idleRec = BulkRecord(hex("0c099dbf05000c00120a01010101010000000000000000"))!
 check(idleRec.layout == .idle && BulkSleep.samples(from: [idleRec]).isEmpty,
       "idle template -> no samples")

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -57,6 +57,23 @@ check(LiveHR.decode(hex("15003d0ab092")) == 61, "live HR resting -> 61 bpm (from
 check(LiveHR.decodeLocked(hex("1500080ab0a7")) == nil, "warm-up sentinel (8) filtered by decodeLocked")
 check(LiveHR.decode([]) == nil, "empty HR -> nil")
 
+// --- Live decode against REAL poll frames from the FR02.018 capture ---
+let realHRFrames = ["1500080ab0a7", "1500520ab0fd", "1500540ab0fb", "1500580ab0f7",
+                    "15005a0ab0f5", "15005b0ab0f4", "1500420ab0ed", "15003d0ab092"]
+let decodedHR = realHRFrames.map { LiveHR.decodeLocked(hex($0)) }
+check(decodedHR == [nil, 82, 84, 88, 90, 91, 66, 61], "real HR poll stream -> bpm sequence")
+let hrDisplay = decodedHR.map { hr in hr.map(String.init) ?? "warm-up" }.joined(separator: ", ")
+print("    => live HR from real frames: \(hrDisplay)")
+
+let realSpO2Frames = ["15010000207afb00000024a1c800600098",
+                      "150100001615ac0000001a2c8f00600062",
+                      "15010000102e8000000010be5c00610039"]
+check(realSpO2Frames.allSatisfy { LiveHR.decode(hex($0)) == nil }, "long 15 01 frames yield NO HR (byte[2]=0)")
+let decodedSpO2 = realSpO2Frames.map { LiveHR.decodeSpO2(hex($0)) }
+check(decodedSpO2 == [96, 96, 97], "real SpO2 frames -> byte[14] %")
+print("    => live SpO2 from real frames: \(decodedSpO2.compactMap { $0 })")
+check(LiveHR.decodeSpO2(hex("15005b0ab0f4")) == nil, "short HR frame yields no SpO2")
+
 // --- Metric models + SyncCursor ---
 check(MetricKind.spo2.unit == "fraction", "spo2 unit is fraction (HealthKit 0…1)")
 check(MetricKind.heartRate.unit == "count/min", "heartRate unit count/min")

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -168,5 +168,27 @@ let idleRec = BulkRecord(hex("0c099dbf05000c00120a01010101010000000000000000"))!
 check(idleRec.layout == .idle && BulkSleep.samples(from: [idleRec]).isEmpty,
       "idle template -> no samples")
 
+// Motion-channel sleep detection: active -> still(9h) -> active finds the night.
+func bulkRec(_ c: UInt32, motion: UInt8, sub: UInt8) -> BulkRecord {
+    var b = [UInt8](repeating: 0, count: 23)
+    b[0] = UInt8(c >> 24); b[1] = UInt8((c >> 16) & 0xFF)
+    b[2] = UInt8((c >> 8) & 0xFF); b[3] = UInt8(c & 0xFF)
+    b[8] = sub
+    for k in 0..<5 { b[10 + k] = motion }
+    return BulkRecord(b)!
+}
+var night: [BulkRecord] = []
+var cc: UInt32 = 0x0c220000
+for _ in 0..<20 { night.append(bulkRec(cc, motion: 0x14, sub: 0x12)); cc += 150 }
+for _ in 0..<216 { night.append(bulkRec(cc, motion: 0x01, sub: 0x62)); cc += 150 }
+for _ in 0..<20 { night.append(bulkRec(cc, motion: 0x14, sub: 0x12)); cc += 150 }
+let block = BulkSleep.mainSleep(from: night)
+check(block?.activity == .sleep, "motion detection finds the sleep block")
+check(abs((block?.duration ?? 0) - 216 * 150) < 30 * 60, "sleep block ~9 h")
+check(BulkSleep.sleepSegments(from: night).contains { $0.stage == .inBed },
+      "sleepSegments emits inBed")
+check(BulkSleep.mainSleep(from: night.prefix(20).map { $0 }) == nil,
+      "all-active -> no sleep block")
+
 print(failures == 0 ? "\nALL CHECKS PASSED" : "\n\(failures) CHECK(S) FAILED")
 exit(failures == 0 ? 0 : 1)

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -103,6 +103,11 @@ check(temp.map { abs($0.fahrenheit - 96.08) < 0.01 } == true, "skin temp -> 96.0
 check(DeviceStatus.skinTemperature(hex("105402000051011f012500000000105400ff96"))?.channelA == 28.7,
       "just-donned ring reads ~28.7 °C (warming curve)")
 check(DeviceStatus.skinTemperature(hex("15005b0ab0f4")) == nil, "non-descriptor frame -> nil temp")
+
+// --- Battery % from the 0x10/0x87 descriptor [1] (real frame, §5.4 🟢) ---
+check(DeviceStatus.battery(hex("104e0300000001630165000000001019 02ffaf".replacingOccurrences(of: " ", with: ""))) == 78,
+      "descriptor [1] 0x4e -> 78% battery (🟢, app-confirmed 76%=0x4c)")
+check(DeviceStatus.battery(hex("15005b0ab0f4")) == nil, "non-descriptor frame -> nil battery")
 check(DeviceStatus.skinTemperature(hex("104e0300000000000000000000001019 02ffaf".replacingOccurrences(of: " ", with: ""))) == nil,
       "zero-temp descriptor -> nil (out of band)")
 

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -144,5 +144,29 @@ check(ActivityPeriod.findSleep(&shortSleep) == nil, "findSleep: ignores <60min s
 var none: [ActivityPeriod] = []
 check(ActivityPeriod.findSleep(&none) == nil, "findSleep: empty -> nil")
 
+// --- Bulk activity/sleep decode (0x4c, PROTOCOL.md §5.3) ---
+// Real, XOR-valid 0x4c page from the 2026-06-13 overnight sync: 6 × 23-byte records.
+let realPage = "4c00260c22a16b55210a7d120a010101010100000402400400000c22a20155000300"
+    + "120a010101010100003c00000d01200c22a297540001005f0a010101010100001101b00f"
+    + "00440c22a32d6027077b120a010101010100402501c02235a00c22a3c351260577120b01"
+    + "0101010108a01000000401300c22a459502d0378120a01010101010160200000040ff0cc"
+let pageRecs = BulkSleep.records(fromPage: hex(realPage))
+check(pageRecs.count == 6, "0x4c page splits into 6 × 23-byte records")
+check(pageRecs[2].layout == .sleepVitals && pageRecs[0].layout == .activity,
+      "record [8] keys layout: sleep-vitals vs activity")
+
+// Deep-sleep epoch confirmed against the app: HR 68 / HRV 77 / SpO2 98.
+let dsr = BulkRecord(hex("0c22d5bf444d057a620a01010101012aa0000090000004"))!
+check(dsr.heartRate == 68, "sleep-vitals [4] -> HR 68 bpm (🟢 app-confirmed)")
+check(dsr.hrvRMSSD == 77, "sleep-vitals [5] -> HRV 77 ms (🟢)")
+check(dsr.spo2Percent == 98, "sleep-vitals [8] -> SpO2 98% (🟢)")
+check(dsr.counter == 0x0c22d5bf, "record [0:4] -> BE counter")
+let dsSamples = BulkSleep.samples(from: [dsr])
+check(dsSamples.count == 3, "sleep-vitals -> HR + HRV + SpO2 samples")
+check(dsSamples.first(where: { $0.kind == .spo2 })?.value == 0.98, "SpO2 emitted as 0…1 fraction")
+let idleRec = BulkRecord(hex("0c099dbf05000c00120a01010101010000000000000000"))!
+check(idleRec.layout == .idle && BulkSleep.samples(from: [idleRec]).isEmpty,
+      "idle template -> no samples")
+
 print(failures == 0 ? "\nALL CHECKS PASSED" : "\n\(failures) CHECK(S) FAILED")
 exit(failures == 0 ? 0 : 1)

--- a/ios/OpenRingKit/Sources/RingKitVerify/main.swift
+++ b/ios/OpenRingKit/Sources/RingKitVerify/main.swift
@@ -19,6 +19,18 @@ func hex(_ s: String) -> [UInt8] {
     }
     return out
 }
+func makeFrame(opcode: UInt8, body: [UInt8]) -> [UInt8] {
+    let withoutTrailer = [opcode] + body
+    return withoutTrailer + [Frame.xorTrailer(withoutTrailer)]
+}
+func makeEpochRecord(size: Int, counter: UInt32, fill: UInt8 = 0x01) -> [UInt8] {
+    var bytes = [EpochRecord.marker,
+                 UInt8((counter >> 16) & 0xFF),
+                 UInt8((counter >> 8) & 0xFF),
+                 UInt8(counter & 0xFF)]
+    bytes += Array(repeating: fill, count: size - bytes.count)
+    return bytes
+}
 
 // Real validated notify frames from desktop/captures/btsnoop_hci.log.
 let realFrames = [
@@ -82,6 +94,41 @@ check(DeviceStatus.steps(hex("8754020000000157015700000000105800ff66")) == 0,
 check(DeviceStatus.steps(hex("8754030000510138013a00000000105402ff3a")) == 81,
       "step count also in 0x87 descriptor")
 check(DeviceStatus.steps(hex("15005b0ab0f4")) == nil, "non-descriptor frame -> nil steps")
+
+// --- Epoch sync Layer A ---
+var ppgA = makeEpochRecord(size: EpochRecord.ppgRecordSize, counter: 0x000100)
+ppgA.replaceSubrange(9..<47, with: Array(repeating: UInt8(0xAA), count: 38))
+let ppgB = makeEpochRecord(size: EpochRecord.ppgRecordSize, counter: 0x000484)
+let ppgFrame = Data(makeFrame(opcode: EpochRecord.ppgOpcode, body: [0x00, 0x03] + ppgA + ppgB))
+let ppgRecords = EpochRecord.parsePPGPage(ppgFrame, streamHighByte: 0x0c)
+check(ppgRecords.count == 2, "0x47 page splits 47-byte records")
+check(ppgRecords.first?.timestamp == Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x0c000100)),
+      "record counter maps to sync epoch Date")
+check(ppgRecords.first?.rawPayload == Data(Array(repeating: UInt8(0xAA), count: 38)),
+      "0x47 exposes 38-byte raw PPG payload")
+
+var activity = makeEpochRecord(size: EpochRecord.activityRecordSize, counter: 0x2298c3, fill: 0x00)
+activity[8] = 0x12
+activity.replaceSubrange(15..<22, with: [1, 2, 3, 4, 5, 6, 7])
+let activityFrame = Data(makeFrame(opcode: EpochRecord.activityOpcode, body: [0x00, 0x00] + activity))
+let activityRecords = EpochRecord.parseActivityPage(activityFrame, streamHighByte: 0x0c)
+check(activityRecords.count == 1, "0x4c routes to final activity page")
+check(activityRecords.first?.subtype == 0x12, "0x4c exposes subtype byte[8]")
+check(activityRecords.first?.rawPayload == Data([1, 2, 3, 4, 5, 6, 7]),
+      "0x4c exposes 7-byte raw metric payload")
+
+let cursorReport = Data([0x50, 0x00, 0x00, 0x12, 0x0c, 0x22, 0xaa, 0xe4, 0x0c, 0x22, 0xac, 0xb5])
+if let report = EpochRecord.parseEndOfHistory(cursorReport) {
+    check(report.cursorTo == 0x0c22acb5, "0x50 cursor report decodes no-XOR end cursor")
+} else {
+    check(false, "0x50 routes to cursor report")
+}
+
+var epochSession = EpochSyncSession()
+_ = epochSession.appendActivityPage(activityFrame)
+_ = epochSession.complete(with: cursorReport)
+check(epochSession.placeholderQuantitySamples().count == 1,
+      "epoch metric decoder emits gated zero-value HR placeholders for worn records")
 
 // --- Metric models + SyncCursor ---
 check(MetricKind.spo2.unit == "fraction", "spo2 unit is fraction (HealthKit 0…1)")

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/AnalyticsTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/AnalyticsTests.swift
@@ -105,8 +105,11 @@ final class AnalyticsTests: XCTestCase {
     // MARK: Sleep score (sleep.rs)
 
     func testSleepScore() {
+        // #28: graded (floating-point ratio), not a 0-or-100 step function.
         XCTAssertEqual(SleepScore.score(durationSeconds: 8 * 3600), 100.0)
-        XCTAssertEqual(SleepScore.score(durationSeconds: 4 * 3600), 0.0)  // integer ratio
-        XCTAssertEqual(SleepScore.score(durationSeconds: 24 * 3600), 100.0)  // clamped
+        XCTAssertEqual(SleepScore.score(durationSeconds: 6 * 3600), 75.0)
+        XCTAssertEqual(SleepScore.score(durationSeconds: 4 * 3600), 50.0)
+        XCTAssertEqual(SleepScore.score(durationSeconds: 0), 0.0)
+        XCTAssertEqual(SleepScore.score(durationSeconds: 24 * 3600), 100.0)  // clamped at the ideal
     }
 }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/AnalyticsTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/AnalyticsTests.swift
@@ -75,6 +75,33 @@ final class AnalyticsTests: XCTestCase {
         XCTAssertEqual(Strain(maxHR: 190, restingHR: 60).calculate(bpms: Array(repeating: 190, count: 86400)), 21.0)
     }
 
+    // MARK: Calories — Mifflin-St Jeor + TRIMP
+
+    func testMaleBMRMifflinStJeor() {
+        let profile = UserProfile(age: 30, weightKg: 80, heightCm: 180, sex: .male)
+        XCTAssertEqual(Calories.bmrKcalPerDay(profile: profile), 1780.0, accuracy: 0.001)
+        XCTAssertEqual(Calories.bmrKcalPerHour(profile: profile), 74.166_666, accuracy: 0.001)
+    }
+
+    func testFemaleBMRMifflinStJeor() {
+        let profile = UserProfile(age: 40, weightKg: 65, heightCm: 165, sex: .female)
+        XCTAssertEqual(Calories.bmrKcalPerDay(profile: profile), 1320.25, accuracy: 0.001)
+    }
+
+    func testActiveCaloriesFromEdwardsTRIMP() {
+        let start = Date(timeIntervalSince1970: 0)
+        let samples = (0..<600).map { offset in
+            HRSample(
+                bpm: 150,
+                start: start.addingTimeInterval(Double(offset)),
+                end: start.addingTimeInterval(Double(offset + 1))
+            )
+        }
+        // maxHR 180, restingHR 60, bpm 150 => 75% HRR => zone weight 3.
+        // 600 one-second samples = 10 min, TRIMP = 30, kcal = 150.
+        XCTAssertEqual(Calories.activeKcal(hrSamples: samples, maxHR: 180), 150.0, accuracy: 0.001)
+    }
+
     // MARK: Sleep score (sleep.rs)
 
     func testSleepScore() {

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/AutoMeasureGateTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/AutoMeasureGateTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import OpenRingKit
+
+// Auto-measure wear gate (#56): infers "not worn" from consecutive auto-measures that never
+// lock (🟢) plus an optional cold raw skin-temp reading (🟡), and backs the probe interval off
+// exponentially so a ring on the charger isn't probed every 10 min. Asserts the inference +
+// the backoff schedule so a regression (e.g. reverting to a fixed cadence) is caught. No
+// charging-flag byte is consulted (undecoded — #61).
+final class AutoMeasureGateTests: XCTestCase {
+
+    // MARK: not-worn inference
+
+    func testWornUntilThresholdWithoutTemperature() {
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 0))
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 1),
+                       "one transient miss (e.g. a moving hand) is not yet not-worn")
+        XCTAssertTrue(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 2))
+        XCTAssertTrue(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 9))
+    }
+
+    func testWarmSkinTempIsAlwaysWorn() {
+        // A warm reading is direct evidence of wear even after many missed locks.
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 9, rawSkinTempC: 32))
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 0, rawSkinTempC: 30))
+    }
+
+    func testColdSkinTempConfirmsNotWornAfterOneMiss() {
+        // Cold alone (no miss yet) is NOT enough — a worn-but-cool ring would have locked.
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 0, rawSkinTempC: 22),
+                       "cold reading with no failed lock is not conclusive")
+        XCTAssertTrue(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 1, rawSkinTempC: 22),
+                      "cold + a missed lock ⇒ not worn")
+    }
+
+    func testThresholdBoundaryMatchesWornMinTemperature() {
+        let worn = ActivityPeriod.wornMinTemperatureC   // 28 °C
+        XCTAssertFalse(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 1, rawSkinTempC: worn),
+                       "exactly at the worn threshold counts as worn")
+        XCTAssertTrue(AutoMeasureGate.appearsNotWorn(consecutiveNoLock: 1, rawSkinTempC: worn - 0.1))
+    }
+
+    // MARK: backoff schedule
+
+    private let base: TimeInterval = 600     // 10 min
+    private let cap: TimeInterval = 7200     // 2 h
+
+    func testIntervalStaysAtBaseWhileWorn() {
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 0), base)
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 1), base,
+                       "a single miss without temp evidence does not back off yet")
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 9, rawSkinTempC: 33),
+                       base, "warm skin ⇒ keep the normal cadence")
+    }
+
+    func testIntervalDoublesOnceNotWornThenCaps() {
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 2), 1200) // ×2
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 3), 2400) // ×4
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 4), 4800) // ×8
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 5), cap,  // ×16 → cap 7200
+                       "base ×16 = 9600 is clamped to the 2 h cap")
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 99), cap,
+                       "stays capped")
+    }
+
+    func testColdTempBacksOffFromTheFirstConfirmedMiss() {
+        // Cold + 1 miss is not-worn, but the first backed-off interval is still `base`
+        // (0 doublings) — it ramps from there.
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 1, rawSkinTempC: 21), base)
+        XCTAssertEqual(AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 2, rawSkinTempC: 21), 1200)
+    }
+
+    func testIntervalIsMonotonicNonDecreasing() {
+        var prev = AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: 0)
+        for n in 1...12 {
+            let v = AutoMeasureGate.interval(base: base, cap: cap, consecutiveNoLock: n)
+            XCTAssertGreaterThanOrEqual(v, prev)
+            prev = v
+        }
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/BatteryTTETests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/BatteryTTETests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import OpenRingKit
+
+final class BatteryTTETests: XCTestCase {
+
+    private let t0 = Date(timeIntervalSince1970: 0)
+
+    private func sample(_ pct: Int, hours: Double) -> BatteryTTE.Sample {
+        BatteryTTE.Sample(percent: pct, at: t0.addingTimeInterval(hours * 3_600))
+    }
+
+    // MARK: - timeToEmpty
+
+    func testCleanDischarge() {
+        // 10 % drop in 1 hour starting at 100 % → rate = 10 %/hr → TTE = 90% / 10%/hr = 9 h
+        let samples = [sample(100, hours: 0), sample(90, hours: 1)]
+        let tte = BatteryTTE.timeToEmpty(samples, now: t0.addingTimeInterval(1 * 3_600))
+        XCTAssertNotNil(tte)
+        // Expected: 90 % / 10 %/hr × 3600 = 32 400 s (9 h)
+        XCTAssertEqual(tte!, 32_400, accuracy: 1)
+    }
+
+    func testNilOnRisingTrend() {
+        // Strictly rising = charging → nil
+        let samples = [sample(80, hours: 0), sample(85, hours: 1), sample(90, hours: 2)]
+        XCTAssertNil(BatteryTTE.timeToEmpty(samples))
+    }
+
+    func testNilOnFewerThanTwoSamples() {
+        XCTAssertNil(BatteryTTE.timeToEmpty([]))
+        XCTAssertNil(BatteryTTE.timeToEmpty([sample(80, hours: 0)]))
+    }
+
+    func testNilOnImplausibleRate() {
+        // 60 % drop in 1 hour → 60 %/hr > 50 %/hr threshold → nil
+        let samples = [sample(80, hours: 0), sample(20, hours: 1)]
+        XCTAssertNil(BatteryTTE.timeToEmpty(samples))
+    }
+
+    func testNilOnSmallDrop() {
+        // 1 % drop — below the noise floor (< 2 pp)
+        let samples = [sample(80, hours: 0), sample(79, hours: 1)]
+        XCTAssertNil(BatteryTTE.timeToEmpty(samples))
+    }
+
+    func testRisingThenFallingResetsWindow() {
+        // [70, 80, 75]: rises then falls. The window after the rise-reset is [80, 75].
+        // Drop = 5 pp, elapsed = 1 h → rate = 5 %/hr → TTE = 75/5 × 3600 = 54 000 s
+        let samples = [sample(70, hours: 0), sample(80, hours: 1), sample(75, hours: 2)]
+        let tte = BatteryTTE.timeToEmpty(samples)
+        XCTAssertNotNil(tte)
+        XCTAssertEqual(tte!, 54_000, accuracy: 1)
+    }
+
+    func testFlatSamplesSkipped() {
+        // [90, 90, 88]: flat then drop of 2 pp. The flat sample doesn't break the window,
+        // but the effective discharging window is [90@t0, 88@t2].
+        // Actually in the algorithm, flat is skipped so window = [90@t0, 88@t2]:
+        // drop=2, elapsed=2h → rate=1%/hr → TTE = 88/1 × 3600 = 316 800 s
+        let samples = [sample(90, hours: 0), sample(90, hours: 1), sample(88, hours: 2)]
+        let tte = BatteryTTE.timeToEmpty(samples)
+        XCTAssertNotNil(tte)
+    }
+
+    // MARK: - estimatedDepletionDate
+
+    func testEstimatedDepletionDate() {
+        let samples = [sample(100, hours: 0), sample(90, hours: 1)]
+        let now = t0.addingTimeInterval(1 * 3_600)  // now = end of last sample
+        let depletion = BatteryTTE.estimatedDepletionDate(samples, now: now)
+        XCTAssertNotNil(depletion)
+        // TTE = 9 h → depletion at now + 9 h
+        XCTAssertEqual(depletion!.timeIntervalSince(now), 9 * 3_600, accuracy: 1)
+    }
+
+    func testEstimatedDepletionNilWhenNoTTE() {
+        XCTAssertNil(BatteryTTE.estimatedDepletionDate([]))
+    }
+
+    // MARK: - justReachedFull
+
+    func testJustReachedFullFires() {
+        XCTAssertTrue(BatteryTTE.justReachedFull(percent: 100, inferredCharging: true, wasFull: false))
+    }
+
+    func testJustReachedFullDoesNotFireIfAlreadyFull() {
+        XCTAssertFalse(BatteryTTE.justReachedFull(percent: 100, inferredCharging: true, wasFull: true))
+    }
+
+    func testJustReachedFullDoesNotFireIfNotCharging() {
+        XCTAssertFalse(BatteryTTE.justReachedFull(percent: 100, inferredCharging: false, wasFull: false))
+    }
+
+    func testJustReachedFullDoesNotFireBelow100() {
+        XCTAssertFalse(BatteryTTE.justReachedFull(percent: 99, inferredCharging: true, wasFull: false))
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
@@ -173,4 +173,29 @@ final class BulkSleepTests: XCTestCase {
         // Stream split drops a trailing partial chunk.
         XCTAssertEqual(BulkSleep.records(fromStream: hex(deepSleepRec) + [0xff, 0xff]).count, 1)
     }
+
+    // MARK: #39 — desaturations keep their vitals (layout no longer gated on the SpO2 value)
+
+    /// A genuine desaturation epoch (deepSleepRec with SpO2 byte 0x62→0x50 = 80 %, below the
+    /// old 87…99 gate). It must still decode as sleep-vitals so HR/HRV/SpO2 survive — the old
+    /// gate dropped the WHOLE epoch. The HR/HRV bytes are unchanged from the proven fixture.
+    func testLowSpO2EpochKeepsVitals() {
+        let r = BulkRecord(hex("0c22d5bf444d057a500a01010101012aa0000090000004"))!
+        XCTAssertEqual(r.layout, .sleepVitals)
+        XCTAssertEqual(r.heartRate, 68)
+        XCTAssertEqual(r.hrvRMSSD, 77)
+        XCTAssertEqual(r.spo2Percent, 80, "80 % is a plausible desaturation (≥70) — emitted")
+        let kinds = Set(BulkSleep.samples(from: [r]).map(\.kind))
+        XCTAssertTrue(kinds.isSuperset(of: [.heartRate, .hrvSDNN, .spo2]), "all vitals emitted")
+    }
+
+    /// An implausible SpO2 (< 70) is range-guarded out of the emitted sample, but the epoch
+    /// stays sleep-vitals so its HR/HRV are not lost with it (SpO2 byte 0x62→0x30 = 48 %).
+    func testImplausibleSpO2GuardedButHRKept() {
+        let r = BulkRecord(hex("0c22d5bf444d057a300a01010101012aa0000090000004"))!
+        XCTAssertEqual(r.layout, .sleepVitals)
+        XCTAssertNil(r.spo2Percent, "48 % is implausible → dropped")
+        XCTAssertEqual(r.heartRate, 68, "but HR survives")
+        XCTAssertEqual(r.hrvRMSSD, 77)
+    }
 }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
@@ -198,4 +198,54 @@ final class BulkSleepTests: XCTestCase {
         XCTAssertEqual(r.heartRate, 68, "but HR survives")
         XCTAssertEqual(r.hrvRMSSD, 77)
     }
+
+    // MARK: #41 — wear gate WIRED through BulkSleep.sleepSegments / mainSleep
+    //
+    // SleepDetection's temperature path is covered in SleepDetectionTests; these assert the
+    // `temperatures:` overload that RingSession actually calls threads that gate end-to-end, so
+    // a charging/off-wrist still night doesn't get committed (to the dashboard or Apple Health)
+    // as a night of sleep.
+
+    /// A synthetic night: 20 active epochs, ~9 h still (216 epochs), 20 active. One temperature
+    /// sample per epoch at `celsius`, spanning the records' real time range.
+    private func night() -> [BulkRecord] {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<20 { recs.append(rec(c, motion: 0x14, sub: 0x12)); c += 150 }
+        for _ in 0..<216 { recs.append(rec(c, motion: 0x01, sub: 0x62)); c += 150 }
+        for _ in 0..<20 { recs.append(rec(c, motion: 0x14, sub: 0x12)); c += 150 }
+        return recs
+    }
+    private func temps(for recs: [BulkRecord], celsius: Double) -> [TemperatureSample] {
+        recs.map { TemperatureSample(time: $0.date(), celsius: celsius) }
+    }
+
+    func testSleepSegmentsWearGateDropsColdNight() {
+        let recs = night()
+        // Motion-only (status quo): the still block reads as a night of sleep.
+        XCTAssertTrue(BulkSleep.sleepSegments(from: recs).contains { $0.stage == .inBed },
+                      "motion-only: still block reads as sleep")
+        // Worn (32 °C): still a night of sleep.
+        XCTAssertTrue(BulkSleep.sleepSegments(from: recs, temperatures: temps(for: recs, celsius: 32))
+                        .contains { $0.stage == .inBed },
+                      "worn temps keep the night")
+        // Cold (22 °C, off-wrist / charging): no sleep night survives the gate.
+        XCTAssertTrue(BulkSleep.sleepSegments(from: recs, temperatures: temps(for: recs, celsius: 22)).isEmpty,
+                      "cold (unworn) still block must not produce a sleep night")
+    }
+
+    func testMainSleepWearGateDropsColdNight() {
+        let recs = night()
+        XCTAssertNotNil(BulkSleep.mainSleep(from: recs, temperatures: temps(for: recs, celsius: 32)),
+                        "worn night has a main sleep block")
+        XCTAssertNil(BulkSleep.mainSleep(from: recs, temperatures: temps(for: recs, celsius: 22)),
+                     "cold night yields no main sleep block")
+    }
+
+    func testSleepSegmentsEmptyTemperaturesUnchanged() {
+        let recs = night()
+        XCTAssertEqual(BulkSleep.sleepSegments(from: recs, temperatures: []).count,
+                       BulkSleep.sleepSegments(from: recs).count,
+                       "no temp coverage ⇒ identical to motion-only (absence ≠ unworn)")
+    }
 }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
@@ -120,6 +120,42 @@ final class BulkSleepTests: XCTestCase {
                        Double(Int(wake) + Command.syncEpoch), accuracy: 20 * 60)
     }
 
+    /// Synthetic record with explicit HR (sleep-vitals layout).
+    func rec(_ counter: UInt32, motion: UInt8, sub: UInt8, hr: UInt8) -> BulkRecord {
+        let r = rec(counter, motion: motion, sub: sub)
+        var b = r.raw; b[4] = hr
+        return BulkRecord(b)!
+    }
+
+    func testStagingSeparatesDeepRemLight() {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<20 { recs.append(rec(c, motion: 0x14, sub: 0x12)); c += 150 }   // awake
+        // still block: 60 high-HR (REM), 60 low-HR (Deep), 60 mid-HR (Light)
+        for _ in 0..<60 { recs.append(rec(c, motion: 0x01, sub: 0x62, hr: 72)); c += 150 }
+        for _ in 0..<60 { recs.append(rec(c, motion: 0x01, sub: 0x62, hr: 50)); c += 150 }
+        for _ in 0..<60 { recs.append(rec(c, motion: 0x01, sub: 0x62, hr: 60)); c += 150 }
+        for _ in 0..<20 { recs.append(rec(c, motion: 0x14, sub: 0x12)); c += 150 }   // awake
+
+        let segs = BulkSleep.stagedSegments(from: recs)
+        let stages = Set(segs.map(\.stage))
+        XCTAssertTrue(stages.contains(.inBed))
+        XCTAssertTrue(stages.contains(.asleepDeep), "low-HR region -> deep")
+        XCTAssertTrue(stages.contains(.asleepREM), "high-HR region -> REM")
+        XCTAssertTrue(stages.contains(.asleepCore), "mid-HR region -> light/core")
+        // Deep segment should fall in the low-HR (middle) third of the night.
+        let deep = segs.filter { $0.stage == .asleepDeep }.max(by: { $0.duration < $1.duration })!
+        let remSeg = segs.filter { $0.stage == .asleepREM }.max(by: { $0.duration < $1.duration })!
+        XCTAssertLessThan(remSeg.start, deep.start, "REM region (HR 72) precedes Deep region (HR 50) as constructed")
+    }
+
+    func testStagingEmptyWithoutSleep() {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<50 { recs.append(rec(c, motion: 0x18, sub: 0x12, hr: 70)); c += 150 }
+        XCTAssertTrue(BulkSleep.stagedSegments(from: recs).isEmpty, "no sleep block -> no staging")
+    }
+
     func testNoSleepWhenAllActive() {
         var recs: [BulkRecord] = []
         var c: UInt32 = 0x0c220000

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
@@ -68,11 +68,12 @@ final class BulkSleepTests: XCTestCase {
     func testSamplesFromSleepVitals() {
         let r = BulkRecord(hex(deepSleepRec))!
         let s = BulkSleep.samples(from: [r])
-        XCTAssertEqual(s.count, 3, "HR + HRV + SpO2")
+        XCTAssertEqual(s.count, 4, "HR + HRV + SpO2 + respiratory rate")
         let byKind = Dictionary(grouping: s, by: { $0.kind })
         XCTAssertEqual(byKind[.heartRate]?.first?.value, 68)
         XCTAssertEqual(byKind[.hrvSDNN]?.first?.value, 77)
         XCTAssertEqual(byKind[.spo2]?.first?.value, 0.98, "SpO2 emitted as 0…1 fraction")
+        XCTAssertEqual(byKind[.respiratoryRate]?.first?.value, 15.25, "RR = byte[7] 0x7a / 8 (🟢)")
         XCTAssertEqual(s.first?.start,
                        Date(timeIntervalSince1970: TimeInterval(Int(0x0c22d5bf) + Command.syncEpoch)))
     }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
@@ -77,6 +77,57 @@ final class BulkSleepTests: XCTestCase {
                        Date(timeIntervalSince1970: TimeInterval(Int(0x0c22d5bf) + Command.syncEpoch)))
     }
 
+    /// Build a synthetic 23-byte record: counter, motion byte (×5), subtype [8].
+    func rec(_ counter: UInt32, motion: UInt8, sub: UInt8) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: 23)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xFF)
+        b[2] = UInt8((counter >> 8) & 0xFF); b[3] = UInt8(counter & 0xFF)
+        b[8] = sub
+        for k in 0..<5 { b[10 + k] = motion }
+        return BulkRecord(b)!
+    }
+
+    func testMotionTimelineExpansion() {
+        let r = BulkRecord(hex(deepSleepRec))!
+        let tl = BulkSleep.motionTimeline(from: [r])
+        XCTAssertEqual(tl.count, 5, "5 sub-samples per 150 s epoch")
+        XCTAssertEqual(tl[1].time.timeIntervalSince(tl[0].time), 30, "30 s spacing")
+        XCTAssertEqual(tl[0].movement, 1, "motion baseline 01 = still")
+    }
+
+    func testSleepDetectionFindsNight() {
+        // 20 active epochs, then ~9 h still (216 epochs @150 s), then 20 active.
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<20 { recs.append(rec(c, motion: 0x14, sub: 0x12)); c += 150 }
+        let onset = c
+        for _ in 0..<216 { recs.append(rec(c, motion: 0x01, sub: 0x62)); c += 150 }
+        let wake = c
+        for _ in 0..<20 { recs.append(rec(c, motion: 0x14, sub: 0x12)); c += 150 }
+
+        let block = BulkSleep.mainSleep(from: recs)
+        XCTAssertNotNil(block)
+        XCTAssertEqual(block?.activity, .sleep)
+        // ~9 h block, boundaries near onset/wake (within the 15-min merge window).
+        XCTAssertEqual(block!.duration, 216 * 150, accuracy: 30 * 60)
+        let segs = BulkSleep.sleepSegments(from: recs)
+        XCTAssertTrue(segs.contains { $0.stage == .inBed }, "emits an inBed span")
+        XCTAssertTrue(segs.contains { $0.stage == .asleepCore }, "emits asleep core")
+        let inBed = segs.first { $0.stage == .inBed }!
+        XCTAssertEqual(inBed.start.timeIntervalSince1970,
+                       Double(Int(onset) + Command.syncEpoch), accuracy: 20 * 60)
+        XCTAssertEqual(inBed.end.timeIntervalSince1970,
+                       Double(Int(wake) + Command.syncEpoch), accuracy: 20 * 60)
+    }
+
+    func testNoSleepWhenAllActive() {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<100 { recs.append(rec(c, motion: 0x18, sub: 0x12)); c += 150 }
+        XCTAssertNil(BulkSleep.mainSleep(from: recs))
+        XCTAssertTrue(BulkSleep.sleepSegments(from: recs).isEmpty)
+    }
+
     func testIdleAndStreamSplit() {
         // Idle template record: motion 01×5 + zero payload -> .idle, no samples.
         let idle = BulkRecord(hex("0c099dbf05000c00120a01010101010000000000000000"))!

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/BulkSleepTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import OpenRingKit
+
+// Fixtures are REAL 0x4c frames/records pulled from the 2026-06-13 overnight sync
+// (desktop/captures/sleep_sync_btsnoop.log, FR02.018), decoded and aligned to the
+// RingConn app's readout for that night. They mirror desktop/decode_bulk.py so the
+// Swift port is provably byte-identical.
+final class BulkSleepTests: XCTestCase {
+
+    func hex(_ s: String) -> [UInt8] {
+        var out = [UInt8](); var i = s.startIndex
+        while i < s.endIndex {
+            let j = s.index(i, offsetBy: 2)
+            out.append(UInt8(s[i..<j], radix: 16)!); i = j
+        }
+        return out
+    }
+
+    // A real, XOR-valid 0x4c page: header 4c 00 26, then 6 × 23-byte records, then XOR.
+    let realPage = "4c00260c22a16b55210a7d120a010101010100000402400400000c22a20155000300"
+        + "120a010101010100003c00000d01200c22a297540001005f0a010101010100001101b00f"
+        + "00440c22a32d6027077b120a010101010100402501c02235a00c22a3c351260577120b01"
+        + "0101010108a01000000401300c22a459502d0378120a01010101010160200000040ff0cc"
+
+    // A single hand-verified deep-sleep record (counter 0c22d5bf): HR 68, HRV 77, SpO2 98.
+    let deepSleepRec = "0c22d5bf444d057a620a01010101012aa0000090000004"
+
+    func testPageSplitsIntoSixRecords() {
+        let recs = BulkSleep.records(fromPage: hex(realPage))
+        XCTAssertEqual(recs.count, 6, "page body is 138 B = 6 × 23-byte records")
+    }
+
+    func testInvalidPageRejected() {
+        var bad = hex(realPage); bad[bad.count - 1] ^= 0xFF   // break XOR trailer
+        XCTAssertTrue(BulkSleep.records(fromPage: bad).isEmpty, "bad XOR -> no records")
+        XCTAssertTrue(BulkSleep.records(fromPage: hex("8100b031")).isEmpty, "wrong opcode -> none")
+    }
+
+    func testSleepVitalsRecordDecode() {
+        // Deep-sleep epoch confirmed against the app: HR 68 / HRV 77 / SpO2 98.
+        let r = BulkRecord(hex(deepSleepRec))!
+        XCTAssertEqual(r.layout, .sleepVitals)
+        XCTAssertEqual(r.counter, 0x0c22d5bf)
+        XCTAssertEqual(r.heartRate, 68)
+        XCTAssertEqual(r.hrvRMSSD, 77)
+        XCTAssertEqual(r.spo2Percent, 98)
+        XCTAssertEqual(r.motion, [1, 1, 1, 1, 1])
+    }
+
+    func testCounterToWallClock() {
+        // counter = seconds since syncEpoch (PROTOCOL.md §5.6).
+        let r = BulkRecord(hex(deepSleepRec))!
+        XCTAssertEqual(r.date(),
+                       Date(timeIntervalSince1970: TimeInterval(Int(0x0c22d5bf) + Command.syncEpoch)))
+    }
+
+    func testActivityVsSleepLayout() {
+        let recs = BulkSleep.records(fromPage: hex(realPage))
+        // Records [0],[1] are activity epochs ([8]=0x12); record [2] is sleep-vitals ([8]=0x5f).
+        XCTAssertEqual(recs[0].layout, .activity)
+        XCTAssertEqual(recs[2].layout, .sleepVitals)
+        XCTAssertEqual(recs[2].spo2Percent, 0x5f)        // 95 %
+        XCTAssertEqual(recs[2].heartRate, 0x54)          // 84 bpm (waking/active in-bed)
+        XCTAssertNil(recs[2].hrvRMSSD, "HRV byte is 0 here -> no sample")
+        XCTAssertNil(recs[0].heartRate, "activity epoch exposes no HR field")
+    }
+
+    func testSamplesFromSleepVitals() {
+        let r = BulkRecord(hex(deepSleepRec))!
+        let s = BulkSleep.samples(from: [r])
+        XCTAssertEqual(s.count, 3, "HR + HRV + SpO2")
+        let byKind = Dictionary(grouping: s, by: { $0.kind })
+        XCTAssertEqual(byKind[.heartRate]?.first?.value, 68)
+        XCTAssertEqual(byKind[.hrvSDNN]?.first?.value, 77)
+        XCTAssertEqual(byKind[.spo2]?.first?.value, 0.98, "SpO2 emitted as 0…1 fraction")
+        XCTAssertEqual(s.first?.start,
+                       Date(timeIntervalSince1970: TimeInterval(Int(0x0c22d5bf) + Command.syncEpoch)))
+    }
+
+    func testIdleAndStreamSplit() {
+        // Idle template record: motion 01×5 + zero payload -> .idle, no samples.
+        let idle = BulkRecord(hex("0c099dbf05000c00120a01010101010000000000000000"))!
+        XCTAssertEqual(idle.layout, .idle)
+        XCTAssertTrue(BulkSleep.samples(from: [idle]).isEmpty)
+        // Stream split drops a trailing partial chunk.
+        XCTAssertEqual(BulkSleep.records(fromStream: hex(deepSleepRec) + [0xff, 0xff]).count, 1)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/ChargingInferenceTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/ChargingInferenceTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import OpenRingKit
+
+// Charging inference from battery % trend (#60): fires only on a strictly rising
+// sequence of ≥ 2 readings; any flat, falling, or mixed pattern returns false.
+final class ChargingInferenceTests: XCTestCase {
+
+    // MARK: Degenerate inputs
+
+    func testEmptyTrendReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: []))
+    }
+
+    func testSingleReadingReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [75]))
+    }
+
+    // MARK: Rising (charging)
+
+    func testTwoRisingReadingsReturnsTrue() {
+        XCTAssertTrue(ChargingInference.inferred(from: [74, 76]))
+    }
+
+    func testThreeRisingReadingsReturnsTrue() {
+        XCTAssertTrue(ChargingInference.inferred(from: [74, 76, 78]))
+    }
+
+    func testFourRisingReadingsReturnsTrue() {
+        XCTAssertTrue(ChargingInference.inferred(from: [60, 65, 70, 75]))
+    }
+
+    func testRisingByOneReturnsTrueEachPair() {
+        // Single-unit increments still count as rising.
+        XCTAssertTrue(ChargingInference.inferred(from: [80, 81, 82]))
+    }
+
+    // MARK: Non-rising (not charging)
+
+    func testFlatTwoReadingsReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [75, 75]))
+    }
+
+    func testFlatThreeReadingsReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [75, 75, 75]))
+    }
+
+    func testFallingTwoReadingsReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [80, 78]))
+    }
+
+    func testFallingThreeReadingsReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [80, 78, 76]))
+    }
+
+    // MARK: Mixed (one pair not rising → whole sequence fails)
+
+    func testMixedRisingThenFlatReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [74, 76, 76]))
+    }
+
+    func testMixedRisingThenFallingReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [74, 76, 75]))
+    }
+
+    func testMixedFlatThenRisingReturnsFalse() {
+        XCTAssertFalse(ChargingInference.inferred(from: [74, 74, 76]))
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/CumulativeMetricAccumulatorTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/CumulativeMetricAccumulatorTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import OpenRingKit
+
+final class CumulativeMetricAccumulatorTests: XCTestCase {
+    private let t0 = Date(timeIntervalSince1970: 1_000)
+    private let t1 = Date(timeIntervalSince1970: 2_000)
+    private let t2 = Date(timeIntervalSince1970: 3_000)
+
+    func testNormalDeltaAccumulationProducesRunningTotal() {
+        let first = CumulativeMetricAccumulator.accumulate(
+            QuantitySample(kind: .steps, start: t0, value: 100),
+            state: CumulativeMetricState()
+        )
+        let second = CumulativeMetricAccumulator.accumulate(
+            QuantitySample(kind: .steps, start: t1, value: 140),
+            state: CumulativeMetricState(previousRawValue: first.rawValue, dailyTotal: first.dailyTotal)
+        )
+
+        XCTAssertEqual(first.deltaValue, 100)
+        XCTAssertEqual(first.dailyTotal, 100)
+        XCTAssertEqual(second.deltaValue, 40)
+        XCTAssertEqual(second.dailyTotal, 140)
+        XCTAssertEqual(second.sample.value, 140)
+    }
+
+    func testCounterRolloverTreatsRawValueAsDelta() {
+        let result = CumulativeMetricAccumulator.accumulate(
+            QuantitySample(kind: .steps, start: t1, value: 12),
+            state: CumulativeMetricState(previousRawValue: 250, dailyTotal: 250)
+        )
+
+        XCTAssertEqual(result.deltaValue, 12)
+        XCTAssertEqual(result.dailyTotal, 262)
+        XCTAssertEqual(result.sample.value, 262)
+    }
+
+    func testMultiSessionAccumulationContinuesFromPersistedState() {
+        let sessionOne = CumulativeMetricAccumulator.accumulate(
+            QuantitySample(kind: .steps, start: t0, value: 75),
+            state: CumulativeMetricState()
+        )
+        let persistedState = CumulativeMetricState(
+            previousRawValue: sessionOne.rawValue,
+            dailyTotal: sessionOne.dailyTotal
+        )
+        let sessionTwoFirst = CumulativeMetricAccumulator.accumulate(
+            QuantitySample(kind: .steps, start: t1, value: 90),
+            state: persistedState
+        )
+        let sessionTwoSecond = CumulativeMetricAccumulator.accumulate(
+            QuantitySample(kind: .steps, start: t2, value: 125),
+            state: CumulativeMetricState(
+                previousRawValue: sessionTwoFirst.rawValue,
+                dailyTotal: sessionTwoFirst.dailyTotal
+            )
+        )
+
+        XCTAssertEqual(sessionTwoFirst.deltaValue, 15)
+        XCTAssertEqual(sessionTwoFirst.dailyTotal, 90)
+        XCTAssertEqual(sessionTwoSecond.deltaValue, 35)
+        XCTAssertEqual(sessionTwoSecond.dailyTotal, 125)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/CyclePredictorTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/CyclePredictorTests.swift
@@ -166,6 +166,33 @@ final class CyclePredictorTests: XCTestCase {
         XCTAssertEqual(durDays, 5, accuracy: 0.01)
     }
 
+    func testPredict_RollsForwardWhenLoggingWentStale() {
+        // User logged two cycles long ago then stopped (last period 90 days ago, 28-day cycle).
+        // The naive next-period (last + 28d) is in the PAST; predict() must roll it forward so
+        // the "next" period and its ovulation/fertile window are all in the FUTURE.
+        let now = cal.startOfDay(for: Date())
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(118))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(90))
+        let pred = CyclePredictor.predict(from: [p1, p2], now: now)!
+
+        XCTAssertGreaterThan(pred.nextPeriodStart, now, "next period must be in the future")
+        XCTAssertGreaterThan(pred.ovulationEstimate, now, "ovulation must be in the future")
+        XCTAssertGreaterThan(pred.fertileWindowStart, now, "fertile window must be in the future")
+        // It must be the FIRST future occurrence: rolling back one whole cycle lands at/before now.
+        let oneCycle = pred.avgCycleLengthDays * 86_400
+        XCTAssertLessThan(pred.nextPeriodStart.addingTimeInterval(-oneCycle), now,
+                          "must not over-roll past the first future cycle")
+    }
+
+    func testPredict_DoesNotRollForwardWhenAlreadyFuture() {
+        // Last period today → naive next (today + 28d) is already future → no roll-forward.
+        let now = cal.startOfDay(for: Date())
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred = CyclePredictor.predict(from: [p1, p2], now: now)!
+        XCTAssertEqual(cal.startOfDay(for: pred.nextPeriodStart), daysFromNow(28))
+    }
+
     func testPredict_UsesLoggedPeriodDuration() {
         let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28), end: daysAgo(24))  // 4 days
         let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/CyclePredictorTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/CyclePredictorTests.swift
@@ -1,0 +1,283 @@
+// Tests/OpenRingKitTests/CyclePredictorTests.swift — SYNTHETIC-ONLY tests for
+// cycle prediction (#78). No real health values; controlled inputs with
+// known expected outputs.
+
+import XCTest
+@testable import OpenRingKit
+
+final class CyclePredictorTests: XCTestCase {
+
+    // MARK: Helpers
+
+    private let cal = Calendar.current
+
+    private func daysAgo(_ n: Int) -> Date {
+        cal.date(byAdding: .day, value: -n, to: cal.startOfDay(for: Date()))!
+    }
+
+    private func daysFromNow(_ n: Int) -> Date {
+        cal.date(byAdding: .day, value: n, to: cal.startOfDay(for: Date()))!
+    }
+
+    private func period(startDaysAgo: Int,
+                        endDaysAgo: Int? = nil) -> CyclePredictor.PeriodEntry {
+        CyclePredictor.PeriodEntry(
+            start: daysAgo(startDaysAgo),
+            end: endDaysAgo.map { daysAgo($0) }
+        )
+    }
+
+    // MARK: cycleStats — minimum history guard
+
+    func testCycleStatsNilWhenEmpty() {
+        XCTAssertNil(CyclePredictor.cycleStats(from: []))
+    }
+
+    func testCycleStatsNilWhenOnePeriod() {
+        XCTAssertNil(CyclePredictor.cycleStats(from: [period(startDaysAgo: 30)]))
+    }
+
+    // MARK: cycleStats — interval math
+
+    func testCycleStats_SingleInterval_28Days() {
+        let periods = [period(startDaysAgo: 28), period(startDaysAgo: 0)]
+        let stats = CyclePredictor.cycleStats(from: periods)
+        XCTAssertNotNil(stats)
+        XCTAssertEqual(stats!.avgCycleLengthDays, 28, accuracy: 0.01)
+        XCTAssertEqual(stats!.sampleCount, 1)
+    }
+
+    func testCycleStats_MultipleIntervals_Average() {
+        // 56 days ago, 28 days ago, today → two 28-day cycles
+        let periods = [
+            period(startDaysAgo: 56),
+            period(startDaysAgo: 28),
+            period(startDaysAgo: 0),
+        ]
+        let stats = CyclePredictor.cycleStats(from: periods)!
+        XCTAssertEqual(stats.avgCycleLengthDays, 28, accuracy: 0.1)
+        XCTAssertEqual(stats.sampleCount, 2)
+    }
+
+    func testCycleStats_UnequalIntervals_TrueAverage() {
+        // 56 + 28 → intervals: 28, 28; but vary: 62 + 28 → intervals 34, 28 → avg 31
+        let periods = [
+            period(startDaysAgo: 62),
+            period(startDaysAgo: 28),
+            period(startDaysAgo: 0),
+        ]
+        let stats = CyclePredictor.cycleStats(from: periods)!
+        XCTAssertEqual(stats.avgCycleLengthDays, 31, accuracy: 0.1)
+    }
+
+    // MARK: cycleStats — out-of-range interval exclusion
+
+    func testCycleStats_TooShortInterval_Excluded() {
+        // 15 days → below minCycleLengthDays (21) → no valid interval → nil
+        let periods = [period(startDaysAgo: 15), period(startDaysAgo: 0)]
+        XCTAssertNil(CyclePredictor.cycleStats(from: periods))
+    }
+
+    func testCycleStats_TooLongInterval_Excluded() {
+        // 50 days → above maxCycleLengthDays (45) → excluded → nil
+        let periods = [period(startDaysAgo: 50), period(startDaysAgo: 0)]
+        XCTAssertNil(CyclePredictor.cycleStats(from: periods))
+    }
+
+    func testCycleStats_MixedValidity_OnlyValidIncluded() {
+        // Three periods: interval 1 = 15 days (invalid), interval 2 = 28 days (valid)
+        let periods = [
+            period(startDaysAgo: 43),
+            period(startDaysAgo: 28),  // 15 days after prev — invalid
+            period(startDaysAgo: 0),   // 28 days after prev — valid
+        ]
+        let stats = CyclePredictor.cycleStats(from: periods)!
+        XCTAssertEqual(stats.avgCycleLengthDays, 28, accuracy: 0.1)
+        XCTAssertEqual(stats.sampleCount, 1)
+    }
+
+    // MARK: cycleStats — period duration
+
+    func testCycleStats_AvgDurationFromCompletedPeriods() {
+        // One completed period (5 days), one ongoing
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(30), end: daysAgo(25))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let stats = CyclePredictor.cycleStats(from: [p1, p2])!
+        XCTAssertNotNil(stats.avgPeriodDurationDays)
+        XCTAssertEqual(stats.avgPeriodDurationDays!, 5, accuracy: 0.1)
+    }
+
+    func testCycleStats_NilDurationWhenNoneCompleted() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let stats = CyclePredictor.cycleStats(from: [p1, p2])!
+        XCTAssertNil(stats.avgPeriodDurationDays)
+    }
+
+    // MARK: predict — nil guard
+
+    func testPredictNilBelowMinimum() {
+        XCTAssertNil(CyclePredictor.predict(from: [period(startDaysAgo: 30)]))
+        XCTAssertNil(CyclePredictor.predict(from: []))
+    }
+
+    // MARK: predict — date math
+
+    func testPredict_28DayCycle_NextPeriodDate() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred = CyclePredictor.predict(from: [p1, p2])!
+
+        // Next period ≈ 28 days from now (from start-of-today)
+        let expected = daysFromNow(28)
+        XCTAssertEqual(cal.startOfDay(for: pred.nextPeriodStart), expected)
+        XCTAssertEqual(pred.avgCycleLengthDays, 28, accuracy: 0.01)
+    }
+
+    func testPredict_OvulationIs14DaysBeforeNextPeriod() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred = CyclePredictor.predict(from: [p1, p2])!
+
+        let expectedOvulation = cal.startOfDay(for: pred.nextPeriodStart)
+            .addingTimeInterval(-Double(CyclePredictor.lutealPhaseDays) * 86_400)
+        XCTAssertEqual(cal.startOfDay(for: pred.ovulationEstimate), expectedOvulation)
+        XCTAssertEqual(cal.startOfDay(for: pred.fertileWindowEnd), expectedOvulation,
+                       "fertileWindowEnd == ovulation day")
+    }
+
+    func testPredict_FertileWindowStartIs5DaysBeforeOvulation() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred = CyclePredictor.predict(from: [p1, p2])!
+
+        let expectedStart = cal.startOfDay(for: pred.ovulationEstimate)
+            .addingTimeInterval(-Double(CyclePredictor.fertileWindowDaysBeforeOvulation) * 86_400)
+        XCTAssertEqual(cal.startOfDay(for: pred.fertileWindowStart), expectedStart)
+    }
+
+    func testPredict_DefaultPeriodDuration_5Days() {
+        // No completed periods → default 5-day duration
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred = CyclePredictor.predict(from: [p1, p2])!
+
+        let durDays = pred.nextPeriodEnd.timeIntervalSince(pred.nextPeriodStart) / 86_400
+        XCTAssertEqual(durDays, 5, accuracy: 0.01)
+    }
+
+    func testPredict_UsesLoggedPeriodDuration() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28), end: daysAgo(24))  // 4 days
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred = CyclePredictor.predict(from: [p1, p2])!
+
+        let durDays = pred.nextPeriodEnd.timeIntervalSince(pred.nextPeriodStart) / 86_400
+        XCTAssertEqual(durDays, 4, accuracy: 0.1)
+    }
+
+    // MARK: predict — skin-temp corroboration
+
+    func testTempCorroborated_WithSufficientRise() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred0 = CyclePredictor.predict(from: [p1, p2])!
+
+        // Place two rising nights within ±3 days of the predicted ovulation
+        let ov = pred0.ovulationEstimate
+        let deviations: [(night: Date, offsetC: Double)] = [
+            (night: ov.addingTimeInterval(-1 * 86_400), offsetC: 0.3),
+            (night: ov.addingTimeInterval( 1 * 86_400), offsetC: 0.4),
+        ]
+        let pred = CyclePredictor.predict(from: [p1, p2], skinTempDeviations: deviations)!
+        XCTAssertTrue(pred.tempCorroborated)
+    }
+
+    func testTempNotCorroborated_OnlyOneRisingNight() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred0 = CyclePredictor.predict(from: [p1, p2])!
+
+        let ov = pred0.ovulationEstimate
+        let deviations: [(night: Date, offsetC: Double)] = [
+            (night: ov, offsetC: 0.5),           // only one night
+        ]
+        let pred = CyclePredictor.predict(from: [p1, p2], skinTempDeviations: deviations)!
+        XCTAssertFalse(pred.tempCorroborated, "need ≥ 2 nights to corroborate")
+    }
+
+    func testTempNotCorroborated_RiseBelowThreshold() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred0 = CyclePredictor.predict(from: [p1, p2])!
+
+        let ov = pred0.ovulationEstimate
+        // Offsets present but below threshold (0.2 °C)
+        let deviations: [(night: Date, offsetC: Double)] = [
+            (night: ov.addingTimeInterval(-86_400), offsetC: 0.1),
+            (night: ov, offsetC: 0.05),
+        ]
+        let pred = CyclePredictor.predict(from: [p1, p2], skinTempDeviations: deviations)!
+        XCTAssertFalse(pred.tempCorroborated)
+    }
+
+    func testTempNotCorroborated_RiseOutsideWindow() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred0 = CyclePredictor.predict(from: [p1, p2])!
+
+        let ov = pred0.ovulationEstimate
+        // Rising nights are 7 days away — outside the ±3-day window
+        let deviations: [(night: Date, offsetC: Double)] = [
+            (night: ov.addingTimeInterval(-7 * 86_400), offsetC: 0.5),
+            (night: ov.addingTimeInterval( 7 * 86_400), offsetC: 0.5),
+        ]
+        let pred = CyclePredictor.predict(from: [p1, p2], skinTempDeviations: deviations)!
+        XCTAssertFalse(pred.tempCorroborated)
+    }
+
+    // MARK: day-classification helpers
+
+    func testIsLoggedPeriodDay() {
+        let p = CyclePredictor.PeriodEntry(start: daysAgo(5), end: daysAgo(2))
+        XCTAssertTrue(CyclePredictor.isLoggedPeriodDay(daysAgo(5), entries: [p]))
+        XCTAssertTrue(CyclePredictor.isLoggedPeriodDay(daysAgo(3), entries: [p]))
+        XCTAssertTrue(CyclePredictor.isLoggedPeriodDay(daysAgo(2), entries: [p]))
+        XCTAssertFalse(CyclePredictor.isLoggedPeriodDay(daysAgo(1), entries: [p]))
+        XCTAssertFalse(CyclePredictor.isLoggedPeriodDay(daysAgo(6), entries: [p]))
+    }
+
+    func testIsLoggedPeriodDay_NoEnd_OnlyStartDay() {
+        let p = CyclePredictor.PeriodEntry(start: daysAgo(3))
+        XCTAssertTrue(CyclePredictor.isLoggedPeriodDay(daysAgo(3), entries: [p]))
+        XCTAssertFalse(CyclePredictor.isLoggedPeriodDay(daysAgo(2), entries: [p]))
+    }
+
+    func testIsInPredictedPeriod() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred = CyclePredictor.predict(from: [p1, p2])!
+
+        let duringPred = cal.startOfDay(for: pred.nextPeriodStart)
+        XCTAssertTrue(CyclePredictor.isInPredictedPeriod(duringPred, prediction: pred))
+        XCTAssertFalse(CyclePredictor.isInPredictedPeriod(daysAgo(100), prediction: pred))
+    }
+
+    func testIsInFertileWindow() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred = CyclePredictor.predict(from: [p1, p2])!
+
+        let duringFertile = pred.fertileWindowStart.addingTimeInterval(86_400)
+        XCTAssertTrue(CyclePredictor.isInFertileWindow(duringFertile, prediction: pred))
+        XCTAssertFalse(CyclePredictor.isInFertileWindow(daysAgo(100), prediction: pred))
+    }
+
+    func testIsOvulationDay() {
+        let p1 = CyclePredictor.PeriodEntry(start: daysAgo(28))
+        let p2 = CyclePredictor.PeriodEntry(start: daysAgo(0))
+        let pred = CyclePredictor.predict(from: [p1, p2])!
+
+        XCTAssertTrue(CyclePredictor.isOvulationDay(pred.ovulationEstimate, prediction: pred))
+        XCTAssertFalse(CyclePredictor.isOvulationDay(daysAgo(100), prediction: pred))
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/DistanceEstimateTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/DistanceEstimateTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import OpenRingKit
+
+final class DistanceEstimateTests: XCTestCase {
+
+    // MARK: Stride math
+
+    func testStrideMale() {
+        // 170 cm × 0.415 = 70.55 cm
+        XCTAssertEqual(DistanceEstimate.strideCm(heightCm: 170, sex: .male), 70.55, accuracy: 0.001)
+    }
+
+    func testStrideFemale() {
+        // 165 cm × 0.413 = 68.145 cm
+        XCTAssertEqual(DistanceEstimate.strideCm(heightCm: 165, sex: .female), 68.145, accuracy: 0.001)
+    }
+
+    func testStrideZeroHeight() {
+        XCTAssertEqual(DistanceEstimate.strideCm(heightCm: 0, sex: .male), 0, accuracy: 0.001)
+    }
+
+    // MARK: Distance in metres
+
+    func testDistanceMale170cm10000Steps() {
+        // 10000 × 70.55 cm / 100 = 7055 m
+        let m = DistanceEstimate.meters(steps: 10_000, heightCm: 170, sex: .male)
+        XCTAssertEqual(m, 7055.0, accuracy: 0.01)
+    }
+
+    func testDistanceFemale165cm8000Steps() {
+        // 8000 × 68.145 cm / 100 = 5451.6 m
+        let m = DistanceEstimate.meters(steps: 8_000, heightCm: 165, sex: .female)
+        XCTAssertEqual(m, 5451.6, accuracy: 0.01)
+    }
+
+    func testDistanceZeroSteps() {
+        XCTAssertEqual(DistanceEstimate.meters(steps: 0, heightCm: 170, sex: .male), 0)
+    }
+
+    func testDistanceNegativeStepsReturnsZero() {
+        XCTAssertEqual(DistanceEstimate.meters(steps: -100, heightCm: 170, sex: .male), 0)
+    }
+
+    // MARK: UserProfile overload
+
+    func testDistanceViaProfile() {
+        let profile = UserProfile(age: 30, weightKg: 70, heightCm: 180, sex: .male)
+        // 180 × 0.415 = 74.7 cm; 5000 × 74.7 / 100 = 3735 m
+        let m = DistanceEstimate.meters(steps: 5_000, profile: profile)
+        XCTAssertEqual(m, 3735.0, accuracy: 0.01)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/EpochSyncTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/EpochSyncTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import OpenRingKit
+
+final class EpochSyncTests: XCTestCase {
+    private func frame(opcode: UInt8, body: [UInt8]) -> Data {
+        let withoutTrailer = [opcode] + body
+        return Data(withoutTrailer + [Frame.xorTrailer(withoutTrailer)])
+    }
+
+    private func record(size: Int, counter: UInt32, fill: UInt8 = 0x01) -> [UInt8] {
+        var bytes = [EpochRecord.marker,
+                     UInt8((counter >> 16) & 0xFF),
+                     UInt8((counter >> 8) & 0xFF),
+                     UInt8(counter & 0xFF)]
+        bytes += Array(repeating: fill, count: size - bytes.count)
+        return bytes
+    }
+
+    func testParsesActivityPageTimestampSubtypeAndRawPayload() {
+        var rec = record(size: EpochRecord.activityRecordSize, counter: 0x223344, fill: 0x01)
+        rec[8] = 0x13
+        rec.replaceSubrange(15..<22, with: [1, 2, 3, 4, 5, 6, 7])
+        let bytes = frame(opcode: EpochRecord.activityOpcode, body: [0x00, 0x00] + rec)
+
+        let records = EpochRecord.parseActivityPage(bytes, streamHighByte: 0x0C)
+
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].subtype, 0x13)
+        XCTAssertEqual(records[0].rawPayload, Data([1, 2, 3, 4, 5, 6, 7]))
+        XCTAssertEqual(records[0].timestamp,
+                       Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x0c223344)))
+    }
+
+    func testParsesPPGPageTimestampAndRawPayload() {
+        var rec = record(size: EpochRecord.ppgRecordSize, counter: 0x000100, fill: 0x01)
+        rec.replaceSubrange(9..<47, with: Array(0..<38).map(UInt8.init))
+        let bytes = frame(opcode: EpochRecord.ppgOpcode, body: [0x00, 0x03] + rec)
+
+        let records = EpochRecord.parsePPGPage(bytes, streamHighByte: 0x02)
+
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].rawPayload, Data(Array(0..<38).map(UInt8.init)))
+        XCTAssertEqual(records[0].timestamp,
+                       Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x02000100)))
+        XCTAssertEqual(EpochRecord.remainingRecordCountdown(bytes), 0x03)
+    }
+
+    func testRejectsMalformedEpochPages() {
+        let wrongMarker = [UInt8](repeating: 0x01, count: EpochRecord.activityRecordSize)
+        let bytes = frame(opcode: EpochRecord.activityOpcode, body: [0x00, 0x00] + wrongMarker)
+
+        XCTAssertEqual(EpochRecord.parseActivityPage(bytes), [])
+        XCTAssertEqual(EpochRecord.parsePPGPage(Data([0x47, 0x00, 0x00])), [])
+    }
+
+    func testDecodesEndOfHistoryWithoutXorTrailer() {
+        let bytes = Data([
+            0x50, 0x00, 0x00, 0x12,
+            0x0c, 0x22, 0xaa, 0xe4,
+            0x0c, 0x22, 0xac, 0xb5,
+        ])
+
+        let report = EpochRecord.parseEndOfHistory(bytes)
+
+        XCTAssertEqual(report?.subtype, 0x12)
+        XCTAssertEqual(report?.cursorFrom, 0x0c22aae4)
+        XCTAssertEqual(report?.cursorTo, 0x0c22acb5)
+        XCTAssertEqual(report?.streamHighByte, 0x0c)
+    }
+
+    func testSessionReparsesBufferedPagesWhenEndFrameProvidesHighByte() {
+        var rec = record(size: EpochRecord.activityRecordSize, counter: 0x223344, fill: 0x00)
+        rec.replaceSubrange(15..<22, with: [1, 0, 0, 0, 0, 0, 0])
+        let page = frame(opcode: EpochRecord.activityOpcode, body: [0x00, 0x00] + rec)
+        let end = Data([
+            0x50, 0x00, 0x00, 0x12,
+            0x0c, 0x22, 0x33, 0x44,
+            0x0c, 0x22, 0x33, 0x44,
+        ])
+
+        var session = EpochSyncSession()
+        XCTAssertEqual(session.appendActivityPage(page).first?.timestamp,
+                       Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x00223344)))
+        XCTAssertNotNil(session.complete(with: end))
+
+        XCTAssertTrue(session.isComplete)
+        XCTAssertEqual(session.activityRecords.first?.timestamp,
+                       Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x0c223344)))
+        XCTAssertEqual(session.placeholderQuantitySamples(), [
+            QuantitySample(
+                kind: .heartRate,
+                start: Date(timeIntervalSince1970: TimeInterval(Command.syncEpoch + 0x0c223344)),
+                value: 0.0
+            )
+        ])
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/ExerciseMinutesTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/ExerciseMinutesTests.swift
@@ -37,16 +37,37 @@ final class ExerciseMinutesTests: XCTestCase {
 
     // MARK: Basic elevated estimate
 
-    func testSingleElevatedPointSampleGivesOneEpoch() {
-        // One point sample at threshold → 1 epoch (150s = 2.5 min)
+    func testSingleIsolatedPointSampleGivesNoFullEpoch() {
+        // One ISOLATED elevated point read (e.g. a single live-HR spot read) must NOT be
+        // credited a full 2.5-min epoch — a lone spot read isn't evidence of exercise (#82 fix).
         let s = HRSample(bpm: 100, start: t0, end: t0)
         let minutes = ExerciseMinutes.estimate(hrSamples: [s], maxHR: 180,
                                                epochSeconds: 150)
-        XCTAssertEqual(minutes, 2.5, accuracy: 0.01)
+        XCTAssertEqual(minutes, 0, accuracy: 0.01)
+    }
+
+    func testIsolatedPointSampleHonorsCustomWidth() {
+        // An isolated point read gets the caller-supplied small width, not a full epoch.
+        let s = HRSample(bpm: 100, start: t0, end: t0)
+        let minutes = ExerciseMinutes.estimate(hrSamples: [s], maxHR: 180,
+                                               epochSeconds: 150, pointSampleWidth: 30)
+        XCTAssertEqual(minutes, 0.5, accuracy: 0.01)   // 30 s
+    }
+
+    func testTwoConsecutivePointsCountAsSustained() {
+        // Two point reads within one epoch ⇒ a sustained run ⇒ each gets a full epoch.
+        let epoch: TimeInterval = 150
+        let samples = [0, 150].map { offset in
+            HRSample(bpm: 100, start: t0.addingTimeInterval(Double(offset)), end: t0.addingTimeInterval(Double(offset)))
+        }
+        let minutes = ExerciseMinutes.estimate(hrSamples: samples, maxHR: 180, epochSeconds: epoch)
+        // [0,150) + [150,300) → merged [0,300] = 5 min
+        XCTAssertEqual(minutes, 5.0, accuracy: 0.01)
     }
 
     func testThreeConsecutiveEpochs() {
-        // Three point samples at t=0, 150, 300 → merges to [0, 450s] = 7.5 min
+        // Three point samples at t=0, 150, 300 → consecutive run → merges to [0, 450s] = 7.5 min.
+        // Bulk-epoch behavior is preserved: back-to-back elevated epochs still count in full.
         let epoch: TimeInterval = 150
         let samples = [0, 150, 300].map { offset in
             HRSample(bpm: 100, start: t0.addingTimeInterval(Double(offset)), end: t0.addingTimeInterval(Double(offset)))
@@ -57,13 +78,16 @@ final class ExerciseMinutesTests: XCTestCase {
     }
 
     func testGapBetweenElevatedRuns() {
-        // Two isolated elevated samples with a 10-min gap → two separate intervals
+        // Two separate sustained runs (each ≥2 consecutive points) split by a 10-min gap stay
+        // as two intervals; isolated reads within neither run do not inflate the total.
         let epoch: TimeInterval = 150
-        let s1 = HRSample(bpm: 100, start: t0, end: t0)
-        let s2 = HRSample(bpm: 100, start: t0.addingTimeInterval(600), end: t0.addingTimeInterval(600))
-        let minutes = ExerciseMinutes.estimate(hrSamples: [s1, s2], maxHR: 180, epochSeconds: epoch)
-        // Two separate 150s intervals = 5 min total
-        XCTAssertEqual(minutes, 5.0, accuracy: 0.01)
+        func run(at base: Double) -> [HRSample] {
+            [base, base + 150].map { HRSample(bpm: 100, start: t0.addingTimeInterval($0), end: t0.addingTimeInterval($0)) }
+        }
+        let samples = run(at: 0) + run(at: 1200)
+        let minutes = ExerciseMinutes.estimate(hrSamples: samples, maxHR: 180, epochSeconds: epoch)
+        // Two separate [x, x+300] runs = 5 min + 5 min = 10 min
+        XCTAssertEqual(minutes, 10.0, accuracy: 0.01)
     }
 
     func testSampleWithRealDurationIsUsed() {
@@ -77,26 +101,26 @@ final class ExerciseMinutesTests: XCTestCase {
     // MARK: Sleep-window exclusion
 
     func testSleepWindowExcludesElevatedHR() {
-        // Elevated HR samples during sleep → excluded; outside → counted
+        // Elevated HR samples during sleep → excluded; a sustained awake run → counted.
         let epoch: TimeInterval = 150
         let sleep = DateInterval(start: t0.addingTimeInterval(-3600), end: t0.addingTimeInterval(3600))
-        // Inside sleep window (elevated but sleeping)
-        let sleeping = HRSample(bpm: 100, start: t0, end: t0)
-        // Outside sleep window (elevated and awake)
-        let awake = HRSample(bpm: 100, start: t0.addingTimeInterval(7200), end: t0.addingTimeInterval(7200))
+        // Inside sleep window (elevated but sleeping) — two consecutive, all excluded.
+        let sleeping = [0.0, 150.0].map { HRSample(bpm: 100, start: t0.addingTimeInterval($0), end: t0.addingTimeInterval($0)) }
+        // Outside sleep window (elevated and awake) — a sustained run of two.
+        let awake = [7200.0, 7350.0].map { HRSample(bpm: 100, start: t0.addingTimeInterval($0), end: t0.addingTimeInterval($0)) }
 
-        let minutes = ExerciseMinutes.estimate(hrSamples: [sleeping, awake], maxHR: 180,
+        let minutes = ExerciseMinutes.estimate(hrSamples: sleeping + awake, maxHR: 180,
                                                sleepWindow: sleep, epochSeconds: epoch)
-        // Only awake sample counted: 1 epoch = 2.5 min
-        XCTAssertEqual(minutes, 2.5, accuracy: 0.01)
+        // Only the awake run counted: [7200,7500] = 5 min
+        XCTAssertEqual(minutes, 5.0, accuracy: 0.01)
     }
 
     func testNoExclusionWhenNoSleepWindow() {
         let epoch: TimeInterval = 150
-        let s = HRSample(bpm: 100, start: t0, end: t0)
-        let minutes = ExerciseMinutes.estimate(hrSamples: [s], maxHR: 180,
+        let samples = [0.0, 150.0].map { HRSample(bpm: 100, start: t0.addingTimeInterval($0), end: t0.addingTimeInterval($0)) }
+        let minutes = ExerciseMinutes.estimate(hrSamples: samples, maxHR: 180,
                                                sleepWindow: nil, epochSeconds: epoch)
-        XCTAssertEqual(minutes, 2.5, accuracy: 0.01)
+        XCTAssertEqual(minutes, 5.0, accuracy: 0.01)
     }
 
     // MARK: Interval merging

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/ExerciseMinutesTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/ExerciseMinutesTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import OpenRingKit
+
+final class ExerciseMinutesTests: XCTestCase {
+
+    private let t0 = Date(timeIntervalSince1970: 0)
+
+    // MARK: Threshold
+
+    func testThresholdHalf() {
+        // maxHR 180 → threshold = 90 bpm
+        XCTAssertEqual(ExerciseMinutes.threshold(maxHR: 180), 90)
+    }
+
+    func testThresholdMinimumClamp() {
+        // maxHR 60 → 50% = 30 < 60 → clamped to 60
+        XCTAssertEqual(ExerciseMinutes.threshold(maxHR: 60), 60)
+    }
+
+    func testThresholdAtAge35() {
+        // maxHR = 220 - 35 = 185 → 50% = 92
+        XCTAssertEqual(ExerciseMinutes.threshold(maxHR: 185), 92)
+    }
+
+    // MARK: Empty / below threshold
+
+    func testNoSamplesReturnsZero() {
+        XCTAssertEqual(ExerciseMinutes.estimate(hrSamples: [], maxHR: 180), 0)
+    }
+
+    func testAllBelowThresholdReturnsZero() {
+        let samples = [60, 70, 80].map { bpm in
+            HRSample(bpm: bpm, start: t0, end: t0)
+        }
+        XCTAssertEqual(ExerciseMinutes.estimate(hrSamples: samples, maxHR: 180), 0)
+    }
+
+    // MARK: Basic elevated estimate
+
+    func testSingleElevatedPointSampleGivesOneEpoch() {
+        // One point sample at threshold → 1 epoch (150s = 2.5 min)
+        let s = HRSample(bpm: 100, start: t0, end: t0)
+        let minutes = ExerciseMinutes.estimate(hrSamples: [s], maxHR: 180,
+                                               epochSeconds: 150)
+        XCTAssertEqual(minutes, 2.5, accuracy: 0.01)
+    }
+
+    func testThreeConsecutiveEpochs() {
+        // Three point samples at t=0, 150, 300 → merges to [0, 450s] = 7.5 min
+        let epoch: TimeInterval = 150
+        let samples = [0, 150, 300].map { offset in
+            HRSample(bpm: 100, start: t0.addingTimeInterval(Double(offset)), end: t0.addingTimeInterval(Double(offset)))
+        }
+        let minutes = ExerciseMinutes.estimate(hrSamples: samples, maxHR: 180, epochSeconds: epoch)
+        // intervals: [0,150), [150,300), [300,450) → merged: [0, 450] = 7.5 min
+        XCTAssertEqual(minutes, 7.5, accuracy: 0.01)
+    }
+
+    func testGapBetweenElevatedRuns() {
+        // Two isolated elevated samples with a 10-min gap → two separate intervals
+        let epoch: TimeInterval = 150
+        let s1 = HRSample(bpm: 100, start: t0, end: t0)
+        let s2 = HRSample(bpm: 100, start: t0.addingTimeInterval(600), end: t0.addingTimeInterval(600))
+        let minutes = ExerciseMinutes.estimate(hrSamples: [s1, s2], maxHR: 180, epochSeconds: epoch)
+        // Two separate 150s intervals = 5 min total
+        XCTAssertEqual(minutes, 5.0, accuracy: 0.01)
+    }
+
+    func testSampleWithRealDurationIsUsed() {
+        // A sample spanning 5 minutes — its real duration should be used, not epochSeconds
+        let end = t0.addingTimeInterval(5 * 60)
+        let s = HRSample(bpm: 100, start: t0, end: end)
+        let minutes = ExerciseMinutes.estimate(hrSamples: [s], maxHR: 180, epochSeconds: 150)
+        XCTAssertEqual(minutes, 5.0, accuracy: 0.01)
+    }
+
+    // MARK: Sleep-window exclusion
+
+    func testSleepWindowExcludesElevatedHR() {
+        // Elevated HR samples during sleep → excluded; outside → counted
+        let epoch: TimeInterval = 150
+        let sleep = DateInterval(start: t0.addingTimeInterval(-3600), end: t0.addingTimeInterval(3600))
+        // Inside sleep window (elevated but sleeping)
+        let sleeping = HRSample(bpm: 100, start: t0, end: t0)
+        // Outside sleep window (elevated and awake)
+        let awake = HRSample(bpm: 100, start: t0.addingTimeInterval(7200), end: t0.addingTimeInterval(7200))
+
+        let minutes = ExerciseMinutes.estimate(hrSamples: [sleeping, awake], maxHR: 180,
+                                               sleepWindow: sleep, epochSeconds: epoch)
+        // Only awake sample counted: 1 epoch = 2.5 min
+        XCTAssertEqual(minutes, 2.5, accuracy: 0.01)
+    }
+
+    func testNoExclusionWhenNoSleepWindow() {
+        let epoch: TimeInterval = 150
+        let s = HRSample(bpm: 100, start: t0, end: t0)
+        let minutes = ExerciseMinutes.estimate(hrSamples: [s], maxHR: 180,
+                                               sleepWindow: nil, epochSeconds: epoch)
+        XCTAssertEqual(minutes, 2.5, accuracy: 0.01)
+    }
+
+    // MARK: Interval merging
+
+    func testOverlappingIntervalsAreMerged() {
+        // Two overlapping real-duration samples → merged to one interval
+        let s1 = HRSample(bpm: 100,
+                          start: t0,
+                          end: t0.addingTimeInterval(300))   // 5 min
+        let s2 = HRSample(bpm: 110,
+                          start: t0.addingTimeInterval(200), // overlaps
+                          end: t0.addingTimeInterval(600))   // extends to 10 min
+        let minutes = ExerciseMinutes.estimate(hrSamples: [s1, s2], maxHR: 180, epochSeconds: 150)
+        // Merged: [0, 600s] = 10 min
+        XCTAssertEqual(minutes, 10.0, accuracy: 0.01)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/ExportEngineTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/ExportEngineTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import OpenRingKit
+
+final class ExportEngineTests: XCTestCase {
+
+    // Reference dates for deterministic output
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)  // 2023-11-14T22:13:20Z
+    private let t1 = Date(timeIntervalSince1970: 1_700_003_600)  // +1 h
+    private let night = Date(timeIntervalSince1970: 1_699_920_000) // 2023-11-13 (approx)
+
+    // MARK: - samplesCSV
+
+    func testSamplesCSVHeader() {
+        let csv = ExportEngine.samplesCSV([])
+        XCTAssertTrue(csv.hasPrefix("kind,start,end,value"), "header missing — got: \(csv)")
+    }
+
+    func testSamplesCSVOneRow() {
+        let row = ExportEngine.SampleRow(kind: "heartRate", start: t0, end: t1, value: 72)
+        let csv = ExportEngine.samplesCSV([row])
+        let lines = csv.components(separatedBy: "\n")
+        XCTAssertEqual(lines.count, 2, "expected header + 1 data line")
+        XCTAssertTrue(lines[1].hasPrefix("heartRate,"), "first field should be kind")
+        XCTAssertTrue(lines[1].hasSuffix(",72"), "last field should be value 72")
+    }
+
+    func testSamplesCSVEmptyIsHeaderOnly() {
+        let csv = ExportEngine.samplesCSV([])
+        XCTAssertEqual(csv, "kind,start,end,value")
+    }
+
+    func testSamplesCSVMultipleRows() {
+        let rows = [
+            ExportEngine.SampleRow(kind: "heartRate", start: t0, end: t1, value: 72),
+            ExportEngine.SampleRow(kind: "spo2", start: t1, end: t1, value: 0.98),
+        ]
+        let lines = ExportEngine.samplesCSV(rows).components(separatedBy: "\n")
+        XCTAssertEqual(lines.count, 3)
+    }
+
+    // MARK: - sleepCSV
+
+    func testSleepCSVHeader() {
+        let csv = ExportEngine.sleepCSV([])
+        XCTAssertTrue(csv.hasPrefix("night,asleepMin,"), "header missing — got: \(csv)")
+    }
+
+    func testSleepCSVOneRow() {
+        let row = ExportEngine.SleepRow(
+            night: night, asleepMin: 450, deepMin: 90, lightMin: 180,
+            remMin: 120, awakeMin: 30, efficiency: 0.9375,
+            skinTempC: 36.5, sleepScore: 82, stressScore: 40)
+        let csv = ExportEngine.sleepCSV([row])
+        let lines = csv.components(separatedBy: "\n")
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(lines[1].contains("450"), "asleepMin should appear")
+        XCTAssertTrue(lines[1].contains("36.50"), "skinTempC should appear as 2 dp")
+    }
+
+    func testSleepCSVEmptyIsHeaderOnly() {
+        let csv = ExportEngine.sleepCSV([])
+        XCTAssertTrue(csv.hasPrefix("night,"))
+        XCTAssertFalse(csv.contains("\n"), "no newline in header-only result")
+    }
+
+    // MARK: - dailyCSV
+
+    func testDailyCSVHeader() {
+        let csv = ExportEngine.dailyCSV([])
+        XCTAssertEqual(csv, "day,steps")
+    }
+
+    func testDailyCSVOneRow() {
+        let row = ExportEngine.DailyRow(day: night, steps: 8_000)
+        let lines = ExportEngine.dailyCSV([row]).components(separatedBy: "\n")
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(lines[1].hasSuffix(",8000"), "steps should be last field")
+    }
+
+    // MARK: - toJSON
+
+    func testToJSONReturnsValidJSON() {
+        let sRow = ExportEngine.SampleRow(kind: "heartRate", start: t0, end: t1, value: 72)
+        let slRow = ExportEngine.SleepRow(
+            night: night, asleepMin: 450, deepMin: 90, lightMin: 180,
+            remMin: 120, awakeMin: 30, efficiency: 0.9375,
+            skinTempC: 36.5, sleepScore: 82, stressScore: 40)
+        let dRow = ExportEngine.DailyRow(day: night, steps: 8_000)
+
+        let json = ExportEngine.toJSON(samples: [sRow], sleep: [slRow], daily: [dRow], now: t0)
+        XCTAssertNotNil(json, "toJSON should not return nil")
+
+        guard let json, let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return XCTFail("produced string is not valid JSON")
+        }
+        XCTAssertNotNil(obj["exportedAt"], "exportedAt key required")
+        XCTAssertNotNil(obj["samples"] as? [[String: Any]])
+        XCTAssertNotNil(obj["sleep"] as? [[String: Any]])
+        XCTAssertNotNil(obj["daily"] as? [[String: Any]])
+    }
+
+    func testToJSONEmptyInputsStillValid() {
+        let json = ExportEngine.toJSON(samples: [], sleep: [], daily: [], now: t0)
+        XCTAssertNotNil(json)
+        guard let json, let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return XCTFail("empty-input JSON is invalid")
+        }
+        XCTAssertEqual((obj["samples"] as? [[String: Any]])?.count, 0)
+        XCTAssertEqual((obj["sleep"] as? [[String: Any]])?.count, 0)
+        XCTAssertEqual((obj["daily"] as? [[String: Any]])?.count, 0)
+    }
+
+    func testToJSONExportedAtPresent() {
+        let json = ExportEngine.toJSON(samples: [], sleep: [], daily: [], now: t0)!
+        XCTAssertTrue(json.contains("exportedAt"), "exportedAt timestamp must appear")
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/FirmwareInfoTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/FirmwareInfoTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import OpenRingKit
+
+final class FirmwareInfoTests: XCTestCase {
+
+    // MARK: - Generation detection
+
+    func testGen1Prefix() {
+        var info = FirmwareInfo()
+        info.version = "FR01.010"
+        XCTAssertEqual(info.generation, .gen1)
+    }
+
+    func testGen2Prefix() {
+        var info = FirmwareInfo()
+        info.version = "FR02.018"
+        XCTAssertEqual(info.generation, .gen2)
+    }
+
+    func testGen2AirPrefix() {
+        var info = FirmwareInfo()
+        info.version = "FR04.003"
+        XCTAssertEqual(info.generation, .gen2Air)
+    }
+
+    func testUnknownPrefix() {
+        var info = FirmwareInfo()
+        info.version = "FR99.001"
+        XCTAssertEqual(info.generation, .unknown)
+    }
+
+    func testEmptyVersionIsUnknown() {
+        let info = FirmwareInfo()
+        XCTAssertEqual(info.generation, .unknown)
+    }
+
+    // MARK: - hasFirmwareMismatch
+
+    func testExactPinnedVersionNoMismatch() {
+        var info = FirmwareInfo()
+        info.version = FirmwareInfo.pinnedVersion   // "FR02.018"
+        XCTAssertFalse(info.hasFirmwareMismatch)
+    }
+
+    func testVersionStartingWithPinnedNoMismatch() {
+        var info = FirmwareInfo()
+        info.version = "FR02.018.extra"
+        XCTAssertFalse(info.hasFirmwareMismatch)
+    }
+
+    func testDifferentVersionMismatch() {
+        var info = FirmwareInfo()
+        info.version = "FR02.020"
+        XCTAssertTrue(info.hasFirmwareMismatch)
+    }
+
+    func testGen1VersionMismatch() {
+        var info = FirmwareInfo()
+        info.version = "FR01.010"
+        XCTAssertTrue(info.hasFirmwareMismatch)
+    }
+
+    func testEmptyVersionNoMismatch() {
+        let info = FirmwareInfo()
+        // Empty version → we haven't read DIS yet; must not report mismatch.
+        XCTAssertFalse(info.hasFirmwareMismatch)
+    }
+
+    // MARK: - MAC formatting
+
+    func testMACStoredAndReadBack() {
+        let mac = "AA:BB:CC:DD:EE:FF"
+        var info = FirmwareInfo()
+        info.mac = mac
+        XCTAssertEqual(info.mac, mac)
+    }
+
+    func testNilMACByDefault() {
+        let info = FirmwareInfo()
+        XCTAssertNil(info.mac)
+    }
+
+    // MARK: - Equatable
+
+    func testEqualInfos() {
+        let a = FirmwareInfo(version: "FR02.018", modelName: "RingConn",
+                             manufacturer: "RingConn", hardwareRevision: "1.0",
+                             mac: "AA:BB:CC:DD:EE:FF")
+        let b = FirmwareInfo(version: "FR02.018", modelName: "RingConn",
+                             manufacturer: "RingConn", hardwareRevision: "1.0",
+                             mac: "AA:BB:CC:DD:EE:FF")
+        XCTAssertEqual(a, b)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/FrameTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/FrameTests.swift
@@ -80,6 +80,18 @@ final class FrameTests: XCTestCase {
         XCTAssertEqual(Array(Command.syncSince(unixSeconds: 0)[2...5]), [0, 0, 0, 0])
     }
 
+    func testSyncUpToNowOpensAtNowNotSyncAll() {
+        // History sync opens at cursor ≈ now (the official app's behaviour, §3) — NEVER syncAll
+        // (0xFFFFFFFF, a far-future cursor that returns an empty backlog and dropped sleep/HRV/RR).
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let open = Command.syncUpToNow(now: now)
+        XCTAssertEqual(open, Command.syncSince(unixSeconds: 1_750_000_000))
+        XCTAssertNotEqual(open, Command.syncAll)
+        XCTAssertNotEqual(Array(open[2...5]), [0xFF, 0xFF, 0xFF, 0xFF], "cursor must be ≈now, not 0xFFFFFFFF")
+        XCTAssertEqual(Array(open[0...1]), [0x02, 0x00])
+        XCTAssertEqual(Array(open[6...8]), [0x00, 0x01, 0x00])
+    }
+
     func testLiveHRDecode() {
         // Real 0x15 frame from the capture: byte[2] = 0x5B = 91 bpm.
         XCTAssertEqual(LiveHR.decode(hex("15005b0ab0f4")), 91)

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/GoalProgressTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/GoalProgressTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import OpenRingKit
+
+final class GoalProgressTests: XCTestCase {
+
+    // MARK: GoalProgress math
+
+    func testFractionAtZeroIsZero() {
+        let p = GoalProgress(current: 0, goal: 8000)
+        XCTAssertEqual(p.fraction, 0, accuracy: 0.0001)
+        XCTAssertFalse(p.met)
+    }
+
+    func testFractionAtHalf() {
+        let p = GoalProgress(current: 4000, goal: 8000)
+        XCTAssertEqual(p.fraction, 0.5, accuracy: 0.0001)
+        XCTAssertFalse(p.met)
+    }
+
+    func testFractionCappedAt1() {
+        let p = GoalProgress(current: 12000, goal: 8000)
+        XCTAssertEqual(p.fraction, 1.0, accuracy: 0.0001)
+        XCTAssertTrue(p.met)
+    }
+
+    func testFractionExactlyMet() {
+        let p = GoalProgress(current: 8000, goal: 8000)
+        XCTAssertEqual(p.fraction, 1.0, accuracy: 0.0001)
+        XCTAssertTrue(p.met)
+    }
+
+    func testZeroGoalIsZeroFraction() {
+        let p = GoalProgress(current: 100, goal: 0)
+        XCTAssertEqual(p.fraction, 0, accuracy: 0.0001)
+        XCTAssertFalse(p.met)
+    }
+
+    // MARK: Weekday / weekend selection
+
+    /// Build a Date that falls on a given weekday (1=Sun…7=Sat) in a Gregorian calendar,
+    /// guaranteed to be local-midnight regardless of timezone.
+    private func dateOnWeekday(_ weekday: Int) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.locale = Locale(identifier: "en_US")
+        var comps = cal.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date())
+        comps.weekday = weekday
+        return cal.date(from: comps) ?? Date()
+    }
+
+    func testWeekendDetection() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.locale = Locale(identifier: "en_US")
+        let saturday = dateOnWeekday(7)  // 7 = Saturday in Gregorian
+        XCTAssertTrue(GoalDefaults.isWeekend(saturday, calendar: cal))
+    }
+
+    func testWeekdayDetection() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.locale = Locale(identifier: "en_US")
+        let monday = dateOnWeekday(2)  // 2 = Monday in Gregorian
+        XCTAssertFalse(GoalDefaults.isWeekend(monday, calendar: cal))
+    }
+
+    // MARK: Steps goal selection
+
+    func testStepsGoalFallsBackToDefault() {
+        let defaults = UserDefaults(suiteName: "GoalProgressTestsSuite")!
+        defaults.removePersistentDomain(forName: "GoalProgressTestsSuite")
+        var cal = Calendar(identifier: .gregorian)
+        cal.locale = Locale(identifier: "en_US")
+        let monday = dateOnWeekday(2)   // Monday = weekday
+        let goal = GoalDefaults.stepsGoal(for: monday, calendar: cal, defaults: defaults)
+        XCTAssertEqual(goal, GoalDefaults.defaultWorkdaySteps)
+    }
+
+    func testWeekendStepsGoalDefault() {
+        let defaults = UserDefaults(suiteName: "GoalProgressTestsSuiteW")!
+        defaults.removePersistentDomain(forName: "GoalProgressTestsSuiteW")
+        var cal = Calendar(identifier: .gregorian)
+        cal.locale = Locale(identifier: "en_US")
+        let saturday = dateOnWeekday(7)   // Saturday = weekend
+        let goal = GoalDefaults.stepsGoal(for: saturday, calendar: cal, defaults: defaults)
+        XCTAssertEqual(goal, GoalDefaults.defaultWeekendSteps)
+    }
+
+    // MARK: DailyGoalProgress
+
+    func testDailyProgressSummary() {
+        let p = DailyGoalProgress(
+            steps: GoalProgress(current: 6000, goal: 8000),
+            activeKcal: GoalProgress(current: 150, goal: 300),
+            activityMinutes: GoalProgress(current: 20, goal: 30),
+            sleepMinutes: GoalProgress(current: 420, goal: 480)
+        )
+        XCTAssertEqual(p.steps.fraction, 0.75, accuracy: 0.0001)
+        XCTAssertEqual(p.activeKcal.fraction, 0.5, accuracy: 0.0001)
+        XCTAssertFalse(p.activityMinutes.met)
+        XCTAssertFalse(p.sleepMinutes.met)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/HealthAlertsTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/HealthAlertsTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import OpenRingKit
+
+/// SYNTHETIC-ONLY tests for the local health-alert engine: thresholds (#73), flag routing (#85),
+/// quiet-hours DND, and the anti-spam de-dupe gate. No real health values.
+final class HealthAlertsTests: XCTestCase {
+
+    private let cal = Calendar(identifier: .gregorian)
+    private func at(_ h: Int, _ m: Int = 0) -> Date {
+        cal.date(from: DateComponents(year: 2026, month: 6, day: 17, hour: h, minute: m))!
+    }
+    private func hr(_ bpm: Int, _ h: Int, _ m: Int = 0) -> HRSample { HRSample(bpm: bpm, start: at(h, m)) }
+
+    // MARK: #73 threshold rules
+
+    func testHighHRPicksWorstReading() {
+        let s = [hr(80, 9), hr(125, 10), hr(140, 11), hr(90, 12)]
+        let hit = HealthAlertEvaluator.highHR(s, thresholdBpm: 120)
+        XCTAssertEqual(hit?.bpm, 140)
+        XCTAssertNil(HealthAlertEvaluator.highHR([hr(80, 9), hr(100, 10)], thresholdBpm: 120))
+    }
+
+    func testLowSpO2PicksWorstReading() {
+        let r = [SpO2Reading(percent: 97, time: at(2)), SpO2Reading(percent: 88, time: at(3)),
+                 SpO2Reading(percent: 91, time: at(4))]
+        XCTAssertEqual(HealthAlertEvaluator.lowSpO2(r, thresholdPercent: 90)?.percent, 88)
+        // Zero/invalid placeholders are ignored.
+        XCTAssertNil(HealthAlertEvaluator.lowSpO2([SpO2Reading(percent: 0, time: at(2))], thresholdPercent: 90))
+        XCTAssertNil(HealthAlertEvaluator.lowSpO2(r, thresholdPercent: 80))
+    }
+
+    func testElevatedHRInactiveSustained() {
+        // 5 readings ≥100 spanning 10 min (epochs ~2.5 min apart) → fires on the last.
+        let s = [hr(105, 1, 0), hr(108, 1, 3), hr(110, 1, 6), hr(106, 1, 9), hr(112, 1, 12)]
+        let hit = HealthAlertEvaluator.elevatedHRInactive(s, thresholdBpm: 100, minDuration: 10 * 60)
+        XCTAssertEqual(hit?.bpm, 112)
+    }
+
+    func testElevatedHRInactiveTooShort() {
+        // Elevated for only ~6 min → no fire.
+        let s = [hr(105, 1, 0), hr(108, 1, 3), hr(110, 1, 6)]
+        XCTAssertNil(HealthAlertEvaluator.elevatedHRInactive(s, thresholdBpm: 100, minDuration: 10 * 60))
+    }
+
+    func testElevatedHRInactiveResetsBelowThreshold() {
+        // A dip below threshold breaks the run; the later cluster is too short on its own.
+        let s = [hr(105, 1, 0), hr(108, 1, 3), hr(70, 1, 6), hr(110, 1, 9), hr(112, 1, 12)]
+        XCTAssertNil(HealthAlertEvaluator.elevatedHRInactive(s, thresholdBpm: 100, minDuration: 10 * 60))
+    }
+
+    func testElevatedHRInactiveGapBreaksRun() {
+        // Two elevated readings 30 min apart — gap exceeds maxGap, so not one continuous run.
+        let s = [hr(110, 1, 0), hr(112, 1, 30)]
+        XCTAssertNil(HealthAlertEvaluator.elevatedHRInactive(s, thresholdBpm: 100,
+                                                             minDuration: 10 * 60, maxGap: 5 * 60))
+    }
+
+    func testEvaluateRespectsEnableFlags() {
+        let highOnly = HealthAlertThresholds(highHREnabled: true, lowSpO2Enabled: false, elevatedHREnabled: false)
+        let hits = HealthAlertEvaluator.evaluate(
+            hr: [hr(130, 10)],
+            spo2: [SpO2Reading(percent: 85, time: at(3))],
+            inactiveHR: [],
+            thresholds: highOnly)
+        XCTAssertEqual(hits.map(\.notification), [.highHR])
+    }
+
+    // MARK: #85 flag routing
+
+    func testTempFeverRouting() {
+        var flags = SkinTempBaseline.AnomalyFlags()
+        flags.abnormalRise = true
+        flags.fluctuationDrop = true
+        let notifs = TempFeverNotifications.notifications(flags: flags, feverSuspected: true)
+        XCTAssertEqual(Set(notifs), [.skinTempRise, .skinTempFluctuationDrop, .fever])
+        XCTAssertTrue(TempFeverNotifications.notifications(flags: SkinTempBaseline.AnomalyFlags(),
+                                                          feverSuspected: false).isEmpty)
+    }
+
+    // MARK: Quiet hours (DND)
+
+    func testQuietHoursWrapsMidnight() {
+        let q = QuietHours(enabled: true, startMinutes: 22 * 60, endMinutes: 7 * 60)
+        XCTAssertTrue(q.contains(at(23), calendar: cal))
+        XCTAssertTrue(q.contains(at(2), calendar: cal))
+        XCTAssertFalse(q.contains(at(12), calendar: cal))
+        XCTAssertFalse(q.contains(at(7), calendar: cal), "end is exclusive")
+    }
+
+    func testQuietHoursDisabled() {
+        let q = QuietHours(enabled: false, startMinutes: 22 * 60, endMinutes: 7 * 60)
+        XCTAssertFalse(q.contains(at(2), calendar: cal))
+    }
+
+    // MARK: De-dupe / DND gate
+
+    func testGateSuppressesDuringQuietHours() {
+        let gate = NotificationGate()
+        let q = QuietHours(enabled: true, startMinutes: 22 * 60, endMinutes: 7 * 60)
+        XCTAssertFalse(gate.shouldFire(.highHR, now: at(2), lastFired: [:], quietHours: q, calendar: cal))
+        XCTAssertTrue(gate.shouldFire(.highHR, now: at(12), lastFired: [:], quietHours: q, calendar: cal))
+    }
+
+    func testGateRenotifyBackoff() {
+        let gate = NotificationGate(renotifyInterval: 2 * 3600)
+        let last: [HealthNotification: Date] = [.lowSpO2: at(10)]
+        let q = QuietHours(enabled: false)
+        // 1h later — still inside backoff.
+        XCTAssertFalse(gate.shouldFire(.lowSpO2, now: at(11), lastFired: last, quietHours: q, calendar: cal))
+        // 3h later — backoff elapsed.
+        XCTAssertTrue(gate.shouldFire(.lowSpO2, now: at(13), lastFired: last, quietHours: q, calendar: cal))
+        // A DIFFERENT condition is independent.
+        XCTAssertTrue(gate.shouldFire(.highHR, now: at(11), lastFired: last, quietHours: q, calendar: cal))
+    }
+
+    func testGateFilterStableOrder() {
+        let gate = NotificationGate()
+        let q = QuietHours(enabled: false)
+        let out = gate.filter([.fever, .highHR, .lowSpO2], now: at(12), lastFired: [:],
+                              quietHours: q, calendar: cal)
+        // Returned in HealthNotification.allCases order: highHR, lowSpO2, …, fever.
+        XCTAssertEqual(out, [.highHR, .lowSpO2, .fever])
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/KeepaliveCadenceTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/KeepaliveCadenceTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import OpenRingKit
+
+// Adaptive keepalive cadence (#31): slow by day, tighter at night / during a live read,
+// and stretched further in battery-saver. Asserts the ordering so a regression that, say,
+// reverts to a 30 s day poll is caught.
+final class KeepaliveCadenceTests: XCTestCase {
+
+    func testDaytimeIsSlow() {
+        XCTAssertEqual(KeepaliveCadence.interval(isNight: false, activeMeasurement: false, batterySaver: false), 180)
+    }
+
+    func testNightTightens() {
+        XCTAssertEqual(KeepaliveCadence.interval(isNight: true, activeMeasurement: false, batterySaver: false), 60)
+    }
+
+    func testBatterySaverStretchesIdleCadences() {
+        XCTAssertEqual(KeepaliveCadence.interval(isNight: false, activeMeasurement: false, batterySaver: true), 300)
+        XCTAssertEqual(KeepaliveCadence.interval(isNight: true, activeMeasurement: false, batterySaver: true), 90)
+    }
+
+    func testActiveMeasurementOverridesEverything() {
+        // A live read suppresses the heartbeat but wants fast re-checks regardless of night/saver.
+        for night in [true, false] {
+            for saver in [true, false] {
+                XCTAssertEqual(KeepaliveCadence.interval(isNight: night, activeMeasurement: true, batterySaver: saver), 30)
+            }
+        }
+    }
+
+    func testNightIsAlwaysTighterThanDay() {
+        let day = KeepaliveCadence.interval(isNight: false, activeMeasurement: false, batterySaver: false)
+        let night = KeepaliveCadence.interval(isNight: true, activeMeasurement: false, batterySaver: false)
+        XCTAssertLessThan(night, day)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/NapDetectionTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/NapDetectionTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import OpenRingKit
+
+/// SYNTHETIC-ONLY tests for automatic nap detection (#76). Builds a day of 0x4c motion epochs
+/// (active / still / active) anchored at a chosen wall-clock via the `epoch` parameter, then
+/// asserts a daytime stillness block ≥ 15 min is a nap, while an overnight block, an overlap
+/// with the main night, and a sub-15-min block are all rejected.
+final class NapDetectionTests: XCTestCase {
+
+    private let step: UInt32 = 150
+
+    /// One epoch with a uniform motion byte (baseline 1 = still; higher = movement).
+    private func rec(_ counter: UInt32, motion: UInt8) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: 23)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xFF)
+        b[2] = UInt8((counter >> 8) & 0xFF); b[3] = UInt8(counter & 0xFF)
+        for k in 0..<5 { b[10 + k] = motion }
+        return BulkRecord(b)!
+    }
+
+    /// Build active→still→active records and the `epoch` so that counter 0 lands at `anchorHour`
+    /// local today. `activeEpochs`/`stillEpochs` are 2.5-min epochs each.
+    private func dayRecords(anchorHour: Int, activeEpochs: Int, stillEpochs: Int)
+        -> (records: [BulkRecord], epoch: Int) {
+        let cal = Calendar.current
+        let anchor = cal.date(byAdding: .hour, value: anchorHour, to: cal.startOfDay(for: Date()))!
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0
+        for _ in 0..<activeEpochs { recs.append(rec(c, motion: 20)); c += step }
+        for _ in 0..<stillEpochs { recs.append(rec(c, motion: 1)); c += step }
+        for _ in 0..<activeEpochs { recs.append(rec(c, motion: 20)); c += step }
+        return (recs, Int(anchor.timeIntervalSince1970))
+    }
+
+    func testDetectsDaytimeNap() {
+        // 14:00 anchor; 20-min active, 60-min still nap, 20-min active.
+        let (recs, epoch) = dayRecords(anchorHour: 14, activeEpochs: 8, stillEpochs: 24)
+        let naps = NapDetection.naps(from: recs, mainSleep: nil, epoch: epoch)
+        XCTAssertEqual(naps.count, 1, "one daytime nap")
+        let nap = naps[0]
+        XCTAssertGreaterThanOrEqual(nap.duration, NapDetection.minNapDuration)
+        XCTAssertGreaterThan(nap.asleep, 0)
+        XCTAssertFalse(nap.isLongNap, "60-min nap is not a long nap")
+        XCTAssertFalse(nap.segments.isEmpty)
+    }
+
+    func testRejectsShortStillBlock() {
+        // 10-min still block (< 15 min) → not a nap.
+        let (recs, epoch) = dayRecords(anchorHour: 14, activeEpochs: 8, stillEpochs: 4)
+        let naps = NapDetection.naps(from: recs, mainSleep: nil, epoch: epoch)
+        XCTAssertTrue(naps.isEmpty)
+    }
+
+    func testRejectsOvernightBlock() {
+        // Same shape but at 02:00 — an overnight midpoint is night sleep, not a nap.
+        let (recs, epoch) = dayRecords(anchorHour: 2, activeEpochs: 8, stillEpochs: 24)
+        let naps = NapDetection.naps(from: recs, mainSleep: nil, epoch: epoch)
+        XCTAssertTrue(naps.isEmpty, "overnight stillness is excluded from naps")
+    }
+
+    func testExcludesOverlapWithMainSleep() {
+        let (recs, epoch) = dayRecords(anchorHour: 14, activeEpochs: 8, stillEpochs: 24)
+        // A main-sleep block spanning the whole captured day window → the nap is suppressed.
+        let firstT = recs.first!.date(epoch: epoch)
+        let lastT = recs.last!.date(epoch: epoch)
+        let main = ActivityPeriod(activity: .sleep, start: firstT, end: lastT)
+        let naps = NapDetection.naps(from: recs, mainSleep: main, epoch: epoch)
+        XCTAssertTrue(naps.isEmpty, "a block overlapping the main night is not double-counted as a nap")
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/ReconnectBackoffTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/ReconnectBackoffTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import OpenRingKit
+
+// Auto-reconnect backoff (#35): grows the gap between consecutive failed reconnects so a ring
+// left on the charger isn't hammered, and flips to the calm "unreachable" state after a few
+// tries. Asserts the schedule + thresholds so a regression (e.g. reverting to immediate retry)
+// is caught.
+final class ReconnectBackoffTests: XCTestCase {
+
+    func testScheduleGrowsThenCaps() {
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 1), 1)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 2), 5)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 3), 30)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 4), 30)   // capped
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 99), 30)  // stays capped
+    }
+
+    func testZeroOrNegativeAttemptIsImmediate() {
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 0), 0)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: -3), 0)
+    }
+
+    func testDelayIsMonotonicNonDecreasing() {
+        var prev = ReconnectBackoff.delay(forAttempt: 0)
+        for attempt in 1...12 {
+            let d = ReconnectBackoff.delay(forAttempt: attempt)
+            XCTAssertGreaterThanOrEqual(d, prev)
+            prev = d
+        }
+    }
+
+    func testCalmStateOnlyAfterThreshold() {
+        XCTAssertFalse(ReconnectBackoff.shouldSurfaceCalmState(attempts: 0))
+        XCTAssertFalse(ReconnectBackoff.shouldSurfaceCalmState(attempts: 2))
+        XCTAssertTrue(ReconnectBackoff.shouldSurfaceCalmState(attempts: 3))
+        XCTAssertTrue(ReconnectBackoff.shouldSurfaceCalmState(attempts: 10))
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/ReminderEngineTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/ReminderEngineTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import OpenRingKit
+
+final class ReminderEngineTests: XCTestCase {
+
+    // Calendar fixed to UTC so minute-of-day maths are locale-independent in CI.
+    private let cal: Calendar = {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(secondsFromGMT: 0)!
+        return c
+    }()
+
+    // A "now" that maps to 10:00 UTC (600 minutes since midnight) on 2024-01-15.
+    private var now1000: Date {
+        var c = DateComponents()
+        c.year = 2024; c.month = 1; c.day = 15
+        c.hour = 10; c.minute = 0; c.second = 0; c.timeZone = TimeZone(secondsFromGMT: 0)
+        return cal.date(from: c)!
+    }
+
+    // 22:45 UTC — outside the default 08:00–21:00 active window.
+    private var now2245: Date {
+        var c = DateComponents()
+        c.year = 2024; c.month = 1; c.day = 15
+        c.hour = 22; c.minute = 45; c.second = 0; c.timeZone = TimeZone(secondsFromGMT: 0)
+        return cal.date(from: c)!
+    }
+
+    // MARK: - SedentaryReminder
+
+    func testSedentaryFiresAfterInterval() {
+        let r = SedentaryReminder(interval: 50 * 60, activeStartMinutes: 8 * 60, activeEndMinutes: 21 * 60)
+        let last = now1000.addingTimeInterval(-(51 * 60))  // 51 min ago
+        XCTAssertTrue(r.shouldFire(lastActivityAt: last, now: now1000, calendar: cal))
+    }
+
+    func testSedentaryDoesNotFireBeforeInterval() {
+        let r = SedentaryReminder(interval: 50 * 60, activeStartMinutes: 8 * 60, activeEndMinutes: 21 * 60)
+        let last = now1000.addingTimeInterval(-(49 * 60))  // only 49 min ago
+        XCTAssertFalse(r.shouldFire(lastActivityAt: last, now: now1000, calendar: cal))
+    }
+
+    func testSedentaryDoesNotFireOutsideActiveHours() {
+        let r = SedentaryReminder(interval: 50 * 60, activeStartMinutes: 8 * 60, activeEndMinutes: 21 * 60)
+        let last = now2245.addingTimeInterval(-(60 * 60))   // 1 h ago, but it's 22:45 now
+        XCTAssertFalse(r.shouldFire(lastActivityAt: last, now: now2245, calendar: cal))
+    }
+
+    func testSedentaryDoesNotFireWithNilLastActivity() {
+        let r = SedentaryReminder()
+        XCTAssertFalse(r.shouldFire(lastActivityAt: nil, now: now1000, calendar: cal))
+    }
+
+    // MARK: - WearReminder
+
+    func testWearFiresAfterInterval() {
+        let r = WearReminder(noDataInterval: 20 * 60)
+        let last = Date().addingTimeInterval(-(21 * 60))
+        XCTAssertTrue(r.shouldFire(lastRingDataAt: last, now: Date(), everConnected: true))
+    }
+
+    func testWearDoesNotFireBeforeInterval() {
+        let r = WearReminder(noDataInterval: 20 * 60)
+        let last = Date().addingTimeInterval(-(19 * 60))
+        XCTAssertFalse(r.shouldFire(lastRingDataAt: last, now: Date(), everConnected: true))
+    }
+
+    func testWearDoesNotFireIfNeverConnected() {
+        let r = WearReminder(noDataInterval: 20 * 60)
+        XCTAssertFalse(r.shouldFire(lastRingDataAt: nil, now: Date(), everConnected: false))
+    }
+
+    func testWearFiresWhenNilDataButEverConnected() {
+        let r = WearReminder(noDataInterval: 20 * 60)
+        // nil lastRingDataAt + everConnected = true → fire (ring disappeared)
+        XCTAssertTrue(r.shouldFire(lastRingDataAt: nil, now: Date(), everConnected: true))
+    }
+
+    // MARK: - BedtimeReminder (normal window, no midnight wrap)
+
+    // Bed at 23:00 (1380 min), minutesBefore = 30 → window is [22:30, 23:00).
+    func testBedtimeFiresInsideWindow() {
+        let r = BedtimeReminder(minutesBefore: 30)
+        // now = 22:45 (1365 min) — inside [1350, 1380)
+        let now = now2245  // 22:45 UTC
+        XCTAssertTrue(r.shouldFire(now: now, bedMinutes: 1380, wakeMinutes: 7 * 60, calendar: cal))
+    }
+
+    func testBedtimeDoesNotFireOutsideWindow() {
+        let r = BedtimeReminder(minutesBefore: 30)
+        // now = 10:00 — far from [22:30, 23:00)
+        XCTAssertFalse(r.shouldFire(now: now1000, bedMinutes: 1380, wakeMinutes: 7 * 60, calendar: cal))
+    }
+
+    func testBedtimeDoesNotFireWhenBedEqualsWake() {
+        let r = BedtimeReminder(minutesBefore: 30)
+        XCTAssertFalse(r.shouldFire(now: now1000, bedMinutes: 600, wakeMinutes: 600, calendar: cal))
+    }
+
+    // MARK: - BedtimeReminder (window wraps midnight)
+
+    // Bed at 01:00 (60 min), minutesBefore = 30 → window is [00:30, 01:00).
+    func testBedtimeWrapsAroundMidnightFires() {
+        let r = BedtimeReminder(minutesBefore: 30)
+        // now = 00:45 (45 min) — inside wrapping window [30, 60)
+        var c = DateComponents()
+        c.year = 2024; c.month = 1; c.day = 15
+        c.hour = 0; c.minute = 45; c.timeZone = TimeZone(secondsFromGMT: 0)
+        let now0045 = cal.date(from: c)!
+        XCTAssertTrue(r.shouldFire(now: now0045, bedMinutes: 60, wakeMinutes: 7 * 60, calendar: cal))
+    }
+
+    func testBedtimeWrapsAroundMidnightDoesNotFireOutside() {
+        let r = BedtimeReminder(minutesBefore: 30)
+        // now = 10:00 — not inside [30, 60)
+        XCTAssertFalse(r.shouldFire(now: now1000, bedMinutes: 60, wakeMinutes: 7 * 60, calendar: cal))
+    }
+
+    // Bed = 23:45 (1425 min), minutesBefore = 30 → window [1395, 1425) = [23:15, 23:45)
+    // Wraps? No, both are before midnight — purely same-day window.
+    func testBedtimeNearMidnightSameDay() {
+        let r = BedtimeReminder(minutesBefore: 30)
+        // now = 23:20 → 1400 min — inside [1395, 1425)
+        var c = DateComponents()
+        c.year = 2024; c.month = 1; c.day = 15
+        c.hour = 23; c.minute = 20; c.timeZone = TimeZone(secondsFromGMT: 0)
+        let now2320 = cal.date(from: c)!
+        XCTAssertTrue(r.shouldFire(now: now2320, bedMinutes: 1425, wakeMinutes: 7 * 60, calendar: cal))
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/RestingHRTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/RestingHRTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import OpenRingKit
+
+// Resting-HR derivation (#18, #37). Pure value-type math; runs under `swift test`.
+final class RestingHRTests: XCTestCase {
+
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)  // fixed anchor
+
+    private func hr(_ bpm: Int, _ offset: TimeInterval) -> HRSample {
+        HRSample(bpm: bpm, start: t0.addingTimeInterval(offset))
+    }
+
+    /// Assert an optional Double equals `expected` (the derivations return nil when there's
+    /// no data, so unwrap before the accuracy comparison).
+    private func assertEqual(_ value: Double?, _ expected: Double,
+                             file: StaticString = #filePath, line: UInt = #line) {
+        guard let value else {
+            XCTFail("expected \(expected), got nil", file: file, line: line); return
+        }
+        XCTAssertEqual(value, expected, accuracy: 0.001, file: file, line: line)
+    }
+
+    // MARK: Sleep mean (preferred tier)
+
+    func testSleepMeanAveragesAsleepReadings() {
+        let sleep = [SleepSegment(start: t0, end: t0.addingTimeInterval(600), stage: .asleepCore)]
+        let samples = [hr(60, 0), hr(50, 100), hr(70, 200)]  // all inside the segment
+        assertEqual(RestingHR.sleepMean(hr: samples, sleep: sleep, minSleepSamples: 3), 60)
+    }
+
+    func testSleepMeanExcludesAwakeAndOutOfWindow() {
+        let sleep = [
+            SleepSegment(start: t0, end: t0.addingTimeInterval(300), stage: .asleepDeep),
+            SleepSegment(start: t0.addingTimeInterval(300), end: t0.addingTimeInterval(600), stage: .awake),
+        ]
+        // 3 asleep readings (mean 55) + a high awake reading + a reading after the window.
+        let samples = [hr(50, 0), hr(55, 100), hr(60, 200), hr(120, 400), hr(120, 1000)]
+        assertEqual(RestingHR.sleepMean(hr: samples, sleep: sleep, minSleepSamples: 3), 55)
+    }
+
+    func testSleepMeanNilWhenTooFewAsleepReadings() {
+        let sleep = [SleepSegment(start: t0, end: t0.addingTimeInterval(600), stage: .asleepREM)]
+        XCTAssertNil(RestingHR.sleepMean(hr: [hr(60, 0), hr(58, 100)], sleep: sleep, minSleepSamples: 3))
+    }
+
+    func testSleepMeanNilWhenNoAsleepSegments() {
+        let sleep = [SleepSegment(start: t0, end: t0.addingTimeInterval(600), stage: .inBed)]
+        XCTAssertNil(RestingHR.sleepMean(hr: [hr(60, 0), hr(58, 100), hr(59, 200)], sleep: sleep, minSleepSamples: 3))
+    }
+
+    // MARK: Lowest sustained (fallback tier)
+
+    func testLowestSustainedFindsTheLowMinuteBlock() {
+        // 5 high readings then 5 low readings, one per minute; the 5-min window over the low
+        // block has the minimum mean (50).
+        var samples: [HRSample] = []
+        for i in 0..<5 { samples.append(hr(70, Double(i) * 60)) }
+        for i in 5..<10 { samples.append(hr(50, Double(i) * 60)) }
+        assertEqual(RestingHR.lowestSustained(hr: samples, window: 300), 50)
+    }
+
+    func testLowestSustainedSingleReadingFallsBackToThatReading() {
+        assertEqual(RestingHR.lowestSustained(hr: [hr(55, 0)], window: 300), 55)
+    }
+
+    func testLowestSustainedAllIsolatedFallsBackToLowestSingle() {
+        // Readings >5 min apart never co-occur in a window → fall back to the single lowest.
+        let samples = [hr(60, 0), hr(50, 1000), hr(70, 2000)]
+        assertEqual(RestingHR.lowestSustained(hr: samples, window: 300), 50)
+    }
+
+    func testLowestSustainedNilWhenEmpty() {
+        XCTAssertNil(RestingHR.lowestSustained(hr: [], window: 300))
+    }
+
+    // MARK: Tier selection
+
+    func testValuePrefersSleepMeanOverDaytimeLow() {
+        let sleep = [SleepSegment(start: t0, end: t0.addingTimeInterval(300), stage: .asleepCore)]
+        let asleep = [hr(55, 0), hr(55, 100), hr(55, 200)]          // sleep mean 55
+        let daytime = [hr(45, 4000), hr(45, 4060), hr(45, 4120)]    // sustained low 45 (ignored)
+        assertEqual(RestingHR.value(hr: asleep + daytime, sleep: sleep), 55)
+    }
+
+    func testValueFallsBackWhenNoSleep() {
+        let daytime = [hr(45, 0), hr(45, 60), hr(45, 120)]
+        assertEqual(RestingHR.value(hr: daytime), 45)
+    }
+
+    // MARK: Daily grouping
+
+    func testDailyValuesGroupsByCalendarDay() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let day1 = cal.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+        let day2 = cal.date(byAdding: .day, value: 1, to: day1)!
+        let samples = [
+            HRSample(bpm: 60, start: day1.addingTimeInterval(3600)),
+            HRSample(bpm: 50, start: day1.addingTimeInterval(3660)),
+            HRSample(bpm: 70, start: day2.addingTimeInterval(3600)),
+            HRSample(bpm: 72, start: day2.addingTimeInterval(3660)),
+        ]
+        let daily = RestingHR.dailyValues(hr: samples, calendar: cal)
+        XCTAssertEqual(daily.count, 2)
+        XCTAssertEqual(daily[0].day, day1)
+        XCTAssertEqual(daily[1].day, day2)
+        XCTAssertEqual(daily[0].bpm, 55, accuracy: 0.001)   // (60+50)/2 sustained window
+        XCTAssertEqual(daily[1].bpm, 71, accuracy: 0.001)   // (70+72)/2
+    }
+
+    func testDailyValuesEmptyForNoReadings() {
+        XCTAssertEqual(RestingHR.dailyValues(hr: []), [])
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SkinTempBaselineTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SkinTempBaselineTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import OpenRingKit
+
+/// SYNTHETIC-ONLY tests for the sleeping skin-temp baseline + nightly deviation (#69).
+/// No real health values — controlled inputs with a known expected baseline/offset/band.
+final class SkinTempBaselineTests: XCTestCase {
+
+    private func night(_ daysAgo: Int, _ c: Double) -> SkinTempBaseline.NightlyTemp {
+        let day = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date())!
+        return SkinTempBaseline.NightlyTemp(night: day, celsius: c)
+    }
+
+    func testNightlyMean() {
+        XCTAssertNil(SkinTempBaseline.nightlyMean([]))
+        XCTAssertEqual(SkinTempBaseline.nightlyMean([30, 31, 32])!, 31, accuracy: 1e-9)
+    }
+
+    func testNightlyMeanWindowed() {
+        let base = Date()
+        let samples = [
+            TemperatureSample(time: base, celsius: 30),
+            TemperatureSample(time: base.addingTimeInterval(60), celsius: 32),
+            TemperatureSample(time: base.addingTimeInterval(10_000), celsius: 99),  // outside window
+        ]
+        let window = DateInterval(start: base, end: base.addingTimeInterval(120))
+        XCTAssertEqual(SkinTempBaseline.nightlyMean(samples: samples, in: window)!, 31, accuracy: 1e-9)
+    }
+
+    func testBaselineNeedsMinimumHistory() {
+        XCTAssertNil(SkinTempBaseline.baseline(priorNights: [night(1, 30), night(2, 31)]),
+                     "below minBaselineNights → no baseline")
+        let three = [night(1, 30), night(2, 31), night(3, 32)]
+        XCTAssertEqual(SkinTempBaseline.baseline(priorNights: three)!, 31, accuracy: 1e-9)
+    }
+
+    func testBaselineTrailingWindow() {
+        // 5 nights but a window of 3 → only the 3 most-recent count.
+        let nights = [night(5, 20), night(4, 20), night(3, 30), night(2, 31), night(1, 32)]
+        XCTAssertEqual(SkinTempBaseline.baseline(priorNights: nights, windowNights: 3)!, 31, accuracy: 1e-9)
+    }
+
+    func testOffsetSign() {
+        XCTAssertEqual(SkinTempBaseline.offset(tonight: 32, baseline: 31), 1, accuracy: 1e-9)
+        XCTAssertEqual(SkinTempBaseline.offset(tonight: 30, baseline: 31), -1, accuracy: 1e-9)
+    }
+
+    func testDeviationBand() {
+        XCTAssertEqual(SkinTempBaseline.deviationBand(offset: 0.5), .normal)
+        XCTAssertEqual(SkinTempBaseline.deviationBand(offset: 1.5), .abnormalRise)
+        XCTAssertEqual(SkinTempBaseline.deviationBand(offset: -1.5), .abnormalDrop)
+        XCTAssertEqual(SkinTempBaseline.deviationBand(offset: 1.0), .normal, "exactly ±1 °C is still normal")
+    }
+
+    func testAnomalyFlags() {
+        // +1.2 °C vs baseline → abnormalRise; +0.8 °C vs last night → fluctuationRise.
+        let f = SkinTempBaseline.anomalyFlags(tonight: 32.2, baseline: 31.0, previousNight: 31.4)
+        XCTAssertTrue(f.abnormalRise)
+        XCTAssertFalse(f.abnormalDrop)
+        XCTAssertTrue(f.fluctuationRise)
+        XCTAssertFalse(f.fluctuationDrop)
+        XCTAssertTrue(f.any)
+
+        // A calm night within both bands → no flags.
+        let calm = SkinTempBaseline.anomalyFlags(tonight: 31.1, baseline: 31.0, previousNight: 31.0)
+        XCTAssertFalse(calm.any)
+
+        // A sharp DROP vs last night even when baseline is unknown.
+        let drop = SkinTempBaseline.anomalyFlags(tonight: 30.0, baseline: nil, previousNight: 31.0)
+        XCTAssertTrue(drop.fluctuationDrop)
+        XCTAssertFalse(drop.abnormalDrop, "no baseline → no abnormal classification")
+    }
+
+    func testReportWithAndWithoutBaseline() {
+        let prior = [night(1, 30.8), night(2, 31.0), night(3, 31.2)]   // baseline 31.0
+        let r = SkinTempBaseline.report(tonight: 32.5, priorNights: prior, previousNight: 31.0)
+        XCTAssertEqual(r.baselineC!, 31.0, accuracy: 1e-9)
+        XCTAssertEqual(r.offsetC!, 1.5, accuracy: 1e-9)
+        XCTAssertEqual(r.band, .abnormalRise)
+        XCTAssertTrue(r.flags.abnormalRise)
+
+        // Too little history → nightly value present, but no baseline/offset/band.
+        let thin = SkinTempBaseline.report(tonight: 32.5, priorNights: [night(1, 31)])
+        XCTAssertEqual(thin.nightlyC, 32.5, accuracy: 1e-9)
+        XCTAssertNil(thin.baselineC)
+        XCTAssertNil(thin.offsetC)
+        XCTAssertNil(thin.band)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SleepDetailMetricsTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SleepDetailMetricsTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import OpenRingKit
+
+/// SYNTHETIC-ONLY tests for per-stage HR + the movement timeline (#70).
+final class SleepDetailMetricsTests: XCTestCase {
+
+    /// A sleep-vitals epoch with explicit HR + uniform motion byte.
+    private func rec(_ counter: UInt32, hr: UInt8, motion: UInt8 = 1) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: 23)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xFF)
+        b[2] = UInt8((counter >> 8) & 0xFF); b[3] = UInt8(counter & 0xFF)
+        b[4] = hr; b[8] = 0x62
+        for k in 0..<5 { b[10 + k] = motion }
+        return BulkRecord(b)!
+    }
+
+    private let step: UInt32 = 150
+
+    func testAverageHRByStage() {
+        let epoch = Command.syncEpoch
+        func t(_ c: UInt32) -> Date { Date(timeIntervalSince1970: TimeInterval(Int(c) + epoch)) }
+
+        // Two deep epochs @ 50/52, two REM epochs @ 64/66.
+        var c: UInt32 = 1000
+        let deepStart = c
+        let r0 = rec(c, hr: 50); c += step
+        let r1 = rec(c, hr: 52); c += step
+        let deepEnd = c
+        let remStart = c
+        let r2 = rec(c, hr: 64); c += step
+        let r3 = rec(c, hr: 66); c += step
+        let remEnd = c + step
+
+        let segs = [
+            SleepSegment(start: t(deepStart), end: t(remEnd), stage: .inBed),
+            SleepSegment(start: t(deepStart), end: t(deepEnd), stage: .asleepDeep),
+            SleepSegment(start: t(remStart), end: t(remEnd), stage: .asleepREM),
+        ]
+        let byStage = SleepDetailMetrics.averageHRByStage(records: [r0, r1, r2, r3], segments: segs)
+        XCTAssertEqual(byStage[.asleepDeep], 51)
+        XCTAssertEqual(byStage[.asleepREM], 65)
+        XCTAssertNil(byStage[.asleepCore], "no light epochs → omitted")
+        XCTAssertNil(byStage[.inBed], "inBed excluded so stages don't double-count")
+    }
+
+    func testMovementLevels() {
+        var c: UInt32 = 0
+        let still = rec(c, hr: 55, motion: 1); c += step      // baseline → still
+        let light = rec(c, hr: 55, motion: 3); c += step      // 5×(3) = 15, not > 15 → light
+        let active = rec(c, hr: 55, motion: 20)               // 5×20 = 100 → active
+
+        let m = SleepDetailMetrics.movement(records: [still, light, active])
+        XCTAssertEqual(m.map(\.level), [.still, .light, .active])
+        XCTAssertEqual(m[0].magnitude, 0)
+        XCTAssertEqual(m[2].magnitude, 100)
+    }
+
+    func testMovementSummaryCounts() {
+        var c: UInt32 = 0
+        var recs: [BulkRecord] = []
+        for _ in 0..<6 { recs.append(rec(c, hr: 55, motion: 1)); c += step }   // still
+        for _ in 0..<3 { recs.append(rec(c, hr: 55, motion: 3)); c += step }   // light
+        for _ in 0..<1 { recs.append(rec(c, hr: 55, motion: 30)); c += step }  // active
+
+        let s = SleepDetailMetrics.movementSummary(records: recs)
+        XCTAssertEqual(s.still, 6)
+        XCTAssertEqual(s.light, 3)
+        XCTAssertEqual(s.active, 1)
+        XCTAssertEqual(s.total, 10)
+        XCTAssertEqual(s.levels.count, 10)
+        XCTAssertEqual(s.movementFraction, 0.4, accuracy: 1e-9)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SleepDetectionTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SleepDetectionTests.swift
@@ -58,4 +58,36 @@ final class SleepDetectionTests: XCTestCase {
         XCTAssertTrue(ActivityPeriod(activity: .active, start: base, end: base.addingTimeInterval(3600)).isActive)
         XCTAssertFalse(ActivityPeriod(activity: .sleep, start: base, end: base.addingTimeInterval(3600)).isActive)
     }
+
+    // MARK: #41 — wear / charging gate
+
+    /// A 4 h still motion block (would detect as sleep) sampled every 5 min.
+    private func stillNight() -> [MotionSample] {
+        (0..<48).map { MotionSample(time: base.addingTimeInterval(Double($0) * 5 * 60), movement: 1) }
+    }
+    private func temps(_ celsius: Double) -> [TemperatureSample] {
+        (0..<48).map { TemperatureSample(time: base.addingTimeInterval(Double($0) * 5 * 60), celsius: celsius) }
+    }
+
+    func testWearGateReclassifiesColdStillBlockAsActive() {
+        let motion = stillNight()
+        XCTAssertEqual(ActivityPeriod.detectFromMotion(motion).first?.activity, .sleep,
+                       "motion-only: a still block reads as sleep")
+        // Same motion, but skin temp ~22 °C (off-wrist / charging) -> no sleep survives.
+        let gated = ActivityPeriod.detectFromMotion(motion, temperatureSamples: temps(22))
+        XCTAssertFalse(gated.contains { $0.activity == .sleep },
+                       "cold (unworn) still block must not count as sleep")
+    }
+
+    func testWearGateKeepsWarmStillBlockAsSleep() {
+        let gated = ActivityPeriod.detectFromMotion(stillNight(), temperatureSamples: temps(32))
+        XCTAssertEqual(gated.first?.activity, .sleep, "worn (32 °C) still block stays sleep")
+    }
+
+    func testWearGateNoTemperatureLeavesDetectionUnchanged() {
+        let motion = stillNight()
+        XCTAssertEqual(ActivityPeriod.detectFromMotion(motion, temperatureSamples: []),
+                       ActivityPeriod.detectFromMotion(motion),
+                       "no temperature coverage -> identical to motion-only (absence ≠ unworn)")
+    }
 }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SleepScoreCompositeTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SleepScoreCompositeTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import OpenRingKit
+
+/// SYNTHETIC-ONLY tests for the 6-factor composite Sleep Score (#70). Controlled inputs;
+/// asserts tier cut-offs, factor renormalisation when optional inputs are absent, and that a
+/// good night out-scores a poor one. No real health values.
+final class SleepScoreCompositeTests: XCTestCase {
+
+    private let h = 3600.0
+
+    func testTierCutoffs() {
+        XCTAssertEqual(SleepScore.Tier.of(85), .excellent)
+        XCTAssertEqual(SleepScore.Tier.of(84), .good)
+        XCTAssertEqual(SleepScore.Tier.of(70), .good)
+        XCTAssertEqual(SleepScore.Tier.of(69), .needsImprovement)
+    }
+
+    func testDurationOnlyScoreStillGraded() {
+        // The ported duration-only piece is preserved (graded, not a 0/100 step — #28).
+        XCTAssertEqual(SleepScore.score(durationSeconds: 4 * 3600), 50, accuracy: 0.001)
+        XCTAssertEqual(SleepScore.score(durationSeconds: 8 * 3600), 100, accuracy: 0.001)
+    }
+
+    func testGoodNightScoresHigh() {
+        // 8 h asleep, little awake, healthy deep+rem, high efficiency, low HR, on baseline.
+        let input = SleepScore.CompositeInput(
+            totalAsleep: 8 * h, timeAwake: 10 * 60, efficiency: 0.94,
+            deep: 1.5 * h, light: 4.5 * h, rem: 2 * h,
+            restingHR: 48, tempOffsetC: 0.1)
+        let c = SleepScore.composite(input)
+        XCTAssertGreaterThanOrEqual(c.score, 85)
+        XCTAssertEqual(c.tier, .excellent)
+        XCTAssertEqual(c.factors.count, 6, "all six factors present")
+    }
+
+    func testPoorNightScoresLow() {
+        // 4 h asleep, lots awake, scant deep/rem, poor efficiency, high HR, big temp deviation.
+        let input = SleepScore.CompositeInput(
+            totalAsleep: 4 * h, timeAwake: 90 * 60, efficiency: 0.55,
+            deep: 0.2 * h, light: 3.7 * h, rem: 0.1 * h,
+            restingHR: 78, tempOffsetC: 1.5)
+        let c = SleepScore.composite(input)
+        XCTAssertLessThan(c.score, 60)
+        XCTAssertEqual(c.tier, .needsImprovement)
+    }
+
+    func testGoodNightOutScoresPoorNight() {
+        let good = SleepScore.composite(.init(totalAsleep: 8 * h, timeAwake: 10 * 60,
+            efficiency: 0.93, deep: 1.5 * h, light: 4.5 * h, rem: 2 * h))
+        let poor = SleepScore.composite(.init(totalAsleep: 4 * h, timeAwake: 80 * 60,
+            efficiency: 0.6, deep: 0.2 * h, light: 3.7 * h, rem: 0.1 * h))
+        XCTAssertGreaterThan(good.score, poor.score)
+    }
+
+    func testMissingOptionalFactorsAreRenormalised() {
+        // Without HR + temp, only 4 factors are present and the score still spans 0…100.
+        let input = SleepScore.CompositeInput(
+            totalAsleep: 8 * h, timeAwake: 10 * 60, efficiency: 0.93,
+            deep: 1.5 * h, light: 4.5 * h, rem: 2 * h)   // no restingHR / tempOffsetC
+        let c = SleepScore.composite(input)
+        XCTAssertEqual(c.factors.count, 4)
+        XCTAssertNil(c.factors[.heartRate])
+        XCTAssertNil(c.factors[.temperature])
+        XCTAssertGreaterThanOrEqual(c.score, 0)
+        XCTAssertLessThanOrEqual(c.score, 100)
+        XCTAssertGreaterThanOrEqual(c.score, 85, "a strong night still scores high without HR/temp")
+    }
+
+    func testScoreAlwaysInRange() {
+        let zero = SleepScore.composite(.init(totalAsleep: 0, timeAwake: 8 * h, efficiency: 0,
+            deep: 0, light: 0, rem: 0))
+        XCTAssertGreaterThanOrEqual(zero.score, 0)
+        XCTAssertLessThanOrEqual(zero.score, 100)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SleepStagingTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SleepStagingTests.swift
@@ -1,0 +1,195 @@
+import XCTest
+@testable import OpenRingKit
+
+// SYNTHETIC-ONLY tests for the sleep-stage classifier. We have no per-epoch ground
+// truth (the ring sends no hypnogram, §5.3), so these build controlled epoch
+// sequences with a known intended stage and assert the classifier recovers it, plus
+// one "constructed night" that checks the stage totals partition the night the way
+// the RingConn app's night totals do (light ≫ rem > deep, modest awake).
+final class SleepStagingTests: XCTestCase {
+
+    // MARK: - Record builders
+
+    /// A sleep-vitals epoch (sub 0x62) with explicit HR/HRV and a uniform motion byte.
+    private func vrec(_ counter: UInt32, hr: UInt8, hrv: UInt8 = 0, motion: UInt8 = 1) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: 23)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xFF)
+        b[2] = UInt8((counter >> 8) & 0xFF); b[3] = UInt8(counter & 0xFF)
+        b[4] = hr; b[5] = hrv; b[8] = 0x62
+        for k in 0..<5 { b[10 + k] = motion }
+        return BulkRecord(b)!
+    }
+
+    /// An active/awake epoch (sub 0x12, high motion, no vitals).
+    private func arec(_ counter: UInt32, motion: UInt8 = 0x14) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: 23)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xFF)
+        b[2] = UInt8((counter >> 8) & 0xFF); b[3] = UInt8(counter & 0xFF)
+        b[8] = 0x12
+        for k in 0..<5 { b[10 + k] = motion }
+        return BulkRecord(b)!
+    }
+
+    private let step: UInt32 = 150
+
+    /// Fraction of asleep (non-inBed, non-awake) time spent in `stage`.
+    private func fraction(_ segs: [SleepSegment], _ stage: SleepStage) -> Double {
+        let totals = SleepStaging.stageTotals(segs)
+        let asleep = (totals[.asleepCore] ?? 0) + (totals[.asleepDeep] ?? 0) + (totals[.asleepREM] ?? 0)
+        guard asleep > 0 else { return 0 }
+        return (totals[stage] ?? 0) / asleep
+    }
+
+    // MARK: - Single-stage recovery
+
+    func testStillFlatLowHRIsMostlyDeep() {
+        // A calm night: flat low HR, no motion -> should read as predominantly Deep.
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+        for _ in 0..<120 { recs.append(vrec(c, hr: 50)); c += step }   // flat, still, low
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+
+        let segs = SleepStaging.classify(from: recs)
+        XCTAssertFalse(segs.isEmpty)
+        XCTAssertGreaterThan(fraction(segs, .asleepDeep), 0.8, "calm flat low HR -> mostly Deep")
+        XCTAssertEqual(fraction(segs, .asleepREM), 0.0, "no variability/elevation -> no REM")
+    }
+
+    func testElevatedFlatHRLowMotionIsREM() {
+        // Deep baseline + a clearly elevated, still block -> elevated block is REM.
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+        for _ in 0..<100 { recs.append(vrec(c, hr: 50)); c += step }          // Deep baseline
+        let remStart = c
+        for _ in 0..<40 { recs.append(vrec(c, hr: 66)); c += step }           // elevated, still
+        let remEnd = c
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+
+        let segs = SleepStaging.classify(from: recs)
+        XCTAssertGreaterThan(fraction(segs, .asleepREM), 0.2, "elevated still block -> REM present")
+        // The bulk of REM should sit in the elevated window (a couple boundary epochs
+        // may bleed in due to transition variability — tolerate ±2 epochs).
+        let lo = Date(timeIntervalSince1970: Double(Int(remStart) + Command.syncEpoch))
+            .addingTimeInterval(-2 * Double(step))
+        let hi = Date(timeIntervalSince1970: Double(Int(remEnd) + Command.syncEpoch))
+            .addingTimeInterval(2 * Double(step))
+        let remSegs = segs.filter { $0.stage == .asleepREM }
+        let remTotal = remSegs.reduce(0.0) { $0 + $1.duration }
+        let remInWindow = remSegs.filter { $0.start >= lo && $0.end <= hi }.reduce(0.0) { $0 + $1.duration }
+        XCTAssertGreaterThan(remTotal, 0)
+        XCTAssertGreaterThanOrEqual(remInWindow / remTotal, 0.8, "REM concentrates in the elevated window")
+    }
+
+    func testVariabilitySeparatesREMFromLightAtSameMeanHR() {
+        // Two still blocks with the SAME mean HR (58): one flat, one oscillating.
+        // Variability — not absolute HR — must put the oscillating one in REM.
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+        let flatStart = c
+        for _ in 0..<100 { recs.append(vrec(c, hr: 55)); c += step }          // flat
+        let varStart = c
+        // 2-epoch steps so runs survive smoothing; mean 55, swings ±10.
+        for k in 0..<40 { recs.append(vrec(c, hr: (k / 2) % 2 == 0 ? 45 : 65)); c += step }
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+
+        let segs = SleepStaging.classify(from: recs)
+        let varLo = Date(timeIntervalSince1970: Double(Int(varStart) + Command.syncEpoch))
+        let flatLo = Date(timeIntervalSince1970: Double(Int(flatStart) + Command.syncEpoch))
+        let remInVar = segs.filter { $0.stage == .asleepREM && $0.start >= varLo }
+            .reduce(0.0) { $0 + $1.duration }
+        let remInFlat = segs.filter { $0.stage == .asleepREM && $0.start >= flatLo && $0.start < varLo }
+            .reduce(0.0) { $0 + $1.duration }
+        XCTAssertGreaterThan(remInVar, 0, "variable block reads as REM")
+        XCTAssertGreaterThan(remInVar, remInFlat, "REM concentrates in the variable block, not the flat one")
+    }
+
+    func testHighMotionMidSleepIsAwake() {
+        // A burst of motion inside the night must surface as an Awake segment.
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+        for _ in 0..<60 { recs.append(vrec(c, hr: 52)); c += step }
+        let wakeStart = c
+        for _ in 0..<3 { recs.append(arec(c, motion: 0x16)); c += step }     // mid-sleep movement
+        for _ in 0..<60 { recs.append(vrec(c, hr: 52)); c += step }
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+
+        let segs = SleepStaging.classify(from: recs)
+        let awake = segs.filter { $0.stage == .awake }
+        XCTAssertFalse(awake.isEmpty, "mid-sleep motion -> Awake segment")
+        let wt = Date(timeIntervalSince1970: Double(Int(wakeStart) + Command.syncEpoch))
+        XCTAssertTrue(awake.contains { abs($0.start.timeIntervalSince(wt)) < Double(step) * 4 },
+                      "awake segment aligns with the motion burst")
+        // Awake stays inside the inBed window.
+        let inBed = segs.first { $0.stage == .inBed }!
+        for a in awake {
+            XCTAssertGreaterThanOrEqual(a.start, inBed.start)
+            XCTAssertLessThanOrEqual(a.end, inBed.end)
+        }
+    }
+
+    // MARK: - Constructed-night partition (sanity vs. RingConn night totals)
+
+    func testConstructedNightPartitionsLikeATracker() {
+        // ~5 sleep cycles: Light-heavy with periodic Deep troughs and elevated REM,
+        // plus brief awakenings. We assert the SHAPE (light ≫ rem > deep, modest awake,
+        // inBed ≈ asleep + awake) the way the app's night totals do — NOT exact minutes.
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<8 { recs.append(arec(c)); c += step }                   // sleep onset (awake)
+        for cycle in 0..<5 {
+            for _ in 0..<10 { recs.append(vrec(c, hr: 56, hrv: 60)); c += step }   // Light
+            for _ in 0..<8  { recs.append(vrec(c, hr: 50, hrv: 70)); c += step }   // Deep
+            for _ in 0..<8  { recs.append(vrec(c, hr: 56, hrv: 60)); c += step }   // Light
+            for _ in 0..<10 { recs.append(vrec(c, hr: 62, hrv: 45)); c += step }   // REM (elevated)
+            if cycle < 4 { for _ in 0..<2 { recs.append(arec(c, motion: 0x15)); c += step } } // brief wake
+        }
+        for _ in 0..<8 { recs.append(arec(c)); c += step }                   // morning (awake)
+
+        let segs = SleepStaging.classify(from: recs)
+        XCTAssertFalse(segs.isEmpty)
+        let s = SleepStaging.summary(segs)
+
+        // All four stages present.
+        XCTAssertGreaterThan(s.deep, 0); XCTAssertGreaterThan(s.rem, 0)
+        XCTAssertGreaterThan(s.light, 0); XCTAssertGreaterThan(s.awake, 0)
+
+        // Architecture sanity: Light dominates, REM exceeds Deep (as in the GT night:
+        // light 285m > rem 102m > deep 70m). Not exact-minute matching.
+        XCTAssertGreaterThan(s.light, s.rem, "Light is the largest asleep stage")
+        XCTAssertGreaterThan(s.rem, s.deep, "REM exceeds Deep")
+
+        // Totals partition the night: inBed ≈ asleep + awake (within one epoch of rounding).
+        XCTAssertEqual(s.inBed, s.totalAsleep + s.awake, accuracy: Double(step))
+        // Efficiency in a plausible nightly range.
+        XCTAssertGreaterThan(s.efficiency, 0.6)
+        XCTAssertLessThanOrEqual(s.efficiency, 1.0)
+
+        // stageTotals agrees with the summary.
+        let totals = SleepStaging.stageTotals(segs)
+        XCTAssertEqual(totals[.asleepDeep], s.deep)
+        XCTAssertEqual(SleepStaging.totalAsleep(segs), s.totalAsleep, accuracy: 0.001)
+    }
+
+    func testNoSleepBlockYieldsNoSegments() {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<80 { recs.append(arec(c, motion: 0x18)); c += step }
+        XCTAssertTrue(SleepStaging.classify(from: recs).isEmpty, "all-active -> no staging")
+        XCTAssertTrue(SleepStaging.stageTotals([]).isEmpty)
+        XCTAssertEqual(SleepStaging.totalAsleep([]), 0)
+    }
+
+    func testBulkSleepStagedSegmentsDelegatesToClassifier() {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 0x0c220000
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+        for _ in 0..<120 { recs.append(vrec(c, hr: 50)); c += step }
+        for _ in 0..<12 { recs.append(arec(c)); c += step }
+        XCTAssertEqual(BulkSleep.stagedSegments(from: recs), SleepStaging.classify(from: recs),
+                       "BulkSleep.stagedSegments is a thin wrapper over SleepStaging.classify")
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SleepStressTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SleepStressTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import OpenRingKit
+
+/// SYNTHETIC-ONLY tests for the overnight stress mapping (#71). Asserts the RMSSD→score curve
+/// is monotonic decreasing, the app's band thresholds, the median-based overnight score, and
+/// the per-band state durations. No fabricated health values.
+final class SleepStressTests: XCTestCase {
+
+    func testBandThresholds() {
+        XCTAssertEqual(SleepStress.Band.of(1), .relaxed)
+        XCTAssertEqual(SleepStress.Band.of(29), .relaxed)
+        XCTAssertEqual(SleepStress.Band.of(30), .normal)
+        XCTAssertEqual(SleepStress.Band.of(59), .normal)
+        XCTAssertEqual(SleepStress.Band.of(60), .medium)
+        XCTAssertEqual(SleepStress.Band.of(79), .medium)
+        XCTAssertEqual(SleepStress.Band.of(80), .high)
+        XCTAssertEqual(SleepStress.Band.of(100), .high)
+    }
+
+    func testScoreIsMonotonicDecreasingInRMSSD() {
+        // Higher HRV → lower stress.
+        let lowHRV = SleepStress.score(rmssdMs: 15)
+        let midHRV = SleepStress.score(rmssdMs: 40)
+        let highHRV = SleepStress.score(rmssdMs: 70)
+        XCTAssertGreaterThan(lowHRV, midHRV)
+        XCTAssertGreaterThan(midHRV, highHRV)
+    }
+
+    func testScoreClampedToReferenceWindow() {
+        // Beyond the reference bounds the score saturates, never escaping 0…100.
+        let veryHigh = SleepStress.score(rmssdMs: 200)
+        let veryLow = SleepStress.score(rmssdMs: 2)
+        XCTAssertEqual(veryHigh, Int(SleepStress.lowScore))
+        XCTAssertEqual(veryLow, Int(SleepStress.highScore))
+        XCTAssertGreaterThanOrEqual(veryHigh, 0)
+        XCTAssertLessThanOrEqual(veryLow, 100)
+    }
+
+    func testRestedBoundIsRelaxedAndStressedBoundIsHigh() {
+        XCTAssertEqual(SleepStress.Band.of(SleepStress.score(rmssdMs: SleepStress.restedRMSSD)), .relaxed)
+        XCTAssertEqual(SleepStress.Band.of(SleepStress.score(rmssdMs: SleepStress.stressedRMSSD)), .high)
+    }
+
+    func testOvernightScoreUsesMedian() {
+        // Median of [10,40,40,40,200] is 40; the lone outliers don't drag it.
+        let s = SleepStress.overnightScore(rmssd: [10, 40, 40, 40, 200])
+        XCTAssertEqual(s, SleepStress.score(rmssdMs: 40))
+        XCTAssertNil(SleepStress.overnightScore(rmssd: []))
+        XCTAssertNil(SleepStress.overnightScore(rmssd: [0, 0]), "non-positive RMSSD dropped")
+    }
+
+    func testStateDurations() {
+        // Two relaxed (high HRV) + one high-stress (low HRV) epoch.
+        let durations = SleepStress.stateDurations(rmssd: [70, 70, 15], epochSeconds: 150)
+        XCTAssertEqual(durations[.relaxed] ?? 0, 300, accuracy: 1e-9)
+        XCTAssertEqual(durations[.high] ?? 0, 150, accuracy: 1e-9)
+        XCTAssertNil(durations[.medium])
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SleepWindowTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SleepWindowTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import OpenRingKit
+
+// Window math for the sleep-schedule abstraction. Pure date math (UTC calendar so the
+// assertions are timezone-stable), mirroring what `ManualSleepSchedule` does in the app.
+final class SleepWindowTests: XCTestCase {
+
+    /// Fixed UTC calendar so "local midnight" is deterministic in CI.
+    private var utc: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+
+    private func date(_ iso: String) -> Date {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: iso)!
+    }
+
+    // bed 22:30 → wake 06:30: an 8 h window that crosses midnight. Reference is the
+    // afternoon AFTER the night, so the chosen wake is that same morning and the bedtime
+    // lands on the PREVIOUS calendar day.
+    func testCrossMidnightWindow() {
+        let ref = date("2026-06-15T14:00:00Z")   // afternoon
+        let w = SleepWindow.interval(bedMinutes: 22 * 60 + 30,   // 1350
+                                     wakeMinutes: 6 * 60 + 30,    // 390
+                                     nightEndingNear: ref,
+                                     calendar: utc)
+        XCTAssertNotNil(w)
+        XCTAssertEqual(w?.end, date("2026-06-15T06:30:00Z"))     // this morning's wake
+        XCTAssertEqual(w?.start, date("2026-06-14T22:30:00Z"))   // previous evening's bed
+        XCTAssertEqual(w?.duration ?? 0, 8 * 3600, accuracy: 1)
+    }
+
+    // bed 01:00 → wake 06:30: a same-day (no midnight cross) window.
+    func testSameDayWindow() {
+        let ref = date("2026-06-15T14:00:00Z")
+        let w = SleepWindow.interval(bedMinutes: 1 * 60,         // 60
+                                     wakeMinutes: 6 * 60 + 30,   // 390
+                                     nightEndingNear: ref,
+                                     calendar: utc)
+        XCTAssertEqual(w?.start, date("2026-06-15T01:00:00Z"))
+        XCTAssertEqual(w?.end, date("2026-06-15T06:30:00Z"))
+        XCTAssertEqual(w?.duration ?? 0, 5.5 * 3600, accuracy: 1)
+    }
+
+    // The wake nearest the reference is chosen. At 02:00 (mid-sleep) the in-progress
+    // night's wake (a few hours ahead) is nearer than the prior morning's.
+    func testPicksNearestWake() {
+        let ref = date("2026-06-15T02:00:00Z")
+        let w = SleepWindow.interval(bedMinutes: 22 * 60 + 30,
+                                     wakeMinutes: 6 * 60 + 30,
+                                     nightEndingNear: ref,
+                                     calendar: utc)
+        XCTAssertEqual(w?.end, date("2026-06-15T06:30:00Z"))
+        XCTAssertEqual(w?.start, date("2026-06-14T22:30:00Z"))
+    }
+
+    // A degenerate bed == wake schedule yields no window (rather than a 24 h or 0-length one).
+    func testDegenerateScheduleIsNil() {
+        let ref = date("2026-06-15T14:00:00Z")
+        XCTAssertNil(SleepWindow.interval(bedMinutes: 390, wakeMinutes: 390,
+                                          nightEndingNear: ref, calendar: utc))
+    }
+
+    func testMinutesHelper() {
+        XCTAssertEqual(SleepWindow.minutes(hour: 22, minute: 30), 1350)
+        XCTAssertEqual(SleepWindow.minutes(hour: 0, minute: 0), 0)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SleepWindowTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SleepWindowTests.swift
@@ -68,4 +68,37 @@ final class SleepWindowTests: XCTestCase {
         XCTAssertEqual(SleepWindow.minutes(hour: 22, minute: 30), 1350)
         XCTAssertEqual(SleepWindow.minutes(hour: 0, minute: 0), 0)
     }
+
+    // MARK: isOvernightBlock — gate that keeps a worn daytime block from being staged as
+    // "last night" and overwriting the real night (adversarial review #1).
+
+    // A pre-midnight onset (23:00 → 07:00) is overnight.
+    func testOvernightPreMidnight() {
+        XCTAssertTrue(SleepWindow.isOvernightBlock(
+            start: date("2026-06-14T23:00:00Z"), end: date("2026-06-15T07:00:00Z"), calendar: utc))
+    }
+
+    // A post-midnight onset (01:00 → 08:00) is overnight (matches the PRIOR day's night anchor).
+    func testOvernightPostMidnight() {
+        XCTAssertTrue(SleepWindow.isOvernightBlock(
+            start: date("2026-06-15T01:00:00Z"), end: date("2026-06-15T08:00:00Z"), calendar: utc))
+    }
+
+    // An afternoon nap (13:00 → 15:00) is NOT overnight — the case the gate exists to reject.
+    func testAfternoonNapNotOvernight() {
+        XCTAssertFalse(SleepWindow.isOvernightBlock(
+            start: date("2026-06-15T13:00:00Z"), end: date("2026-06-15T15:00:00Z"), calendar: utc))
+    }
+
+    // A long sedentary daytime block (10:00 → 16:00, e.g. a meeting/movie marathon) is NOT overnight.
+    func testLongDaytimeBlockNotOvernight() {
+        XCTAssertFalse(SleepWindow.isOvernightBlock(
+            start: date("2026-06-15T10:00:00Z"), end: date("2026-06-15T16:00:00Z"), calendar: utc))
+    }
+
+    // An early-evening onset (19:30 → 04:00) is overnight (overlaps the same-day 18:00 anchor).
+    func testEarlyEveningOnsetOvernight() {
+        XCTAssertTrue(SleepWindow.isOvernightBlock(
+            start: date("2026-06-14T19:30:00Z"), end: date("2026-06-15T04:00:00Z"), calendar: utc))
+    }
 }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/StepAccumulatorTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/StepAccumulatorTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import OpenRingKit
+
+// Step accumulation (#34): fold the ring's since-handoff raw counter into per-day deltas,
+// reset-aware and midnight-aware. These cases pin the behavior the live BLE path can't
+// easily test: a normal climb, the no-baseline first reading, a mid-day reset/handoff vs the
+// expected midnight reset, a 16-bit wraparound, and "no movement" (which must NOT double-count).
+final class StepAccumulatorTests: XCTestCase {
+
+    func testClimbCountsTheDelta() {
+        let u = StepAccumulator.update(previousRaw: 100, newRaw: 150, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 50)
+        XCTAssertFalse(u.isReset)
+        XCTAssertFalse(u.isAnomalousReset)
+    }
+
+    func testNoMovementAddsNothing() {
+        // Same raw counter twice in a row must add 0 — the keepalive re-reads the descriptor
+        // every cycle, so a flat counter must not keep crediting steps.
+        let u = StepAccumulator.update(previousRaw: 4321, newRaw: 4321, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 0)
+        XCTAssertFalse(u.isReset)
+    }
+
+    func testFirstReadingHasNoBaselineAndCountsNothing() {
+        // previousRaw == nil: we can't tell how many raw steps predate us, so adopt the reading
+        // as the baseline and count none (don't retro-count someone else's steps onto today).
+        let u = StepAccumulator.update(previousRaw: nil, newRaw: 8000, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 0)
+        XCTAssertFalse(u.isReset)
+        XCTAssertFalse(u.isAnomalousReset)
+    }
+
+    func testMidDayResetCountsNewValueAndFlagsAnomaly() {
+        // Counter dropped within the same day (official app took over / ring rebooted): the new
+        // value is the post-reset count, and it's surfaced as anomalous so the caller can log it.
+        let u = StepAccumulator.update(previousRaw: 5000, newRaw: 120, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 120)
+        XCTAssertTrue(u.isReset)
+        XCTAssertTrue(u.isAnomalousReset)
+    }
+
+    func testMidnightResetCountsNewValueButIsNotAnomalous() {
+        // A drop across midnight is the official app's normal daily reset — still a reset (add
+        // the new value to the new day), but NOT anomalous.
+        let u = StepAccumulator.update(previousRaw: 9000, newRaw: 50, dayChanged: true)
+        XCTAssertEqual(u.deltaToAdd, 50)
+        XCTAssertTrue(u.isReset)
+        XCTAssertFalse(u.isAnomalousReset)
+    }
+
+    func testMidnightClimbCreditsIncrementalDeltaToNewDay() {
+        // Official app NOT running: the ring's counter keeps climbing across midnight. The
+        // incremental delta (not the whole counter) is what the new day earns — anything else
+        // would bleed the prior day's accumulated baseline into the new day.
+        let u = StepAccumulator.update(previousRaw: 9000, newRaw: 9100, dayChanged: true)
+        XCTAssertEqual(u.deltaToAdd, 100)
+        XCTAssertFalse(u.isReset)
+        XCTAssertFalse(u.isAnomalousReset)
+    }
+
+    func testWraparoundIsTreatedAsAReset() {
+        // The counter is 16-bit (DeviceStatus.steps, max 65535). A wrap near the top reads as a
+        // drop and is treated as a reset (count the wrapped value) — indistinguishable from a
+        // real reset without more data, and a 65k-step handoff window is implausible anyway.
+        let u = StepAccumulator.update(previousRaw: 65500, newRaw: 30, dayChanged: false)
+        XCTAssertEqual(u.deltaToAdd, 30)
+        XCTAssertTrue(u.isReset)
+    }
+
+    func testResetFlagIsNeverSetOnAClimb() {
+        // isAnomalousReset must only ever be true alongside isReset.
+        for dayChanged in [true, false] {
+            let u = StepAccumulator.update(previousRaw: 10, newRaw: 20, dayChanged: dayChanged)
+            XCTAssertFalse(u.isReset)
+            XCTAssertFalse(u.isAnomalousReset)
+        }
+    }
+
+    func testSummingDeltasReconstructsADayOfSteps() {
+        // End-to-end fold: a session's worth of readings (a climb, a mid-day reset, more climb)
+        // should sum to the steps actually taken: 0→1200, reset, 0→800 = 2000.
+        let readings: [(prev: Int?, raw: Int)] = [
+            (nil, 0),      // baseline
+            (0, 400),      // +400
+            (400, 1200),   // +800
+            (1200, 0),     // reset (official app handed off) — counter back to 0
+            (0, 300),      // +300
+            (300, 800),    // +500
+        ]
+        var total = 0
+        for r in readings {
+            total += StepAccumulator.update(previousRaw: r.prev, newRaw: r.raw, dayChanged: false).deltaToAdd
+        }
+        XCTAssertEqual(total, 400 + 800 + 0 + 300 + 500)   // 2000
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SyncCursorTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SyncCursorTests.swift
@@ -37,6 +37,36 @@ final class SyncCursorTests: XCTestCase {
         XCTAssertEqual(c.last(.heartRate), t2)
     }
 
+    func testSelectNewStagedDoesNotMutateUntilApplied() {
+        let c = SyncCursor()
+        let (fresh, advanced) = c.selectNewStaged([
+            QuantitySample(kind: .heartRate, start: t1, value: 60),
+            QuantitySample(kind: .heartRate, start: t0, value: 58),
+        ])
+        XCTAssertEqual(fresh.map(\.start), [t0, t1])     // sorted, both fresh
+        XCTAssertNil(c.last(.heartRate))                 // original cursor untouched
+        XCTAssertEqual(advanced.last(.heartRate), t1)    // advance only on the returned copy
+    }
+
+    func testStagedAdvanceIgnoredLeavesSamplesRetriable() {
+        // Simulate a failed commit: stage the advance but DON'T adopt `advanced`. The original
+        // cursor must still treat the same samples as new so they're retried (#22).
+        let c = SyncCursor()
+        _ = c.selectNewStaged([QuantitySample(kind: .heartRate, start: t1, value: 60)])
+        XCTAssertTrue(c.isNew(.heartRate, t1))
+    }
+
+    func testAdvancedKindsReportsOnlyMovedCursors() {
+        let base = SyncCursor()
+        var moved = base
+        _ = moved.selectNew([
+            QuantitySample(kind: .heartRate, start: t1, value: 60),
+            QuantitySample(kind: .spo2, start: t1, value: 0.97),
+        ])
+        XCTAssertEqual(Set(moved.advancedKinds(since: base)), [.heartRate, .spo2])
+        XCTAssertTrue(moved.advancedKinds(since: moved).isEmpty)   // no diff with self
+    }
+
     func testUnitsMatchHealthKitMapping() {
         XCTAssertEqual(MetricKind.spo2.unit, "fraction")
         XCTAssertEqual(MetricKind.hrvSDNN.unit, "ms")

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/SyncObservabilityTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/SyncObservabilityTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import OpenRingKit
+
+final class SyncObservabilityTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+    private let policy = SyncAlertPolicy(staleSyncThreshold: 6 * 3600,
+                                         lowBatteryThreshold: 15,
+                                         renotifyInterval: 6 * 3600)
+
+    // MARK: activeConditions
+
+    func testFreshSyncHealthyHasNoConditions() {
+        let active = policy.activeConditions(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-3600),  // 1h ago — fresh
+            batteryPercent: 80,
+            healthAuthorized: true,
+            healthEverAuthorized: true)
+        XCTAssertTrue(active.isEmpty)
+    }
+
+    func testNeverSyncedDoesNotFireStaleness() {
+        // No baseline yet — a brand-new user is not nagged about staleness.
+        let active = policy.activeConditions(
+            now: now, lastSuccessfulSync: nil, batteryPercent: 80,
+            healthAuthorized: true, healthEverAuthorized: true)
+        XCTAssertFalse(active.contains(.notSynced))
+    }
+
+    func testStaleSyncFires() {
+        let active = policy.activeConditions(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),  // 7h ago > 6h
+            batteryPercent: 80,
+            healthAuthorized: true, healthEverAuthorized: true)
+        XCTAssertTrue(active.contains(.notSynced))
+    }
+
+    func testLowBatteryFiresAtThresholdAndNotAbove() {
+        XCTAssertTrue(policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: 15,
+            healthAuthorized: true, healthEverAuthorized: true).contains(.lowBattery))
+        XCTAssertFalse(policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: 16,
+            healthAuthorized: true, healthEverAuthorized: true).contains(.lowBattery))
+    }
+
+    func testNilBatterySkipsBatteryCheck() {
+        let active = policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: nil,
+            healthAuthorized: true, healthEverAuthorized: true)
+        XCTAssertFalse(active.contains(.lowBattery))
+    }
+
+    func testHealthAuthLostOnlyWhenPreviouslyAuthorized() {
+        // Never authorized → not an "auth lost" condition.
+        XCTAssertFalse(policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: 80,
+            healthAuthorized: false, healthEverAuthorized: false).contains(.healthAuthLost))
+        // Was authorized, now off → fires.
+        XCTAssertTrue(policy.activeConditions(
+            now: now, lastSuccessfulSync: now, batteryPercent: 80,
+            healthAuthorized: false, healthEverAuthorized: true).contains(.healthAuthLost))
+    }
+
+    // MARK: alertsToFire (debounce)
+
+    func testAlertFiresWhenNeverFiredBefore() {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),
+            batteryPercent: 80, healthAuthorized: true, healthEverAuthorized: true,
+            lastFired: [:])
+        XCTAssertEqual(fire, [.notSynced])
+    }
+
+    func testAlertSuppressedInsideRenotifyWindow() {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),
+            batteryPercent: 80, healthAuthorized: true, healthEverAuthorized: true,
+            lastFired: [.notSynced: now.addingTimeInterval(-3600)])  // fired 1h ago < 6h window
+        XCTAssertTrue(fire.isEmpty)
+    }
+
+    func testAlertReFiresAfterRenotifyWindow() {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),
+            batteryPercent: 80, healthAuthorized: true, healthEverAuthorized: true,
+            lastFired: [.notSynced: now.addingTimeInterval(-7 * 3600)])  // fired 7h ago > 6h window
+        XCTAssertEqual(fire, [.notSynced])
+    }
+
+    func testMultipleConditionsReturnedInStableOrder() {
+        let fire = policy.alertsToFire(
+            now: now,
+            lastSuccessfulSync: now.addingTimeInterval(-7 * 3600),  // notSynced
+            batteryPercent: 5,                                      // lowBattery
+            healthAuthorized: false, healthEverAuthorized: true,    // healthAuthLost
+            lastFired: [:])
+        XCTAssertEqual(fire, [.notSynced, .lowBattery, .healthAuthLost])
+    }
+
+    // MARK: BoundedLog
+
+    func testBoundedLogAppendsUnderLimit() {
+        let out = BoundedLog.appendCapped(3, to: [1, 2], limit: 5)
+        XCTAssertEqual(out, [1, 2, 3])
+    }
+
+    func testBoundedLogTrimsOldestOverLimit() {
+        let out = BoundedLog.appendCapped(4, to: [1, 2, 3], limit: 3)
+        XCTAssertEqual(out, [2, 3, 4])  // newest survive, oldest (1) dropped
+    }
+
+    func testBoundedLogZeroLimitIsEmpty() {
+        XCTAssertEqual(BoundedLog.appendCapped(1, to: [1, 2], limit: 0), [])
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/TrendsEngineTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/TrendsEngineTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import OpenRingKit
+
+final class TrendsEngineTests: XCTestCase {
+
+    private static let cal = Calendar(identifier: .gregorian)
+    private static let epoch = Date(timeIntervalSince1970: 0)
+
+    private func day(_ offset: Int) -> Date {
+        Self.cal.date(byAdding: .day, value: offset, to: Self.epoch)!
+    }
+
+    // MARK: Rolling averages — basic
+
+    func testRollingAveragesSteps() {
+        let points = (0..<7).map { i in
+            TrendsEngine.DailyPoint(date: day(i), steps: (i + 1) * 1000)
+        }
+        let avgs = TrendsEngine.rollingAverages(points, window: 7)
+        // steps: 1000+2000+...+7000 = 28000 / 7 = 4000
+        XCTAssertEqual(avgs.steps ?? 0, 4000, accuracy: 0.01)
+    }
+
+    func testRollingAveragesSleepScore() {
+        let scores = [80, 85, 90, 75, 0, 88, 82]  // 0 = not computed → excluded
+        let points = scores.enumerated().map { (i, s) in
+            TrendsEngine.DailyPoint(date: day(i), sleepScore: s)
+        }
+        let avgs = TrendsEngine.rollingAverages(points, window: 7)
+        // Excluding 0: (80+85+90+75+88+82)/6 = 500/6 ≈ 83.33
+        XCTAssertEqual(avgs.sleepScore ?? 0, 500.0 / 6.0, accuracy: 0.01)
+    }
+
+    func testRollingAveragesHRGuard() {
+        // Values ≤ 29 bpm are excluded (the APK SQL guard)
+        let hrs: [Double?] = [0, 29, 65, 72, nil, 68, 70]
+        let points = hrs.enumerated().map { (i, hr) in
+            TrendsEngine.DailyPoint(date: day(i), sleepHRAvg: hr)
+        }
+        let avgs = TrendsEngine.rollingAverages(points, window: 7)
+        // Valid: 65, 72, 68, 70 → mean = 275/4 = 68.75
+        XCTAssertEqual(avgs.sleepHRAvg ?? 0, 68.75, accuracy: 0.01)
+    }
+
+    func testRollingAveragesAllNilReturnsNil() {
+        let points = (0..<7).map { i in TrendsEngine.DailyPoint(date: day(i)) }
+        let avgs = TrendsEngine.rollingAverages(points, window: 7)
+        XCTAssertNil(avgs.steps)
+        XCTAssertNil(avgs.sleepHRAvg)
+    }
+
+    func testRollingWindowLimitedByAvailablePoints() {
+        // Only 3 points available for a 7-day window → averages just those 3
+        let points = [1000, 2000, 3000].enumerated().map { (i, s) in
+            TrendsEngine.DailyPoint(date: day(i), steps: s)
+        }
+        let avgs = TrendsEngine.rollingAverages(points, window: 7)
+        XCTAssertEqual(avgs.steps ?? 0, 2000, accuracy: 0.01)
+    }
+
+    // MARK: Trend direction
+
+    func testTrendUp() {
+        // Recent 7 days much higher than prior 7 days
+        var points = (0..<7).map { i in TrendsEngine.DailyPoint(date: day(i), steps: 3000) }
+        points += (7..<14).map { i in TrendsEngine.DailyPoint(date: day(i), steps: 7000) }
+        let t = TrendsEngine.trend(for: points, window: 7) { $0.steps.map(Double.init) }
+        XCTAssertEqual(t, .up)
+    }
+
+    func testTrendDown() {
+        var points = (0..<7).map { i in TrendsEngine.DailyPoint(date: day(i), steps: 8000) }
+        points += (7..<14).map { i in TrendsEngine.DailyPoint(date: day(i), steps: 3000) }
+        let t = TrendsEngine.trend(for: points, window: 7) { $0.steps.map(Double.init) }
+        XCTAssertEqual(t, .down)
+    }
+
+    func testTrendFlat() {
+        // 14 days all equal → flat
+        let points = (0..<14).map { i in TrendsEngine.DailyPoint(date: day(i), steps: 8000) }
+        let t = TrendsEngine.trend(for: points, window: 7) { $0.steps.map(Double.init) }
+        XCTAssertEqual(t, .flat)
+    }
+
+    func testTrendNilWithInsufficientData() {
+        let points = [TrendsEngine.DailyPoint(date: day(0), steps: 5000)]
+        let t = TrendsEngine.trend(for: points, window: 7) { $0.steps.map(Double.init) }
+        XCTAssertNil(t)
+    }
+
+    // MARK: Sleep regularity
+
+    func testSleepRegularityPerfect() {
+        // Same bedtime every night → 0 variance → score = 100
+        let same = Array(repeating: 22 * 60, count: 7) // 22:00 every night
+        XCTAssertEqual(TrendsEngine.sleepRegularity(bedtimeMinutes: same), 100)
+    }
+
+    func testSleepRegularityHighVariance() {
+        // Very different bedtimes → low score
+        let varied = [22 * 60, 0 * 60, 23 * 60, 1 * 60, 22 * 60, 2 * 60, 23 * 60]
+        let score = TrendsEngine.sleepRegularity(bedtimeMinutes: varied) ?? 100
+        XCTAssertLessThan(score, 60)
+    }
+
+    func testSleepRegularityInsufficientData() {
+        XCTAssertNil(TrendsEngine.sleepRegularity(bedtimeMinutes: [22 * 60]))
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/TrendsEngineTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/TrendsEngineTests.swift
@@ -106,4 +106,22 @@ final class TrendsEngineTests: XCTestCase {
     func testSleepRegularityInsufficientData() {
         XCTAssertNil(TrendsEngine.sleepRegularity(bedtimeMinutes: [22 * 60]))
     }
+
+    func testSleepRegularityTightClusterAroundMidnight() {
+        // A very consistent near-midnight sleeper: [23:58, 00:02, 23:55, 00:05, 00:00, 23:57, 00:03]
+        // → true spread ~10 min. Linear variance would treat these as ~1440 min apart and score 0;
+        // circular statistics must score this near-perfect (≥ 90).
+        let minutes = [1438, 2, 1435, 5, 0, 1437, 3]
+        let score = TrendsEngine.sleepRegularity(bedtimeMinutes: minutes) ?? 0
+        XCTAssertGreaterThanOrEqual(score, 90, "tight midnight-wrap cluster should be highly regular")
+    }
+
+    func testSleepRegularityWrapEquivalentToShifted() {
+        // Same spread, once straddling midnight and once shifted to noon → identical score
+        // (rotation-invariance is the whole point of circular statistics).
+        let aroundMidnight = [1438, 2, 1435, 5, 0, 1437, 3]
+        let aroundNoon = aroundMidnight.map { ($0 + 720) % 1440 }
+        XCTAssertEqual(TrendsEngine.sleepRegularity(bedtimeMinutes: aroundMidnight),
+                       TrendsEngine.sleepRegularity(bedtimeMinutes: aroundNoon))
+    }
 }

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/UnitPreferencesTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/UnitPreferencesTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import OpenRingKit
+
+final class UnitPreferencesTests: XCTestCase {
+
+    // MARK: - TemperatureUnit conversion
+
+    func testZeroCelsiusToFahrenheit() {
+        let f = TemperatureUnit.fahrenheit.convert(fromCelsius: 0)
+        XCTAssertEqual(f, 32, accuracy: 0.001)
+    }
+
+    func testHundredCelsiusToFahrenheit() {
+        let f = TemperatureUnit.fahrenheit.convert(fromCelsius: 100)
+        XCTAssertEqual(f, 212, accuracy: 0.001)
+    }
+
+    func testBodyTempCelsiusToFahrenheit() {
+        let f = TemperatureUnit.fahrenheit.convert(fromCelsius: 37)
+        XCTAssertEqual(f, 98.6, accuracy: 0.01)
+    }
+
+    func testCelsiusIdentity() {
+        XCTAssertEqual(TemperatureUnit.celsius.convert(fromCelsius: 36.5), 36.5, accuracy: 0.0001)
+    }
+
+    func testCelsiusSymbol() {
+        XCTAssertEqual(TemperatureUnit.celsius.symbol, "°C")
+    }
+
+    func testFahrenheitSymbol() {
+        XCTAssertEqual(TemperatureUnit.fahrenheit.symbol, "°F")
+    }
+
+    // MARK: - DistanceUnit conversion
+
+    func testMetrestoKilometres() {
+        XCTAssertEqual(DistanceUnit.metric.convert(fromMeters: 5_000), 5.0, accuracy: 0.0001)
+    }
+
+    func testMetresToMiles() {
+        // 1 mile = 1609.344 m
+        XCTAssertEqual(DistanceUnit.imperial.convert(fromMeters: 1_609.344), 1.0, accuracy: 0.0001)
+    }
+
+    func testMetricSymbol() {
+        XCTAssertEqual(DistanceUnit.metric.symbol, "km")
+    }
+
+    func testImperialSymbol() {
+        XCTAssertEqual(DistanceUnit.imperial.symbol, "mi")
+    }
+
+    // MARK: - UnitsFormatter.temperature
+
+    func testFormatterCelsiusOutput() {
+        let s = UnitsFormatter.temperature(36.5, unit: .celsius)
+        XCTAssertEqual(s, "36.5 °C")
+    }
+
+    func testFormatterFahrenheitOutput() {
+        let s = UnitsFormatter.temperature(37, unit: .fahrenheit)
+        // 37 °C = 98.6 °F
+        XCTAssertEqual(s, "98.6 °F")
+    }
+
+    func testFormatterFractionDigitsZero() {
+        // Use 36.6 to avoid banker's-rounding ambiguity at .5
+        let s = UnitsFormatter.temperature(36.6, unit: .celsius, fractionDigits: 0)
+        XCTAssertEqual(s, "37 °C")
+    }
+
+    // MARK: - UnitsFormatter.distance
+
+    func testFormatterKilometres() {
+        let s = UnitsFormatter.distance(3_200, unit: .metric)
+        XCTAssertEqual(s, "3.2 km")
+    }
+
+    func testFormatterMiles() {
+        let metres = 1_609.344 * 2   // 2 miles
+        let s = UnitsFormatter.distance(metres, unit: .imperial)
+        XCTAssertEqual(s, "2.0 mi")
+    }
+
+    // MARK: - RawValue round-trip (AppStorage compatibility)
+
+    func testTemperatureUnitRawValueRoundTrip() {
+        XCTAssertEqual(TemperatureUnit(rawValue: "celsius"), .celsius)
+        XCTAssertEqual(TemperatureUnit(rawValue: "fahrenheit"), .fahrenheit)
+        XCTAssertNil(TemperatureUnit(rawValue: "kelvin"))
+    }
+
+    func testDistanceUnitRawValueRoundTrip() {
+        XCTAssertEqual(DistanceUnit(rawValue: "metric"), .metric)
+        XCTAssertEqual(DistanceUnit(rawValue: "imperial"), .imperial)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/VitalsBaselineTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/VitalsBaselineTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import OpenRingKit
+
+/// SYNTHETIC-ONLY tests for vitals baseline + acute anomaly detection + fever (#72).
+/// Controlled inputs with a known baseline/severity — never real health values.
+final class VitalsBaselineTests: XCTestCase {
+
+    // MARK: Baseline window
+
+    func testBaselineNeedsMinimumHistory() {
+        // 6 days < default minBaselineDays (7) → no baseline.
+        XCTAssertNil(VitalsBaseline.stats(Array(repeating: 60.0, count: 6)))
+        let s = VitalsBaseline.stats(Array(repeating: 60.0, count: 7))
+        XCTAssertNotNil(s)
+        XCTAssertEqual(s!.mean, 60, accuracy: 1e-9)
+        XCTAssertEqual(s!.sd, 0, accuracy: 1e-9)
+        XCTAssertEqual(s!.n, 7)
+    }
+
+    func testBaselineTrailingWindowCaps() {
+        // 40 prior values but a 30-day max → only the most-recent 30 count.
+        let prior = (1...40).map { Double($0) }          // 1…40 oldest→newest
+        let s = VitalsBaseline.stats(prior)              // last 30 = 11…40, mean 25.5
+        XCTAssertEqual(s!.n, 30)
+        XCTAssertEqual(s!.mean, 25.5, accuracy: 1e-9)
+    }
+
+    // MARK: Severity thresholds
+
+    func testRestingHRSignificantRise() {
+        // baseline mean 60, sd 2 → +10 bpm is 5 sd and past the 5-bpm floor → significant.
+        let prior = [58.0, 60, 62, 58, 60, 62, 60]       // mean 60, sd≈1.6
+        let c = VitalsBaseline.classify(today: 75, prior: prior, vital: .restingHR)
+        XCTAssertEqual(c.severity, .significant)
+        XCTAssertEqual(c.direction, .rise)
+    }
+
+    func testRestingHRMinorRise() {
+        // Wider baseline so a moderate rise lands in the minor (1.5–2.5 sd) band.
+        let prior = [50.0, 55, 60, 65, 70, 55, 60]       // mean 59.3, sd≈6.3
+        let c = VitalsBaseline.classify(today: 71, prior: prior, vital: .restingHR)
+        XCTAssertEqual(c.severity, .minor)
+    }
+
+    func testRestingHRLowIsNotConcerning() {
+        // A LOWER resting HR is healthy — never flagged (concern is .high only).
+        let prior = [58.0, 60, 62, 58, 60, 62, 60]
+        let c = VitalsBaseline.classify(today: 45, prior: prior, vital: .restingHR)
+        XCTAssertEqual(c.severity, .normal)
+        XCTAssertEqual(c.direction, .drop)
+    }
+
+    func testAbsoluteFloorSuppressesTinyDeviation() {
+        // Very tight baseline (sd≈0): a 2-bpm change is huge in z but below the 5-bpm floor → normal.
+        let prior = Array(repeating: 60.0, count: 7)
+        let c = VitalsBaseline.classify(today: 62, prior: prior, vital: .restingHR)
+        XCTAssertEqual(c.severity, .normal)
+        // But a change past the floor with zero sd is treated as significant.
+        let big = VitalsBaseline.classify(today: 70, prior: prior, vital: .restingHR)
+        XCTAssertEqual(big.severity, .significant)
+    }
+
+    func testSpO2DropConcerning() {
+        let prior = [98.0, 97, 98, 99, 97, 98, 98]       // mean ≈97.9, sd≈0.6
+        let c = VitalsBaseline.classify(today: 92, prior: prior, vital: .overnightSpO2)
+        XCTAssertEqual(c.severity, .significant)
+        XCTAssertEqual(c.direction, .drop)
+        // A higher SpO2 is never an anomaly.
+        XCTAssertEqual(VitalsBaseline.classify(today: 100, prior: prior, vital: .overnightSpO2).severity, .normal)
+    }
+
+    func testHRVDropConcerning() {
+        let prior = [60.0, 65, 55, 60, 62, 58, 60]       // mean 60, sd≈3
+        let c = VitalsBaseline.classify(today: 40, prior: prior, vital: .overnightHRV)
+        XCTAssertEqual(c.severity, .significant)
+        XCTAssertEqual(c.direction, .drop)
+        XCTAssertEqual(VitalsBaseline.classify(today: 90, prior: prior, vital: .overnightHRV).severity, .normal)
+    }
+
+    func testTempSeverityBands() {
+        XCTAssertEqual(VitalsBaseline.tempSeverity(offsetC: 0.3), .normal)
+        XCTAssertEqual(VitalsBaseline.tempSeverity(offsetC: 0.7), .minor)
+        XCTAssertEqual(VitalsBaseline.tempSeverity(offsetC: 1.4), .significant)
+        XCTAssertEqual(VitalsBaseline.tempSeverity(offsetC: -1.4), .significant, "a sharp drop is also significant")
+    }
+
+    // MARK: Fever (HR + temp cross-reference)
+
+    func testFeverNeedsBothSignals() {
+        let hrPrior = Array(repeating: 60.0, count: 7)
+        // Temp up but HR normal → no fever.
+        XCTAssertFalse(VitalsBaseline.suspectedFever(restingHRToday: 60, restingHRPrior: hrPrior, skinTempOffsetC: 1.2))
+        // HR up but temp normal → no fever.
+        XCTAssertFalse(VitalsBaseline.suspectedFever(restingHRToday: 75, restingHRPrior: hrPrior, skinTempOffsetC: 0.3))
+        // BOTH up → fever.
+        XCTAssertTrue(VitalsBaseline.suspectedFever(restingHRToday: 75, restingHRPrior: hrPrior, skinTempOffsetC: 1.2))
+    }
+
+    func testFeverRequiresInputs() {
+        XCTAssertFalse(VitalsBaseline.suspectedFever(restingHRToday: nil, restingHRPrior: [], skinTempOffsetC: 1.2))
+        XCTAssertFalse(VitalsBaseline.suspectedFever(restingHRToday: 80, restingHRPrior: [], skinTempOffsetC: nil))
+        // Too little HR history → can't establish a personal baseline → no false fever.
+        XCTAssertFalse(VitalsBaseline.suspectedFever(restingHRToday: 90,
+                                                     restingHRPrior: [60, 60, 60],
+                                                     skinTempOffsetC: 1.5))
+    }
+
+    // MARK: Vitals Status report
+
+    func testStatusNormal() {
+        let inputs = [
+            VitalsBaseline.VitalInput(vital: .restingHR, today: 60, prior: Array(repeating: 60.0, count: 7)),
+            VitalsBaseline.VitalInput(vital: .overnightSpO2, today: 98, prior: Array(repeating: 98.0, count: 7)),
+        ]
+        let r = VitalsBaseline.report(inputs, skinTempOffsetC: 0.2)
+        XCTAssertEqual(r.status, .normal)
+        XCTAssertTrue(r.signals.isEmpty)
+        XCTAssertFalse(r.feverSuspected)
+    }
+
+    func testStatusWatchOnMinor() {
+        let prior = [50.0, 55, 60, 65, 70, 55, 60]
+        let inputs = [VitalsBaseline.VitalInput(vital: .restingHR, today: 71, prior: prior)]
+        let r = VitalsBaseline.report(inputs)
+        XCTAssertEqual(r.status, .watch)
+        XCTAssertEqual(r.signals.count, 1)
+        XCTAssertEqual(r.signals.first?.severity, .minor)
+    }
+
+    func testStatusAnomalyOnFever() {
+        // HR + temp both elevated → fever → anomaly, even though HR alone might only be minor.
+        let inputs = [VitalsBaseline.VitalInput(vital: .restingHR, today: 75,
+                                                prior: Array(repeating: 60.0, count: 7))]
+        let r = VitalsBaseline.report(inputs, skinTempOffsetC: 1.3)
+        XCTAssertEqual(r.status, .anomaly)
+        XCTAssertTrue(r.feverSuspected)
+    }
+
+    func testStatusAnomalyOnSignificant() {
+        let inputs = [VitalsBaseline.VitalInput(vital: .overnightSpO2, today: 91,
+                                                prior: [98, 97, 98, 99, 97, 98, 98])]
+        let r = VitalsBaseline.report(inputs)
+        XCTAssertEqual(r.status, .anomaly)
+    }
+}

--- a/ios/OpenRingKit/Tests/OpenRingKitTests/WorkoutSessionTests.swift
+++ b/ios/OpenRingKit/Tests/OpenRingKitTests/WorkoutSessionTests.swift
@@ -1,0 +1,266 @@
+import XCTest
+@testable import OpenRingKit
+
+// Tests for WorkoutSession.swift — zone classification, time-in-zone, session aggregation.
+// Zone boundaries from the APK (pp.txt:0x515c0):
+//   warmUp 50–60%, fatBurn 61–70%, aerobic 71–80%, anaerobic 81–90%, extreme 91–100%
+//   Below 50% of maxHR → not counted (nil zone).
+// maxHR formula: 220 - age.
+final class WorkoutSessionTests: XCTestCase {
+
+    // MARK: - HRZoneClassifier.zone(bpm:maxHR:)
+
+    func testZoneBelowHalfMaxHRIsNil() {
+        // 49% of 200 = 98 bpm — below 50%, not counted per APK
+        XCTAssertNil(HRZoneClassifier.zone(bpm: 98, maxHR: 200))
+    }
+
+    func testZoneExactly50PercentIsWarmUp() {
+        // 50% of 200 = 100 bpm → warm-up (lower bound inclusive)
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 100, maxHR: 200), .warmUp)
+    }
+
+    func testZoneWarmUpUpperBound() {
+        // 60% of 200 = 120 bpm → still warm-up
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 120, maxHR: 200), .warmUp)
+    }
+
+    func testZoneFatBurnLower() {
+        // 61% of 200 = 122 bpm → fat burn
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 122, maxHR: 200), .fatBurn)
+    }
+
+    func testZoneFatBurnUpper() {
+        // 70% of 200 = 140 bpm → fat burn
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 140, maxHR: 200), .fatBurn)
+    }
+
+    func testZoneAerobicLower() {
+        // 71% of 200 = 142 bpm → aerobic
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 142, maxHR: 200), .aerobic)
+    }
+
+    func testZoneAerobicUpper() {
+        // 80% of 200 = 160 bpm → aerobic
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 160, maxHR: 200), .aerobic)
+    }
+
+    func testZoneAnaerobicLower() {
+        // 81% of 200 = 162 bpm → anaerobic
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 162, maxHR: 200), .anaerobic)
+    }
+
+    func testZoneAnaerobicUpper() {
+        // 90% of 200 = 180 bpm → anaerobic
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 180, maxHR: 200), .anaerobic)
+    }
+
+    func testZoneExtremeLower() {
+        // 91% of 200 = 182 bpm → extreme
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 182, maxHR: 200), .extreme)
+    }
+
+    func testZoneExtremeAtMaxHR() {
+        // 100% of 200 = 200 bpm → extreme
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 200, maxHR: 200), .extreme)
+    }
+
+    func testZoneZeroBpmIsNil() {
+        XCTAssertNil(HRZoneClassifier.zone(bpm: 0, maxHR: 200))
+    }
+
+    func testZoneZeroMaxHRIsNil() {
+        XCTAssertNil(HRZoneClassifier.zone(bpm: 100, maxHR: 0))
+    }
+
+    // MARK: - HRZoneClassifier.timeInZones
+
+    func testTimeInZonesEmptySamplesAllZero() {
+        let breakdown = HRZoneClassifier.timeInZones(hrSamples: [], maxHR: 200)
+        for zone in HRZone.allCases {
+            XCTAssertEqual(breakdown.seconds(in: zone), 0)
+        }
+        XCTAssertEqual(breakdown.totalZoneSeconds, 0)
+    }
+
+    func testTimeInZonesInstantaneousSamplesContributeZeroSeconds() {
+        // Instantaneous reading (end == start): classified by BPM but 0 s zone duration.
+        let t = Date(timeIntervalSince1970: 0)
+        let sample = HRSample(bpm: 150, start: t, end: t)
+        let breakdown = HRZoneClassifier.timeInZones(hrSamples: [sample], maxHR: 200)
+        // 150/200 = 75% → aerobic, but 0 duration → 0 s
+        XCTAssertEqual(breakdown.seconds(in: .aerobic), 0)
+        XCTAssertEqual(breakdown.totalZoneSeconds, 0)
+    }
+
+    func testTimeInZones60SecAerobicSample() {
+        // One 60-second sample at 75% maxHR → aerobic zone 60 s
+        let t0 = Date(timeIntervalSince1970: 0)
+        let t1 = t0.addingTimeInterval(60)
+        let sample = HRSample(bpm: 150, start: t0, end: t1)   // 150/200 = 75% → aerobic
+        let breakdown = HRZoneClassifier.timeInZones(hrSamples: [sample], maxHR: 200)
+        XCTAssertEqual(breakdown.seconds(in: .aerobic), 60, accuracy: 0.001)
+        XCTAssertEqual(breakdown.seconds(in: .warmUp), 0)
+        XCTAssertEqual(breakdown.totalZoneSeconds, 60, accuracy: 0.001)
+    }
+
+    func testTimeInZonesMultipleZones() {
+        let t0 = Date(timeIntervalSince1970: 0)
+        // 30 s in warm-up (100 bpm = 50% of 200)
+        let warmUp = HRSample(bpm: 100, start: t0, end: t0.addingTimeInterval(30))
+        // 60 s in aerobic (150 bpm = 75% of 200)
+        let aerobic = HRSample(bpm: 150, start: t0.addingTimeInterval(30), end: t0.addingTimeInterval(90))
+        // 10 s below zone (90 bpm = 45% of 200 — not counted)
+        let below = HRSample(bpm: 90, start: t0.addingTimeInterval(90), end: t0.addingTimeInterval(100))
+
+        let breakdown = HRZoneClassifier.timeInZones(hrSamples: [warmUp, aerobic, below], maxHR: 200)
+        XCTAssertEqual(breakdown.seconds(in: .warmUp), 30, accuracy: 0.001)
+        XCTAssertEqual(breakdown.seconds(in: .aerobic), 60, accuracy: 0.001)
+        XCTAssertEqual(breakdown.totalZoneSeconds, 90, accuracy: 0.001)  // below-zone not counted
+    }
+
+    func testFractionWithTotalZeroReturnsZero() {
+        let breakdown = HRZoneClassifier.timeInZones(hrSamples: [], maxHR: 200)
+        XCTAssertEqual(breakdown.fraction(in: .aerobic), 0)
+    }
+
+    func testFractionSumsToOne() {
+        let t0 = Date(timeIntervalSince1970: 0)
+        let s1 = HRSample(bpm: 100, start: t0, end: t0.addingTimeInterval(30))  // warmUp 30 s
+        let s2 = HRSample(bpm: 150, start: t0.addingTimeInterval(30), end: t0.addingTimeInterval(70)) // aerobic 40 s
+        let breakdown = HRZoneClassifier.timeInZones(hrSamples: [s1, s2], maxHR: 200)
+        let total = HRZone.allCases.map { breakdown.fraction(in: $0) }.reduce(0, +)
+        XCTAssertEqual(total, 1.0, accuracy: 0.001)
+    }
+
+    // MARK: - WorkoutSessionAggregator
+
+    func testAggregatorEmptySessionProducesNilHR() {
+        let agg = WorkoutSessionAggregator(startDate: .distantPast, userAge: 30)
+        let profile = UserProfile(age: 30, weightKg: 70, heightCm: 170, sex: .male)
+        let summary = agg.finalize(
+            sport: .runningOutdoor,
+            endDate: Date(),
+            distanceMeters: nil,
+            hasRoute: false,
+            profile: profile
+        )
+        XCTAssertNil(summary.avgHR)
+        XCTAssertNil(summary.maxHR)
+        XCTAssertNil(summary.estimatedActiveKcal)
+        XCTAssertEqual(summary.hrSampleCount, 0)
+    }
+
+    func testAggregatorComputesAvgAndMaxHR() {
+        let t0 = Date(timeIntervalSince1970: 0)
+        let agg = WorkoutSessionAggregator(startDate: t0, userAge: 30)
+        agg.add(sample: HRSample(bpm: 100, start: t0, end: t0.addingTimeInterval(30)))
+        agg.add(sample: HRSample(bpm: 150, start: t0.addingTimeInterval(30), end: t0.addingTimeInterval(60)))
+        agg.add(sample: HRSample(bpm: 200, start: t0.addingTimeInterval(60), end: t0.addingTimeInterval(90)))
+
+        let profile = UserProfile(age: 30, weightKg: 70, heightCm: 170, sex: .male)
+        let summary = agg.finalize(
+            sport: .runningOutdoor,
+            endDate: t0.addingTimeInterval(90),
+            distanceMeters: 500,
+            hasRoute: false,
+            profile: profile
+        )
+        XCTAssertEqual(summary.avgHR, 150)   // (100+150+200)/3 = 150
+        XCTAssertEqual(summary.maxHR, 200)
+        XCTAssertEqual(summary.hrSampleCount, 3)
+        XCTAssertEqual(summary.distanceMeters, 500)
+    }
+
+    func testAggregatorSportTypeAndDatePassThrough() {
+        let start = Date(timeIntervalSince1970: 1_000_000)
+        let end   = Date(timeIntervalSince1970: 1_003_600)
+        let agg = WorkoutSessionAggregator(startDate: start, userAge: 35)
+        let profile = UserProfile(age: 35, weightKg: 80, heightCm: 175, sex: .male)
+        let summary = agg.finalize(
+            sport: .yoga,
+            endDate: end,
+            distanceMeters: nil,
+            hasRoute: false,
+            profile: profile
+        )
+        XCTAssertEqual(summary.sport, .yoga)
+        XCTAssertEqual(summary.startDate, start)
+        XCTAssertEqual(summary.endDate, end)
+        XCTAssertEqual(summary.durationSeconds, 3600, accuracy: 0.001)
+        XCTAssertFalse(summary.hasRoute)
+    }
+
+    func testAggregatorSufficientSamplesProducesCalorieEstimate() {
+        // Strain.minReadings = 600 — need 600 samples with duration for a TRIMP estimate.
+        let t0 = Date(timeIntervalSince1970: 0)
+        let agg = WorkoutSessionAggregator(startDate: t0, userAge: 30)
+        // maxHR for age 30 = 220 - 30 = 190. 150 bpm = ~84% → anaerobic zone.
+        for i in 0..<600 {
+            let s = t0.addingTimeInterval(Double(i))
+            let e = t0.addingTimeInterval(Double(i) + 1.0)
+            agg.add(sample: HRSample(bpm: 150, start: s, end: e))
+        }
+        let profile = UserProfile(age: 30, weightKg: 70, heightCm: 170, sex: .male)
+        let summary = agg.finalize(
+            sport: .runningOutdoor,
+            endDate: t0.addingTimeInterval(600),
+            distanceMeters: 1000,
+            hasRoute: false,
+            profile: profile
+        )
+        XCTAssertNotNil(summary.estimatedActiveKcal)
+        XCTAssertGreaterThan(summary.estimatedActiveKcal ?? 0, 0)
+    }
+
+    func testAggregatorInsufficientSamplesNilCalories() {
+        let t0 = Date(timeIntervalSince1970: 0)
+        let agg = WorkoutSessionAggregator(startDate: t0, userAge: 30)
+        // Only 10 samples — far below Strain.minReadings (600)
+        for i in 0..<10 {
+            let s = t0.addingTimeInterval(Double(i))
+            agg.add(sample: HRSample(bpm: 150, start: s, end: s.addingTimeInterval(1)))
+        }
+        let profile = UserProfile(age: 30, weightKg: 70, heightCm: 170, sex: .male)
+        let summary = agg.finalize(
+            sport: .walking, // will use fallback
+            endDate: t0.addingTimeInterval(10),
+            distanceMeters: nil,
+            hasRoute: false,
+            profile: profile
+        )
+        XCTAssertNil(summary.estimatedActiveKcal)
+    }
+
+    // MARK: - WorkoutSportType
+
+    func testOutdoorTypesAreOutdoor() {
+        XCTAssertTrue(WorkoutSportType.walkingOutdoor.isOutdoor)
+        XCTAssertTrue(WorkoutSportType.runningOutdoor.isOutdoor)
+        XCTAssertTrue(WorkoutSportType.cyclingOutdoor.isOutdoor)
+        XCTAssertTrue(WorkoutSportType.hiking.isOutdoor)
+    }
+
+    func testIndoorTypesAreNotOutdoor() {
+        XCTAssertFalse(WorkoutSportType.strengthTraining.isOutdoor)
+        XCTAssertFalse(WorkoutSportType.yoga.isOutdoor)
+        XCTAssertFalse(WorkoutSportType.other.isOutdoor)
+    }
+
+    // MARK: - maxHR formula (220 - age)
+
+    func testFormulaMaxHRAge30() {
+        // Indirect test: age 30 → maxHR = 190; 190 bpm at maxHR = 100% → extreme zone.
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 190, maxHR: 190), .extreme)
+        // 50% of 190 = 95 → warm-up lower bound
+        XCTAssertEqual(HRZoneClassifier.zone(bpm: 95, maxHR: 190), .warmUp)
+        // 94 → below 50% of 190 → nil
+        XCTAssertNil(HRZoneClassifier.zone(bpm: 94, maxHR: 190))
+    }
+}
+
+// Extension to allow using `.walking` without the full qualified name in the test
+// (mirrors the app side where `WorkoutSportType.walkingOutdoor` is used).
+private extension WorkoutSportType {
+    static var walking: WorkoutSportType { .walkingOutdoor }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,6 +30,9 @@ targets:
         # Background sync while suspended (docs/HANDOFF_MACOS_IOS.md).
         UIBackgroundModes:
           - bluetooth-central
+          - fetch
+        BGTaskSchedulerPermittedIdentifiers:
+          - com.openringconn.app.bgrefresh
     # HealthKit entitlement intentionally OMITTED for free-team signing (it needs a
     # paid Apple Developer account, and setting CODE_SIGN_ENTITLEMENTS on a free team
     # breaks device launch — see git history). BLE works; HealthKit auth no-ops at
@@ -49,3 +52,15 @@ targets:
         # On-device signing. Xcode fills DEVELOPMENT_TEAM when you pick your team
         # (or set it here to your 10-char Team ID for CLI builds).
         CODE_SIGN_STYLE: Automatic
+
+  OpenRingConnTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: OpenRingConnTests
+    dependencies:
+      - target: OpenRingConn
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openringconn.app.tests
+        SWIFT_VERSION: "5.9"

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -27,6 +27,9 @@ targets:
         NSHealthUpdateUsageDescription: "OpenRingConn writes your ring's metrics into Apple Health."
         # BLE (Phase 3) — required to connect to the ring.
         NSBluetoothAlwaysUsageDescription: "OpenRingConn connects to your RingConn ring over Bluetooth Low Energy."
+        # Location (Phase 3, #75) — used ONLY when recording an outdoor workout to map the
+        # GPS route on the phone side (the ring has no GPS). Not used at any other time.
+        NSLocationWhenInUseUsageDescription: "OpenRingConn uses your location to map outdoor workout routes (walking, running, cycling, hiking). Location is not used outside of an active workout."
         # Background sync while suspended (docs/HANDOFF_MACOS_IOS.md). `processing` enables the
         # BGProcessingTask (longer runtime) so the optical-HR poll can clear its ~60 s warm-up in
         # the background (#45/#50 follow-up). iOS still runs it at its discretion, so this is

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,6 +30,14 @@ targets:
         # Background sync while suspended (docs/HANDOFF_MACOS_IOS.md).
         UIBackgroundModes:
           - bluetooth-central
+    # HealthKit entitlement intentionally OMITTED for free-team signing (it needs a
+    # paid Apple Developer account, and setting CODE_SIGN_ENTITLEMENTS on a free team
+    # breaks device launch — see git history). BLE works; HealthKit auth no-ops at
+    # runtime. When you have a paid team, UNCOMMENT this block and re-run
+    # `xcodegen generate`, then pick your team in Xcode (see docs/HANDOFF_MACOS_IOS.md):
+    #   entitlements:
+    #     path: OpenRingConn/OpenRingConn.entitlements
+    #     properties: { com.apple.developer.healthkit: true }
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openringconn.app
@@ -38,13 +46,6 @@ targets:
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1"
         GENERATE_INFOPLIST_FILE: NO
-        # HealthKit entitlement is GATED on a paid Apple Developer account (free-team
-        # signing can't provision it). Default (env unset) = empty = no entitlement, so
-        # free-team builds work and HealthKit auth no-ops at runtime. On a paid team,
-        # turn it on with ONE command — no YAML edit:
-        #   HEALTHKIT_ENTITLEMENTS=OpenRingConn/OpenRingConn.entitlements xcodegen generate
-        # then set your team and build. See docs/HANDOFF_MACOS_IOS.md.
-        CODE_SIGN_ENTITLEMENTS: ${HEALTHKIT_ENTITLEMENTS}
         # On-device signing. Xcode fills DEVELOPMENT_TEAM when you pick your team
         # (or set it here to your 10-char Team ID for CLI builds).
         CODE_SIGN_STYLE: Automatic

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,6 +1,6 @@
 name: OpenRingConn
 options:
-  bundleIdPrefix: com.openringconn
+  bundleIdPrefix: com.dreamality
   deploymentTarget:
     iOS: "17.0"
   createIntermediateGroups: true
@@ -32,27 +32,26 @@ targets:
           - bluetooth-central
           - fetch
         BGTaskSchedulerPermittedIdentifiers:
-          - com.openringconn.app.bgrefresh
-    # HealthKit entitlement intentionally OMITTED for free-team signing (it needs a
-    # paid Apple Developer account, and setting CODE_SIGN_ENTITLEMENTS on a free team
-    # breaks device launch — see git history). BLE works; HealthKit auth no-ops at
-    # runtime. When you have a paid team, UNCOMMENT this block and re-run
-    # `xcodegen generate`, then pick your team in Xcode (see docs/HANDOFF_MACOS_IOS.md):
-    #   entitlements:
-    #     path: OpenRingConn/OpenRingConn.entitlements
-    #     properties: { com.apple.developer.healthkit: true }
+          - com.dreamality.openringconn.bgrefresh
+    # HealthKit entitlement enabled (2026-06-15) — signed under the paid Dreamality team
+    # (DEVELOPMENT_TEAM below). The App ID com.dreamality.openringconn carries the HealthKit
+    # capability in that account; automatic signing registers it on first build.
+    entitlements:
+      path: OpenRingConn/OpenRingConn.entitlements
+      properties: { com.apple.developer.healthkit: true }
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.openringconn.app
+        PRODUCT_BUNDLE_IDENTIFIER: com.dreamality.openringconn
         MARKETING_VERSION: "0.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1"
         GENERATE_INFOPLIST_FILE: NO
         # On-device signing. Set here so CLI device builds work after `xcodegen generate`
-        # (which would otherwise drop the team and fail signing). Personal/free team.
+        # (which would otherwise drop the team and fail signing). Dreamality paid team
+        # (was personal/free 64R56NUZ5P; switched 2026-06-15 to enable HealthKit).
         CODE_SIGN_STYLE: Automatic
-        DEVELOPMENT_TEAM: 64R56NUZ5P
+        DEVELOPMENT_TEAM: 2ZH5MPQ5G6
 
   OpenRingConnTests:
     type: bundle.unit-test
@@ -63,6 +62,6 @@ targets:
       - target: OpenRingConn
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.openringconn.app.tests
+        PRODUCT_BUNDLE_IDENTIFIER: com.dreamality.openringconn.tests
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: YES

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,12 +30,6 @@ targets:
         # Background sync while suspended (docs/HANDOFF_MACOS_IOS.md).
         UIBackgroundModes:
           - bluetooth-central
-    # HealthKit entitlement intentionally OMITTED for free-team signing (it needs a
-    # paid Apple Developer account). BLE still works; HealthKit auth no-ops at
-    # runtime. Re-add this block (and OpenRingConn.entitlements) when on a paid team:
-    #   entitlements:
-    #     path: OpenRingConn/OpenRingConn.entitlements
-    #     properties: { com.apple.developer.healthkit: true }
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openringconn.app
@@ -44,6 +38,13 @@ targets:
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1"
         GENERATE_INFOPLIST_FILE: NO
+        # HealthKit entitlement is GATED on a paid Apple Developer account (free-team
+        # signing can't provision it). Default (env unset) = empty = no entitlement, so
+        # free-team builds work and HealthKit auth no-ops at runtime. On a paid team,
+        # turn it on with ONE command — no YAML edit:
+        #   HEALTHKIT_ENTITLEMENTS=OpenRingConn/OpenRingConn.entitlements xcodegen generate
+        # then set your team and build. See docs/HANDOFF_MACOS_IOS.md.
+        CODE_SIGN_ENTITLEMENTS: ${HEALTHKIT_ENTITLEMENTS}
         # On-device signing. Xcode fills DEVELOPMENT_TEAM when you pick your team
         # (or set it here to your 10-char Team ID for CLI builds).
         CODE_SIGN_STYLE: Automatic

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -64,3 +64,4 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openringconn.app.tests
         SWIFT_VERSION: "5.9"
+        GENERATE_INFOPLIST_FILE: YES

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -27,12 +27,17 @@ targets:
         NSHealthUpdateUsageDescription: "OpenRingConn writes your ring's metrics into Apple Health."
         # BLE (Phase 3) — required to connect to the ring.
         NSBluetoothAlwaysUsageDescription: "OpenRingConn connects to your RingConn ring over Bluetooth Low Energy."
-        # Background sync while suspended (docs/HANDOFF_MACOS_IOS.md).
+        # Background sync while suspended (docs/HANDOFF_MACOS_IOS.md). `processing` enables the
+        # BGProcessingTask (longer runtime) so the optical-HR poll can clear its ~60 s warm-up in
+        # the background (#45/#50 follow-up). iOS still runs it at its discretion, so this is
+        # best-effort — not a guarantee of daytime background HR.
         UIBackgroundModes:
           - bluetooth-central
           - fetch
+          - processing
         BGTaskSchedulerPermittedIdentifiers:
           - com.dreamality.openringconn.bgrefresh
+          - com.dreamality.openringconn.bgprocessing
     # HealthKit entitlement enabled (2026-06-15) — signed under the paid Dreamality team
     # (DEVELOPMENT_TEAM below). The App ID com.dreamality.openringconn carries the HealthKit
     # capability in that account; automatic signing registers it on first build.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -49,9 +49,10 @@ targets:
         SWIFT_VERSION: "5.9"
         TARGETED_DEVICE_FAMILY: "1"
         GENERATE_INFOPLIST_FILE: NO
-        # On-device signing. Xcode fills DEVELOPMENT_TEAM when you pick your team
-        # (or set it here to your 10-char Team ID for CLI builds).
+        # On-device signing. Set here so CLI device builds work after `xcodegen generate`
+        # (which would otherwise drop the team and fail signing). Personal/free team.
         CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 64R56NUZ5P
 
   OpenRingConnTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Wave 1 — APK gap analysis backlog (18 tickets)

Mines the decompiled official RingConn app (blutter, v3.2.1) for its feature surface, gap-analyzes
against our app, and ships every **implementable-now** ticket. Blocked tickets (#87–#97, captures/decodes)
are deferred to later sessions.

### Implemented (closes on merge)
- **Sleep & overnight analytics** — skin-temp baseline + nightly deviation, composite 0–100 sleep score,
  overnight stress (sleep-window RMSSD), nap detection. Closes #69 #70 #71 #76
- **Vitals & alerts** — personal vitals baseline + acute anomaly/fever, local health alerts, temp/fever
  notifications via one shared notification engine. Closes #72 #73 #85
- **Activity** — distance (steps×stride), exercise-minutes estimate, daily goals, 7-day trends. Closes #74 #77 #81 #82
- **Workouts** — HKWorkout sessions, live-HR, 5-zone breakdown, optional GPS route. Closes #75
- **Women's health** — period logging, cycle prediction + calendar, HealthKit menstrual. Closes #78
- **Device & QoL** — device-info/firmware screen, CSV/JSON export, units, app-side reminders,
  battery time-to-empty + 100%-charged. Closes #79 #80 #83 #84 #86

### Quality
- OpenRingKit **375 unit tests pass**; app target compiles; signed device build installed + launched on hardware.
- Multi-dimension **adversarial review (every finding independently verified)**: fixed 1 P1
  (menstrual flow was writing a fabricated 5-day period to HealthKit), 12 P2, 6 P3.
- Local-first/read-only preserved — **no new BLE write commands** to the ring. Estimates are labeled.

### Notes
- Base commit `abbaa16` snapshots the in-flight Sleep card / history-sync work that Wave 1 builds on.
- HealthKit-entitlement app tests can't run on the simulator (provisions only on device); validated on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
