### PR TITLE
Flag buffer-limited sleep nights with an overnight-charging hint

### DIFF
--- a/ios/OpenCircuit/SleepCardView.swift
+++ b/ios/OpenCircuit/SleepCardView.swift
@@ -23,6 +23,12 @@ struct SleepCardView: View {
     @Environment(\.modelContext) private var modelContext
     /// Temperature display unit (#83). Syncs with the Units section in UserProfileSettingsView.
     @AppStorage("units.temperature") private var tempUnitRaw = TemperatureUnit.localeDefault.rawValue
+    /// User's manual sleep schedule (same keys as SleepScheduleDefaults) — used only to judge whether
+    /// last night looks buffer-limited (the overnight-charging hint). Read directly so the card needs
+    /// no async schedule provider.
+    @AppStorage("sleepSchedule.enabled") private var scheduleEnabled = false
+    @AppStorage("sleepSchedule.bedMinutes") private var bedMinutes = 22 * 60 + 30
+    @AppStorage("sleepSchedule.wakeMinutes") private var wakeMinutes = 6 * 60 + 30
     /// Trailing persisted nights (latest first) — the offline source of truth. The window is
     /// wider than 1 so the rolling skin-temp baseline + the offset mini-chart (#69) have history;
     /// `latest` (= `storedSleep.first`) still drives the headline night.
@@ -175,6 +181,32 @@ struct SleepCardView: View {
         // Footer: sleep window · efficiency · est. caveat.
         Text(footer(night).joined(separator: " · "))
             .font(.caption2).foregroundStyle(.tertiary)
+        captureHint(night)
+    }
+
+    /// Actionable hint when last night looks LIMITED BY THE RING'S ~4.75 h memory (the early hours were
+    /// overwritten before any overnight drain). iOS runs OpenCircuit's background sync far more reliably
+    /// while the phone is charging, so that's the one lever the user controls. Shown only on positive
+    /// evidence (see `SleepCaptureCoverage`), so it doesn't nag on a genuinely short night.
+    @ViewBuilder
+    private func captureHint(_ night: Night) -> some View {
+        // Scheduled bedtime for this night, only when the user enabled a manual schedule — without it
+        // we can't tell a truncated night from a genuinely short one, so no hint (see SleepCaptureCoverage).
+        let bedtime: Date? = {
+            guard scheduleEnabled, let wake = night.inBedEnd else { return nil }
+            return SleepWindow.interval(bedMinutes: bedMinutes, wakeMinutes: wakeMinutes,
+                                        nightEndingNear: wake)?.start
+        }()
+        if let onset = night.inBedStart,
+           SleepCaptureCoverage.classify(capturedOnset: onset, capturedInBed: night.summary.inBed,
+                                         scheduledBedtime: bedtime) == .likelyTruncated {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: "bolt.badge.clock").font(.caption2).foregroundStyle(.orange)
+                Text("Synced only from \(onset.formatted(date: .omitted, time: .shortened)) — the ring holds ~4.75h of memory and overwrites the oldest. Keep your phone charging nearby overnight so OpenCircuit can capture the whole night.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+            .padding(.top, 2)
+        }
     }
 
     /// The Wave-1 sleep-detail rows in one group: per-stage HR, overnight stress, skin-temp

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/SleepCaptureCoverage.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/SleepCaptureCoverage.swift
@@ -1,0 +1,64 @@
+// Was last night's sleep FULLY captured, or limited by the ring's onboard memory?
+//
+// The RingConn Gen-2 history buffer holds only ~4.75 h of epochs and DROPS THE OLDEST when full
+// (PROTOCOL.md §5.3). If nothing drains the ring overnight, the early hours are overwritten before
+// the morning sync, so only the last ~4.75 h survive — the user sees ~5 h for a real ~9 h night.
+// Overnight draining depends on iOS background tasks, which run far more reliably while the phone is
+// CHARGING. This pure helper recognises the buffer-limited signature so the UI can nudge the user to
+// keep the phone charging nearby (the one lever that actually moves overnight capture). Pure (no Apple
+// frameworks) so it unit-tests on the CLI.
+//
+// Duration ALONE can't separate "buffer-truncated" from "genuinely short night" — a 4.5 h reading is
+// either. The discriminator is WHERE the loss is: truncation drops the FRONT of the night, so the
+// captured ONSET lands well after the user's bedtime while the wake time looks normal. A night that
+// fit inside the buffer (even a short one) has its onset captured at the real bedtime. So we flag only
+// with a bedtime reference AND a late captured onset — never on duration alone (that nagged real short
+// sleepers; adversarial review).
+
+import Foundation
+
+public enum SleepCaptureCoverage {
+
+    /// The ring's onboard history-buffer span (seconds). ~114 epochs × 150 s ≈ 4.75 h (🟢 §5.3).
+    public static let ringBufferSeconds: TimeInterval = 4.75 * 3600
+
+    /// Slack above the buffer before a span stops looking buffer-limited (drains aren't instant; a
+    /// little of the prior load can ride along). A span beyond this was drained overnight → complete.
+    static let bufferSlack: TimeInterval = 20 * 60
+
+    /// How far the captured onset must trail the scheduled bedtime before we call the front "missing".
+    static let minMissingOnset: TimeInterval = 90 * 60
+
+    public enum Coverage: Equatable, Sendable {
+        /// The captured night looks complete (or we can't tell it isn't).
+        case full
+        /// The captured span has the buffer-limited signature — early hours were likely overwritten
+        /// on the ring before any drain. The fix is overnight charging (so iOS runs the drain).
+        case likelyTruncated
+    }
+
+    /// Classify last night's coverage from WHERE the capture starts relative to bedtime.
+    ///
+    /// - Parameters:
+    ///   - capturedOnset: start of the captured in-bed window (the first staged epoch).
+    ///   - capturedInBed: the staged night's in-bed span (seconds). `0`/negative ⇒ `.full`.
+    ///   - scheduledBedtime: the user's bedtime for this night (from their sleep schedule), or `nil`
+    ///     when no schedule is set — without it we have no reference for "the front is missing".
+    /// - Returns: `.likelyTruncated` only on POSITIVE evidence: the span fits within the ring buffer
+    ///   (+slack) — so it could be a single buffer-load — AND the captured onset trails bedtime by at
+    ///   least `minMissingOnset` (the early hours are missing). Otherwise `.full`. A span beyond the
+    ///   buffer was drained overnight (complete); an onset at/near bedtime means the whole night fit
+    ///   in the buffer (complete, even if short); no schedule means we don't guess. Conservative by
+    ///   design — a missed flag just omits a tip, a false flag would nag.
+    public static func classify(capturedOnset: Date,
+                                capturedInBed: TimeInterval,
+                                scheduledBedtime: Date?) -> Coverage {
+        guard capturedInBed > 0 else { return .full }
+        // Drained past the buffer ⇒ nothing was lost to overflow.
+        guard capturedInBed <= ringBufferSeconds + bufferSlack else { return .full }
+        // No bedtime reference ⇒ can't distinguish truncation from a genuinely short night.
+        guard let bedtime = scheduledBedtime else { return .full }
+        // Truncation loses the FRONT: the captured onset lands well after bedtime.
+        return capturedOnset.timeIntervalSince(bedtime) >= minMissingOnset ? .likelyTruncated : .full
+    }
+}

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepCaptureCoverageTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepCaptureCoverageTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import OpenCircuitKit
+
+final class SleepCaptureCoverageTests: XCTestCase {
+    private let h = 3600.0
+    private typealias C = SleepCaptureCoverage
+
+    /// Bedtime 22:30; build onset/wake relative to it.
+    private func bedtime() -> Date { Date(timeIntervalSince1970: 1_780_000_000) }
+
+    /// The reported bug shape: bed 22:30, real wake ~07:00, but only the last ~4.75 h drained, so the
+    /// captured onset is ~02:15 (≈3.75 h after bedtime) — the front of the night is missing.
+    func testMissingFrontIsTruncated() {
+        let bed = bedtime()
+        let onset = bed.addingTimeInterval(3.75 * h)
+        XCTAssertEqual(C.classify(capturedOnset: onset, capturedInBed: 4.75 * h, scheduledBedtime: bed),
+                       .likelyTruncated)
+    }
+
+    /// A short night that FIT in the buffer (onset at bedtime, woke early after 4.5 h) is complete, not
+    /// truncated — this is the false positive duration-only flagging would have produced.
+    func testShortNightThatFitTheBufferIsFull() {
+        let bed = bedtime()
+        XCTAssertEqual(C.classify(capturedOnset: bed, capturedInBed: 4.5 * h, scheduledBedtime: bed),
+                       .full)
+    }
+
+    /// A full night (span beyond the buffer) is complete regardless of onset — it was drained overnight.
+    func testOverBufferIsFull() {
+        let bed = bedtime()
+        let onset = bed.addingTimeInterval(4 * h)   // even a late onset
+        XCTAssertEqual(C.classify(capturedOnset: onset, capturedInBed: 8 * h, scheduledBedtime: bed),
+                       .full)
+    }
+
+    /// Onset only slightly after bedtime (< minMissingOnset) is not a missing front.
+    func testOnsetNearBedtimeIsFull() {
+        let bed = bedtime()
+        let onset = bed.addingTimeInterval(30 * 60)
+        XCTAssertEqual(C.classify(capturedOnset: onset, capturedInBed: 4.6 * h, scheduledBedtime: bed),
+                       .full)
+    }
+
+    /// Onset BEFORE bedtime (went to bed early) is never truncated.
+    func testOnsetBeforeBedtimeIsFull() {
+        let bed = bedtime()
+        let onset = bed.addingTimeInterval(-20 * 60)
+        XCTAssertEqual(C.classify(capturedOnset: onset, capturedInBed: 4.5 * h, scheduledBedtime: bed),
+                       .full)
+    }
+
+    /// No schedule ⇒ no bedtime reference ⇒ never flagged (avoids nagging when we can't tell).
+    func testNoScheduleIsFull() {
+        let onset = bedtime().addingTimeInterval(4 * h)
+        XCTAssertEqual(C.classify(capturedOnset: onset, capturedInBed: 4.75 * h, scheduledBedtime: nil),
+                       .full)
+    }
+
+    /// Degenerate / empty spans are treated as "can't tell" → full.
+    func testZeroSpanIsFull() {
+        let bed = bedtime()
+        XCTAssertEqual(C.classify(capturedOnset: bed, capturedInBed: 0, scheduledBedtime: bed), .full)
+        XCTAssertEqual(C.classify(capturedOnset: bed, capturedInBed: -10, scheduledBedtime: bed), .full)
+    }
+
+    /// Boundary: a span just past the buffer + slack is full even with a late onset.
+    func testJustOverBufferPlusSlackIsFull() {
+        let bed = bedtime()
+        let onset = bed.addingTimeInterval(3 * h)
+        XCTAssertEqual(C.classify(capturedOnset: onset,
+                                  capturedInBed: C.ringBufferSeconds + C.bufferSlack + 60,
+                                  scheduledBedtime: bed), .full)
+    }
+
+    /// Boundary: onset exactly minMissingOnset after bedtime, span within buffer ⇒ truncated.
+    func testOnsetExactlyAtThresholdIsTruncated() {
+        let bed = bedtime()
+        let onset = bed.addingTimeInterval(C.minMissingOnset)
+        XCTAssertEqual(C.classify(capturedOnset: onset, capturedInBed: 4.75 * h, scheduledBedtime: bed),
+                       .likelyTruncated)
+    }
+}


### PR DESCRIPTION
## Why
The ring holds only ~4.75h of history and overwrites the oldest. Without an overnight drain, only the last ~4.75h of a night survive — the "I slept 9h but it shows 5h" gap. The background-drain machinery already maximizes every wake (full-buffer drain per BGTask run + standing reconnect); the one real lever is the phone **charging**, when iOS runs background tasks reliably. This surfaces that to the user.

## What
- New pure `SleepCaptureCoverage.classify(capturedOnset:capturedInBed:scheduledBedtime:)` — flags `.likelyTruncated` only on **positive evidence**: the span fits the ring buffer AND the captured onset trails the scheduled bedtime by ≥90m (the *front* of the night is missing). Never guesses from duration alone (no schedule / onset≈bedtime / span past buffer → `.full`), so it doesn't nag genuinely short sleepers.
- `SleepCardView` shows a concise "Synced only from <time> — keep charging nearby" tip when truncated (schedule-gated; shows onset, not a second hour figure).
- 9 unit tests (501 Kit tests total green); app builds for simulator.

## Honest scope
This does **not** make iOS drain more often (that ceiling is OS-imposed and the code already maxes it) — it tells the user how to capture the full night. Residual: a late-to-bed + short + drained night is a narrow false positive, but the tip text stays literally true.

## Review
Adversarially reviewed (2 rounds); both initial false-positive findings resolved by switching from a duration heuristic to the onset-vs-bedtime signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)