### PR TITLE
fix(sleep): stop self-contending overnight — quiet during the sleep window

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -176,6 +176,19 @@ opens at ≈now first (the official app OR us) drains the backlog and advances i
 with nothing. (This is why overnight sleep "vanished" — even after the cursor fix, a competing
 official-app sync can still win the one-time backlog.)
 
+> **🟢 SELF-contention confirmed on-device (night of 2026-06-21→22, device unified log).** The other
+> contender does NOT have to be the official app — it can be **us**. With OpenCircuit the sole syncer
+> (no official app running), our own keepalive `periodic history drain` opened at cursor≈now every
+> ~90 min ALL NIGHT; each open advanced the shared resume pointer past the night, so the morning had
+> no backlog to hand off. The whole night drained as **~12 epochs total** (1–3 per drain), every sync
+> `sleepSegs=0`, and the Sleep card silently held the prior night's value. The earlier "~4.75 h buffer
+> overflow" rationale for draining overnight is **wrong for the sleep channel** — §3 above shows the
+> first open drained a **19-day** backlog in one shot, so the ring buffers history for days, not hours.
+> **Fix (2026-06-22):** OpenCircuit now goes quiet inside the user's sleep window — NO history drains and
+> NO `syncAll` live reads (it keeps only the `07 00 00` fetch heartbeat, which doesn't touch the
+> history pointer, so skin temp + the wear gate still stream) — and does ONE big drain after the window
+> ends, mirroring the official app's morning sync. See `RingSession.isInSleepWindow`.
+
 **The fix in OpenCircuit:** (1) history/overnight opens use `Command.syncUpToNow()`
 (cursor = `floor(now) − epoch`), exactly the app's history behaviour — this part is solid (the
 capture proves cursor≈now drains, and lower-bound is ruled out, so it can't return empty). (2)

--- a/ios/OpenCircuit/BLE/RingScanner.swift
+++ b/ios/OpenCircuit/BLE/RingScanner.swift
@@ -436,10 +436,13 @@ final class RingScanner: NSObject {
                     // automatic syncs never refreshed daytime SpO₂.
                     session.syncHistory()
                     didDrain = true
-                } else if session.syncing == false && !startedLiveRead {
+                } else if session.syncing == false && !startedLiveRead && !session.isInSleepWindow {
                     // Backlog committed — now a quick optical HR read (syncAll → empty → fast lock),
                     // NOT user-initiated so any prior live HR stays until a fresh one locks. The
                     // extended background timeout gives this poll a real budget past its warm-up (#45 A).
+                    // Skipped in the sleep window: a live read opens `syncAll` (FFFFFFFF), whose
+                    // resume-pointer effect is the 🟡 backlog-shredder risk (PROTOCOL.md §3) — so an
+                    // overnight BGTask leaves the ring fully alone to log the night for one morning sync.
                     session.startMonitoring(mode: .hr, userInitiated: false, quickLiveRead: true)
                     startedLiveRead = true
                 }

--- a/ios/OpenCircuit/BLE/RingSession.swift
+++ b/ios/OpenCircuit/BLE/RingSession.swift
@@ -577,12 +577,21 @@ final class RingSession: NSObject {
                     // session drains shortly after (re)connect (lastDrainAt nil ⇒ due) yet a flapping
                     // link can't re-drain more often than the interval. Safe to repeat because
                     // `finalizeSync` re-stitches the night from the EpochArchive union.
-                    let isNight = self.nightWindow?.contains(Date()) ?? false
                     let saver = UserDefaults.standard.bool(forKey: Self.batterySaverEnabledKey)
-                    if self.gotDataFrame,
+                    // Drain history on a cadence — but NEVER inside the sleep window. A history open
+                    // (`02 .. cursor≈now ..`) advances the ring's SINGLE resume pointer (PROTOCOL.md §3
+                    // "Contention"); draining every ~90 min overnight kept advancing it past the night,
+                    // so the morning had no backlog left to hand off (device log 06-22: ~12 sleep epochs
+                    // ALL NIGHT, every drain sleepSegs=0). The official app never syncs overnight — it
+                    // does ONE big morning sync of the whole night — so we leave the backlog untouched in
+                    // the window and let the first drain AFTER it (daytime cadence) pull the night whole.
+                    // The `fetch` heartbeat still fires through the night: it only reads the 0x10/0x87
+                    // descriptor (steps/temp/battery) and does NOT touch the history pointer, so skin
+                    // temp (#69) and the wear gate keep their overnight stream.
+                    if self.gotDataFrame, !self.isInSleepWindow,
                        HistoryDrainCadence.isDue(lastDrainAt: self.epochArchiveStore.lastDrainAt,
-                                                 now: Date(), isNight: isNight, batterySaver: saver) {
-                        ringLog.notice("sync: periodic history drain (keep the ring's ~4.75 h buffer emptied)")
+                                                 now: Date(), isNight: false, batterySaver: saver) {
+                        ringLog.notice("sync: periodic history drain (daytime backlog; overnight left for one morning sync)")
                         self.syncHistory()
                     } else {
                         self.write(Command.fetch)   // 07 00 00 → fresh 0x10/0x87 descriptor
@@ -664,7 +673,11 @@ final class RingSession: NSObject {
     /// measurement, a sync, the live-enter drain, or a workout (which owns the link and must not be
     /// torn down by an auto-measure firing mid-session).
     private var idleForAutoMeasure: Bool {
-        ready && !monitoring && !livePreparing && syncTask == nil && !workoutHolding
+        // `!isInSleepWindow`: an auto-measure enters live mode, which opens a sync and can advance the
+        // ring's resume pointer (syncAll's pointer effect is the 🟡 backlog-shredder risk, PROTOCOL.md
+        // §3) — exactly what we must avoid overnight so the night's backlog survives for one morning
+        // sync. Overnight HR/SpO₂ come from the synced sleep epochs anyway, so nothing is lost.
+        ready && !monitoring && !livePreparing && syncTask == nil && !workoutHolding && !isInSleepWindow
     }
 
     /// Next sleep between auto-measure cycles: the base interval while worn, exponentially backed
@@ -766,6 +779,27 @@ final class RingSession: NSObject {
             nightWindow = DateInterval(start: dayStart, end: dayStart.addingTimeInterval(6 * 3600))
         }
         nightWindowRefreshedAt = Date()
+    }
+
+    /// Whether `now` falls inside the user's sleep window — the gate that suppresses AUTOMATIC
+    /// history drains overnight (see `syncHistory(manual:)`, the keepalive loop, and
+    /// `idleForAutoMeasure`). A history open is `02 .. cursor≈now ..`, which advances the ring's
+    /// SINGLE resume pointer (PROTOCOL.md §3 "Contention"); draining every ~90 min through the night
+    /// kept advancing that pointer past the night, so by morning the ring had no backlog to hand off
+    /// (device log 06-22: ~12 sleep epochs the WHOLE night, every drain `sleepSegs=0` → the stale
+    /// Sleep card). The official app never syncs overnight — it does ONE big morning sync of the whole
+    /// night — and this matches it. Prefers the resolved `nightWindow`; falls back to the stored
+    /// manual/default schedule so the gate still holds before the async window resolves (e.g. a cold
+    /// background drain). MANUAL user syncs bypass this entirely (user intent wins).
+    var isInSleepWindow: Bool {
+        if let w = nightWindow { return w.contains(Date()) }
+        let d = UserDefaults.standard
+        SleepScheduleDefaults.register(d)
+        guard let w = SleepWindow.interval(
+            bedMinutes: d.integer(forKey: SleepScheduleDefaults.bedMinutes),
+            wakeMinutes: d.integer(forKey: SleepScheduleDefaults.wakeMinutes),
+            nightEndingNear: Date()) else { return false }
+        return w.contains(Date())
     }
 
     /// Persist decoded samples to the local store (the vitals dashboard reads from it, so
@@ -1078,7 +1112,15 @@ final class RingSession: NSObject {
     ///
     /// The official app drains both channels every sync; we previously only pulled `0x00`, so daytime
     /// SpO₂ went stale (the #99 gap — resolved by mining the captures, not a byte[6] selector sweep).
-    func syncHistory() {
+    func syncHistory(manual: Bool = false) {
+        // Automatic drains are SUPPRESSED inside the sleep window so the night's backlog accumulates
+        // untouched for ONE big morning sync (PROTOCOL.md §3 contention — see `isInSleepWindow`). A
+        // manual "Sync from ring" / pull-to-refresh passes `manual: true` and bypasses this; user
+        // intent wins (and a daytime manual sync is unaffected).
+        if !manual, isInSleepWindow {
+            ringLog.notice("sync: SKIP auto-drain — in sleep window; leaving the ring to log the night (morning sync pulls it whole)")
+            return
+        }
         guard syncTask == nil else { return }    // already syncing
         stopLiveMonitoring()                     // live polling would fight the drain
         syncTask = Task { [weak self] in

--- a/ios/OpenCircuit/ContentView.swift
+++ b/ios/OpenCircuit/ContentView.swift
@@ -239,7 +239,7 @@ struct ContentView: View {
         // Respect the Sync button's guards: never fight a live read / in-flight sync, and a
         // not-streaming ring would sync nothing (#54).
         guard !session.syncing, !session.monitoring, !session.notStreaming else { return }
-        session.syncHistory()
+        session.syncHistory(manual: true)   // user-initiated: bypass the overnight-quiet gate
         // `syncHistory()` latches `syncing` from inside its own Task, so wait briefly for it to
         // start, then hold until it finalizes. The drain now covers TWO channels (sleep 0x00 +
         // all-day 0x03), each with its own end-marker/quiet/45 s-cap watchdog, so the hold cap is
@@ -786,7 +786,7 @@ struct ContentView: View {
             freshnessRow
             Divider()
             Button {
-                session?.syncHistory()    // drains both channels: 0x00 sleep + 0x03 all-day (daytime SpO₂)
+                session?.syncHistory(manual: true)   // user-initiated: drains both channels (0x00 sleep + 0x03 all-day), bypasses overnight-quiet gate
             } label: {
                 Label(session?.syncing == true ? "Syncing…" : "Sync from ring",
                       systemImage: "arrow.triangle.2.circlepath")

--- a/ios/OpenCircuit/SleepCardView.swift
+++ b/ios/OpenCircuit/SleepCardView.swift
@@ -131,6 +131,34 @@ struct SleepCardView: View {
         }
     }
 
+    /// True when we're past this morning's expected wake yet the night on screen did NOT end today —
+    /// i.e. last night wasn't captured and we're falling back to an older recorded night. Gated on
+    /// being past the scheduled wake so a mid-sleep glance (e.g. 3 a.m., the night still in progress)
+    /// never claims a miss. Uses the same manual/default schedule the rest of the night gating uses.
+    /// Drives `missedNightNotice` so a stale total never silently reads as last night (the
+    /// overnight-self-contention failure mode).
+    private var lastNightMissing: Bool {
+        guard let night, night.wakeKnown else { return false }
+        let now = Date()
+        let wakeRef = SleepWindow.interval(bedMinutes: bedMinutes, wakeMinutes: wakeMinutes,
+                                           nightEndingNear: now)?.end ?? now
+        return now > wakeRef && !Calendar.current.isDateInToday(night.when)
+    }
+
+    /// Honest fallback banner shown above the stage details when `lastNightMissing`: last night didn't
+    /// make it into the store, so the night below is older. The header already carries its real date;
+    /// this makes sure the big total isn't mistaken for last night.
+    private var missedNightNotice: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "moon.zzz").font(.caption2).foregroundStyle(.orange)
+            Text("No sleep recorded for last night. Showing your most recent recorded night — wear the ring to bed and sync in the morning.")
+                .font(.caption2).foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 6).padding(.horizontal, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.orange.opacity(0.12)))
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 8) {
@@ -143,6 +171,7 @@ struct SleepCardView: View {
                 }
             }
             if let night {
+                if lastNightMissing { missedNightNotice }
                 content(night)
             } else {
                 emptyState

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/HistoryDrainCadence.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/HistoryDrainCadence.swift
@@ -9,6 +9,15 @@
 // fills — keeps it emptied. Safe to do repeatedly only because the night is re-stitched from the
 // EpochArchive union (a single drain returns just the slice since the last one).
 //
+// ⚠️ OVERNIGHT UPDATE (2026-06-22, device-log confirmed): draining DURING the sleep window is now
+// SUPPRESSED at the call site (`RingSession.isInSleepWindow`) — each cursor≈now open advanced the
+// ring's shared resume pointer past the night, so the morning had no backlog to hand off (~12 epochs
+// all night, every sync sleepSegs=0). The "~4.75 h buffer overflow" fear above is WRONG for the sleep
+// channel: PROTOCOL §3 shows a 19-day backlog drained in one shot, so the ring buffers for days. This
+// cadence now governs DAYTIME draining only; the night is left untouched for one morning sync (the
+// official app's behaviour). The `isNight` arm is retained for the pure unit tests but no longer
+// drives an overnight drain.
+//
 // Pure (no Apple frameworks) so it unit-tests on the CLI, matching KeepaliveCadence / ReconnectBackoff.
 
 import Foundation


### PR DESCRIPTION
## Problem
Overnight sleep stopped capturing even though OpenCircuit was the **sole** syncer. The device log (night 2026-06-21→22) showed the keepalive `periodic history drain` opening at cursor≈now every ~90 min **all night**; each open advances the ring's single shared resume pointer (`PROTOCOL.md §3`), so it kept marching past the night and orphaning it. The whole night drained as **~12 epochs total** (1–3 per drain), every sync `sleepSegs=0` → nothing staged → the Sleep card silently held the prior night ("timeAsleep stuck at 5h23m"). Worn + charged + normal routine, so a new failure — not wear, not the staging algo.

The "~4.75 h buffer overflow" rationale for draining overnight is **wrong for the sleep channel**: §3 shows the first open draining a **19-day** backlog in one shot, so the ring buffers for days. The official app never syncs overnight — it does **one big morning sync**.

## Fix — match the official app
- New `RingSession.isInSleepWindow` (resolved nightWindow, else stored/default schedule so the gate holds on a cold background drain).
- Keepalive loop: **no history drain** inside the window; keep the `07 00 00` fetch heartbeat (reads the 0x10/0x87 descriptor, does **not** touch the history pointer) so skin temp (#69) + the wear gate still stream overnight.
- `syncHistory(manual:)` gate — automatic callers (keepalive, BGTask, foreground auto-refresh) suppressed in the window; manual Sync / pull-to-refresh pass `manual: true` and always run.
- `idleForAutoMeasure` + the BGTask quick-HR read gated too: both open `syncAll` (FFFFFFFF), the documented pointer-shredder risk (§3).
- First drain **after** the window pulls the night whole.

## Honest UI
When last night isn't captured, the Sleep card now shows a **"No sleep recorded for last night"** notice instead of letting an older total read as current (shown only past the scheduled wake, so a mid-sleep glance doesn't false-flag).

## Docs
`PROTOCOL.md §3` records the self-contention finding; `HistoryDrainCadence` comment corrected (now daytime-only).

## Validation
Built + installed on-device (Debug). The real confirmation is tomorrow morning's capture; this PR ships the fix so it's testable tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)