### PR TITLE
feat(device-info): detect RingConn Gen 3 (FR05 → .gen3)

### DIFF
--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/FirmwareInfo.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/FirmwareInfo.swift
@@ -3,6 +3,13 @@
 //   FR01 → Gen 1
 //   FR02 → Gen 2
 //   FR04 → Gen 2 Air
+//   FR05 → Gen 3   (model "RingConn Gen3-C384", confirmed from an FR05.008 capture)
+//
+// Gen 3 note: an overnight FR05.008 / Gen3-C384 capture decodes byte-for-byte with the
+// Gen-2 schemas — the 0x10/0x87 status descriptor (battery/temp/voltage/steps/case) and
+// the 0x4c history epoch (HR/HRV/RR/SpO2, 0x96 counter step) are unchanged, and the
+// decoded overnight SpO2 nadir matched the official app's reported low. So Gen 3 is
+// labelled here for the device-info screen; no decode path branches on generation.
 //
 // `hasFirmwareMismatch`: the version is non-empty AND doesn't start with the pinned
 // string — a mismatch means we reverse-engineered on a different FW build and certain
@@ -18,6 +25,7 @@ public enum RingGeneration: String, Equatable, Sendable {
     case gen1    = "Gen 1"
     case gen2    = "Gen 2"
     case gen2Air = "Gen 2 Air"
+    case gen3    = "Gen 3"
     case unknown = "Unknown"
 }
 
@@ -43,11 +51,12 @@ public struct FirmwareInfo: Equatable, Sendable {
         !version.isEmpty && !version.hasPrefix(Self.pinnedVersion)
     }
 
-    /// Generation decoded from the four-character FW prefix (FR01/FR02/FR04).
+    /// Generation decoded from the four-character FW prefix (FR01/FR02/FR04/FR05).
     public var generation: RingGeneration {
         if version.hasPrefix("FR01") { return .gen1 }
         if version.hasPrefix("FR02") { return .gen2 }
         if version.hasPrefix("FR04") { return .gen2Air }
+        if version.hasPrefix("FR05") { return .gen3 }
         return .unknown
     }
 

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/FirmwareInfoTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/FirmwareInfoTests.swift
@@ -23,6 +23,12 @@ final class FirmwareInfoTests: XCTestCase {
         XCTAssertEqual(info.generation, .gen2Air)
     }
 
+    func testGen3Prefix() {
+        var info = FirmwareInfo()
+        info.version = "FR05.008"   // RingConn Gen3-C384
+        XCTAssertEqual(info.generation, .gen3)
+    }
+
     func testUnknownPrefix() {
         var info = FirmwareInfo()
         info.version = "FR99.001"


### PR DESCRIPTION
## What
Adds a `RingGeneration.gen3` case and maps the **FR05** firmware prefix to it, so a Gen 3 ring (model **RingConn Gen3-C384**) reports **"Gen 3"** on the device-info screen instead of **"Unknown"**.

## Why
A community tester (discussion #111) installed a build onto a **Gen 3** ring and sent an overnight diagnostic capture (firmware **FR05.008**, `RingConn Gen3-C384`). Today the app shows `Generation: Unknown` for it. This labels it correctly.

## Evidence the Gen 3 protocol is Gen-2-compatible
Decoded the full overnight capture (1,500 frames) against our existing Gen-2 schemas — everything lands:
- **0x10/0x87 status descriptor** decodes byte-for-byte: battery 86→90%, textbook Li-ion voltage curve (4231→4176 mV), sane skin-temp channels, case sentinel `0xff`, step counter.
- **0x4c history epoch** decodes byte-for-byte: 318 epochs, counter step `0x96` (2.5 min) unchanged, HR / HRV (246) / RR (242) / SpO₂ (108 sleep-vitals) all sane.
- **Cross-check:** our decoded overnight SpO₂ nadir **84%** ≈ the official app's reported "lowest blood oxygen **83%**."

No decode path branches on generation, so this change is **label-only** (enum case + prefix map + one test). The firmware-mismatch transparency banner is intentionally left unchanged — Gen 3 support is still validated against a single capture.

## Test
`swift test --filter FirmwareInfoTests` — 14/14 pass, incl. new `testGen3Prefix` (`FR05.008 → .gen3`).

## Not in scope
- Gen-3-exclusive app metrics (sleep-apnea AHI, "Circulation Stress" blood-pressure) — those are app-computed overlays on the SpO₂/PPG we already pull; the apnea AHI rides on the desaturations we decode, BP would need fresh PPG-feature RE.
- The tester's empty Sleep/HRV/RR is a separate, already-fixed issue (overnight self-contention; their build predates `cf94083`), not a Gen-3 decode gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)