### PR TITLE
fix: dedupe temp health alerts per night

### DIFF
--- a/ios/OpenCircuit/HealthNotificationCenter.swift
+++ b/ios/OpenCircuit/HealthNotificationCenter.swift
@@ -136,6 +136,28 @@ struct HealthNotificationStore {
         for n in notifs { raw[n.rawValue] = now.timeIntervalSince1970 }
         defaults.set(raw, forKey: Self.key)
     }
+
+    // Per-night ledger for the skin-temp/fever notifications (#85). Separate from `lastFired` (the
+    // rolling anti-spam backoff) because these flags describe ONE overnight summary and must fire at
+    // most once per night regardless of how many syncs land that day — see
+    // `TempFeverNotifications.freshForNight`. Stores each flag's already-notified night start-of-day.
+    private static let nightKey = "alerts.health.lastNight"   // [HealthNotification.rawValue: nightEpoch]
+
+    func lastNotifiedNight() -> [HealthNotification: Date] {
+        let raw = defaults.dictionary(forKey: Self.nightKey) as? [String: Double] ?? [:]
+        var out: [HealthNotification: Date] = [:]
+        for (k, v) in raw where v > 0 {
+            if let n = HealthNotification(rawValue: k) { out[n] = Date(timeIntervalSince1970: v) }
+        }
+        return out
+    }
+
+    func markNight(_ notifs: [HealthNotification], night: Date) {
+        guard !notifs.isEmpty else { return }
+        var raw = defaults.dictionary(forKey: Self.nightKey) as? [String: Double] ?? [:]
+        for n in notifs { raw[n.rawValue] = night.timeIntervalSince1970 }
+        defaults.set(raw, forKey: Self.nightKey)
+    }
 }
 
 // MARK: - The engine
@@ -195,23 +217,50 @@ struct HealthNotificationCenter {
         }
 
         // --- #85: skin-temp anomaly flags + suspected fever ------------------------------------
+        // These flags describe ONE overnight summary, so they de-dupe per night (not by the 2h
+        // backoff): once a night is notified, later syncs of the same night are dropped here so the
+        // user doesn't get the same "skin temperature dropped" alert after every sync. A new night's
+        // summary re-arms them.
+        var tempNight: Date?
         if HealthAlertDefaults.tempFeverEnabledValue() {
-            candidates += tempFeverCandidates(store: localStore)
+            let (tempCandidates, night) = tempFeverCandidates(store: localStore)
+            tempNight = night
+            if let night {
+                candidates += TempFeverNotifications.freshForNight(
+                    tempCandidates, night: night, lastNotifiedNight: store.lastNotifiedNight())
+            }
         }
 
         // --- Route survivors through the ONE shared gate (quiet hours + backoff) ---------------
         let quiet = HealthAlertDefaults.quietHours()
         let fire = gate.filter(candidates, now: now, lastFired: lastFired, quietHours: quiet)
-        guard !fire.isEmpty, await ensureAuthorized() else { return }
-        for n in fire { await post(n, hit: hitByNotif[n]) }
+        guard !fire.isEmpty else { return }
+        // Reserve the survivors SYNCHRONOUSLY — there is no `await` between reading `lastFired`
+        // above and this write, so on the main actor a second concurrent evaluate() (the app-open
+        // scene-active probe and the sync-complete trigger both fire and each starts its own Task)
+        // reads the mark and is gated out, instead of both passing and double-posting the same
+        // alert. Persisting before the ensureAuthorized() suspension is what closes that window.
         store.markFired(fire, at: now)
+        if let tempNight { store.markNight(fire.filter(Self.isTempFever), night: tempNight) }
+        guard await ensureAuthorized() else { return }
+        for n in fire { await post(n, hit: hitByNotif[n]) }
+    }
+
+    /// The #85 skin-temp/fever notifications, which de-dupe per night (see `markNight`).
+    private static func isTempFever(_ n: HealthNotification) -> Bool {
+        switch n {
+        case .skinTempRise, .skinTempDrop, .skinTempFluctuationRise, .skinTempFluctuationDrop, .fever:
+            return true
+        default:
+            return false
+        }
     }
 
     /// Compute the latest night's skin-temp anomaly flags (#69) + suspected fever (#72), then map
     /// them to notifications (#85). Reuses the SAME canonical SkinTempBaseline offset the Sleep card
     /// shows — temperature is not recomputed for fever.
-    private func tempFeverCandidates(store: LocalStore) -> [HealthNotification] {
-        guard let latest = try? store.latestSleepSummary(), latest.skinTempC > 0 else { return [] }
+    private func tempFeverCandidates(store: LocalStore) -> (candidates: [HealthNotification], night: Date?) {
+        guard let latest = try? store.latestSleepSummary(), latest.skinTempC > 0 else { return ([], nil) }
         let nights = ((try? store.recentSleepSummaries(limit: 40)) ?? []).filter { $0.skinTempC > 0 }
         let cal = Calendar.current
         let tonightDay = cal.startOfDay(for: latest.night)
@@ -224,7 +273,8 @@ struct HealthNotificationCenter {
 
         // Fever: resting-HR baseline vs today + the canonical temp offset (#72 owns the logic).
         let fever = suspectedFever(store: store, tempOffsetC: report.offsetC)
-        return TempFeverNotifications.notifications(flags: report.flags, feverSuspected: fever)
+        let notifs = TempFeverNotifications.notifications(flags: report.flags, feverSuspected: fever)
+        return (notifs, tonightDay)
     }
 
     /// Resting-HR daily series → personal baseline, cross-referenced with the temp offset for the

--- a/ios/OpenCircuit/HealthNotificationCenter.swift
+++ b/ios/OpenCircuit/HealthNotificationCenter.swift
@@ -141,21 +141,23 @@ struct HealthNotificationStore {
     // rolling anti-spam backoff) because these flags describe ONE overnight summary and must fire at
     // most once per night regardless of how many syncs land that day — see
     // `TempFeverNotifications.freshForNight`. Stores each flag's already-notified night start-of-day.
-    private static let nightKey = "alerts.health.lastNight"   // [HealthNotification.rawValue: nightEpoch]
+    private static let nightKey = "alerts.health.lastNight"   // [HealthNotification.rawValue: yyyymmdd dayKey]
 
-    func lastNotifiedNight() -> [HealthNotification: Date] {
-        let raw = defaults.dictionary(forKey: Self.nightKey) as? [String: Double] ?? [:]
-        var out: [HealthNotification: Date] = [:]
+    func lastNotifiedNight() -> [HealthNotification: Int] {
+        // A pre-migration install stored fractional epoch instants here; those fail the `[String: Int]`
+        // cast so the ledger reads empty and re-arms once — a bounded, one-time re-fire on upgrade.
+        let raw = defaults.dictionary(forKey: Self.nightKey) as? [String: Int] ?? [:]
+        var out: [HealthNotification: Int] = [:]
         for (k, v) in raw where v > 0 {
-            if let n = HealthNotification(rawValue: k) { out[n] = Date(timeIntervalSince1970: v) }
+            if let n = HealthNotification(rawValue: k) { out[n] = v }
         }
         return out
     }
 
-    func markNight(_ notifs: [HealthNotification], night: Date) {
+    func markNight(_ notifs: [HealthNotification], night: Int) {
         guard !notifs.isEmpty else { return }
-        var raw = defaults.dictionary(forKey: Self.nightKey) as? [String: Double] ?? [:]
-        for n in notifs { raw[n.rawValue] = night.timeIntervalSince1970 }
+        var raw = defaults.dictionary(forKey: Self.nightKey) as? [String: Int] ?? [:]
+        for n in notifs { raw[n.rawValue] = night }
         defaults.set(raw, forKey: Self.nightKey)
     }
 }
@@ -221,13 +223,14 @@ struct HealthNotificationCenter {
         // backoff): once a night is notified, later syncs of the same night are dropped here so the
         // user doesn't get the same "skin temperature dropped" alert after every sync. A new night's
         // summary re-arms them.
-        var tempNight: Date?
+        var tempNightKey: Int?
         if HealthAlertDefaults.tempFeverEnabledValue() {
             let (tempCandidates, night) = tempFeverCandidates(store: localStore)
-            tempNight = night
             if let night {
+                let key = TempFeverNotifications.dayKey(for: night)
+                tempNightKey = key
                 candidates += TempFeverNotifications.freshForNight(
-                    tempCandidates, night: night, lastNotifiedNight: store.lastNotifiedNight())
+                    tempCandidates, night: key, lastNotifiedNight: store.lastNotifiedNight())
             }
         }
 
@@ -235,25 +238,26 @@ struct HealthNotificationCenter {
         let quiet = HealthAlertDefaults.quietHours()
         let fire = gate.filter(candidates, now: now, lastFired: lastFired, quietHours: quiet)
         guard !fire.isEmpty else { return }
-        // Reserve the survivors SYNCHRONOUSLY — there is no `await` between reading `lastFired`
-        // above and this write, so on the main actor a second concurrent evaluate() (the app-open
-        // scene-active probe and the sync-complete trigger both fire and each starts its own Task)
-        // reads the mark and is gated out, instead of both passing and double-posting the same
-        // alert. Persisting before the ensureAuthorized() suspension is what closes that window.
+        // Reserve the survivors against the anti-spam backoff SYNCHRONOUSLY — there is no `await`
+        // between reading `lastFired` above and this write, so on the main actor a second concurrent
+        // evaluate() (the app-open scene-active probe and the sync-complete trigger both fire and
+        // each starts its own Task) reads the mark and is gated out, instead of both passing and
+        // double-posting the same alert. This must stay BEFORE the ensureAuthorized() suspension —
+        // that's what closes the window. `markNight`, by contrast, is deferred until AFTER auth
+        // succeeds: unlike the 2h backoff the night ledger has no time-based self-heal (it only
+        // re-arms on a strictly newer night), so claiming a night here would silently swallow a
+        // real fever/skin-temp flag for the whole day if auth was denied and nothing was posted.
         store.markFired(fire, at: now)
-        if let tempNight { store.markNight(fire.filter(Self.isTempFever), night: tempNight) }
         guard await ensureAuthorized() else { return }
+        if let tempNightKey { store.markNight(fire.filter(Self.isTempFever), night: tempNightKey) }
         for n in fire { await post(n, hit: hitByNotif[n]) }
     }
 
-    /// The #85 skin-temp/fever notifications, which de-dupe per night (see `markNight`).
+    /// Whether `n` is one of the #85 skin-temp/fever notifications that de-dupe per night (see
+    /// `markNight`). Membership is the single `TempFeverNotifications.notificationSet` source of
+    /// truth, so a new skin-temp case can't silently miss the ledger and regress to every-2h re-fire.
     private static func isTempFever(_ n: HealthNotification) -> Bool {
-        switch n {
-        case .skinTempRise, .skinTempDrop, .skinTempFluctuationRise, .skinTempFluctuationDrop, .fever:
-            return true
-        default:
-            return false
-        }
+        TempFeverNotifications.notificationSet.contains(n)
     }
 
     /// Compute the latest night's skin-temp anomaly flags (#69) + suspected fever (#72), then map
@@ -388,13 +392,16 @@ struct HealthNotificationCenter {
     /// stated intent in `copy(for:)` ("no medical disclaimer appended — they're lifestyle
     /// reminders"), which the previous unconditional append in `post` contradicted.
     private static func appendsDisclaimer(_ n: HealthNotification) -> Bool {
+        // Exhaustive (no `default`) so a new enum case forces a compile-time decision here. The
+        // temp/fever cases resolve through the shared `TempFeverNotifications.notificationSet` so
+        // this and `isTempFever` can never drift.
         switch n {
-        case .highHR, .lowSpO2, .elevatedHRInactive,
-             .skinTempRise, .skinTempDrop, .skinTempFluctuationRise, .skinTempFluctuationDrop,
-             .fever:
+        case .highHR, .lowSpO2, .elevatedHRInactive:
             return true
         case .sedentaryReminder, .wearReminder, .bedtimeReminder, .chargingComplete:
             return false
+        case .skinTempRise, .skinTempDrop, .skinTempFluctuationRise, .skinTempFluctuationDrop, .fever:
+            return TempFeverNotifications.notificationSet.contains(n)
         }
     }
 

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
@@ -211,6 +211,22 @@ public enum HealthAlertEvaluator {
 // MARK: - #85 routing (temp flags + fever → notifications)
 
 public enum TempFeverNotifications {
+    /// The #85 skin-temp/fever notifications — the ones that de-dupe per night. Single source of
+    /// truth so every classifier (`notifications` routing, the app-side `isTempFever` filter, and
+    /// the disclaimer logic) stays in lock-step; adding a skin-temp case means adding it here once.
+    public static let notificationSet: Set<HealthNotification> = [
+        .skinTempRise, .skinTempDrop, .skinTempFluctuationRise, .skinTempFluctuationDrop, .fever,
+    ]
+
+    /// Timezone-stable `yyyymmdd` day key for a night's start-of-day. Used as the per-night ledger
+    /// key instead of a raw instant: an instant (`timeIntervalSince1970`) shifts under westward
+    /// travel between two syncs of the same night, which could re-fire the duplicate; the calendar
+    /// day components do not.
+    public static func dayKey(for night: Date, calendar: Calendar = .current) -> Int {
+        let c = calendar.dateComponents([.year, .month, .day], from: night)
+        return (c.year ?? 0) * 10_000 + (c.month ?? 0) * 100 + (c.day ?? 0)
+    }
+
     /// Map the four `SkinTempBaseline` anomaly flags (#69) + the suspected-fever flag (#72) to the
     /// notifications they should raise. Pure flag→notification routing; the de-dupe/DND gate and
     /// posting happen in the shared app-side center. (#85)
@@ -230,10 +246,10 @@ public enum TempFeverNotifications {
     /// syncs of the same night — the 2h anti-spam backoff alone would re-raise the same night's flag
     /// every couple hours all day (the user sees the same "skin temperature dropped" alert after
     /// every sync). Keeps only the flags whose night is strictly newer than the last night already
-    /// notified for that flag; a fresh night's summary re-arms it. `night` and the map values are the
-    /// summary's start-of-day.
-    public static func freshForNight(_ candidates: [HealthNotification], night: Date,
-                                     lastNotifiedNight: [HealthNotification: Date]) -> [HealthNotification] {
+    /// notified for that flag; a fresh night's summary re-arms it. `night` and the map values are
+    /// timezone-stable `yyyymmdd` day keys (see `dayKey(for:)`).
+    public static func freshForNight(_ candidates: [HealthNotification], night: Int,
+                                     lastNotifiedNight: [HealthNotification: Int]) -> [HealthNotification] {
         candidates.filter { n in
             guard let last = lastNotifiedNight[n] else { return true }
             return night > last

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
@@ -224,4 +224,19 @@ public enum TempFeverNotifications {
         if feverSuspected { out.append(.fever) }
         return out
     }
+
+    /// Per-NIGHT de-dupe for the skin-temp/fever notifications. Each of these flags pertains to ONE
+    /// overnight summary, so once we've notified for a given night it must NOT re-fire on later
+    /// syncs of the same night — the 2h anti-spam backoff alone would re-raise the same night's flag
+    /// every couple hours all day (the user sees the same "skin temperature dropped" alert after
+    /// every sync). Keeps only the flags whose night is strictly newer than the last night already
+    /// notified for that flag; a fresh night's summary re-arms it. `night` and the map values are the
+    /// summary's start-of-day.
+    public static func freshForNight(_ candidates: [HealthNotification], night: Date,
+                                     lastNotifiedNight: [HealthNotification: Date]) -> [HealthNotification] {
+        candidates.filter { n in
+            guard let last = lastNotifiedNight[n] else { return true }
+            return night > last
+        }
+    }
 }

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
@@ -77,6 +77,31 @@ final class HealthAlertsTests: XCTestCase {
                                                           feverSuspected: false).isEmpty)
     }
 
+    func testFreshForNightDropsAlreadyNotifiedNight() {
+        let night = cal.startOfDay(for: at(3))          // this overnight's summary
+        let cands: [HealthNotification] = [.skinTempFluctuationDrop, .fever]
+        // Same night already notified for the fluctuation drop → drop it, keep the unnotified fever.
+        let fresh = TempFeverNotifications.freshForNight(
+            cands, night: night, lastNotifiedNight: [.skinTempFluctuationDrop: night])
+        XCTAssertEqual(fresh, [.fever], "same night must not re-fire the same flag")
+        // No prior night for either → both survive.
+        XCTAssertEqual(TempFeverNotifications.freshForNight(cands, night: night, lastNotifiedNight: [:]),
+                       cands)
+    }
+
+    func testFreshForNightReArmsOnNewerNight() {
+        let lastNight = cal.startOfDay(for: at(3))
+        let newerNight = cal.date(byAdding: .day, value: 1, to: lastNight)!
+        let fresh = TempFeverNotifications.freshForNight(
+            [.skinTempFluctuationDrop], night: newerNight,
+            lastNotifiedNight: [.skinTempFluctuationDrop: lastNight])
+        XCTAssertEqual(fresh, [.skinTempFluctuationDrop], "a new night's summary re-arms the alert")
+        // A stale (older) recompute of a night we've moved past must not re-fire.
+        XCTAssertTrue(TempFeverNotifications.freshForNight(
+            [.skinTempFluctuationDrop], night: lastNight,
+            lastNotifiedNight: [.skinTempFluctuationDrop: newerNight]).isEmpty)
+    }
+
     // MARK: Quiet hours (DND)
 
     func testQuietHoursWrapsMidnight() {

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
@@ -78,7 +78,7 @@ final class HealthAlertsTests: XCTestCase {
     }
 
     func testFreshForNightDropsAlreadyNotifiedNight() {
-        let night = cal.startOfDay(for: at(3))          // this overnight's summary
+        let night = TempFeverNotifications.dayKey(for: at(3), calendar: cal)   // this overnight's summary
         let cands: [HealthNotification] = [.skinTempFluctuationDrop, .fever]
         // Same night already notified for the fluctuation drop → drop it, keep the unnotified fever.
         let fresh = TempFeverNotifications.freshForNight(
@@ -90,8 +90,10 @@ final class HealthAlertsTests: XCTestCase {
     }
 
     func testFreshForNightReArmsOnNewerNight() {
-        let lastNight = cal.startOfDay(for: at(3))
-        let newerNight = cal.date(byAdding: .day, value: 1, to: lastNight)!
+        let lastNightDate = cal.startOfDay(for: at(3))
+        let lastNight = TempFeverNotifications.dayKey(for: lastNightDate, calendar: cal)
+        let newerNight = TempFeverNotifications.dayKey(
+            for: cal.date(byAdding: .day, value: 1, to: lastNightDate)!, calendar: cal)
         let fresh = TempFeverNotifications.freshForNight(
             [.skinTempFluctuationDrop], night: newerNight,
             lastNotifiedNight: [.skinTempFluctuationDrop: lastNight])
@@ -100,6 +102,24 @@ final class HealthAlertsTests: XCTestCase {
         XCTAssertTrue(TempFeverNotifications.freshForNight(
             [.skinTempFluctuationDrop], night: lastNight,
             lastNotifiedNight: [.skinTempFluctuationDrop: newerNight]).isEmpty)
+    }
+
+    func testDayKeyIsTimezoneStableAcrossWestwardTravel() {
+        // The SAME night instant, keyed after westward travel (offset decreasing) between two syncs.
+        // The old ledger stored `startOfDay(...).timeIntervalSince1970`, whose instant shifts later
+        // under that travel and re-fires the duplicate; the yyyymmdd day key must stay put.
+        var east = Calendar(identifier: .gregorian)
+        east.timeZone = TimeZone(identifier: "America/New_York")!    // UTC-4 in June
+        var west = Calendar(identifier: .gregorian)
+        west.timeZone = TimeZone(identifier: "America/Los_Angeles")! // UTC-7 in June
+        // 2026-06-17 12:00 UTC → 08:00 in ET, 05:00 in PT: same calendar day in both zones.
+        var utc = Calendar(identifier: .gregorian); utc.timeZone = TimeZone(identifier: "UTC")!
+        let night = utc.date(from: DateComponents(year: 2026, month: 6, day: 17, hour: 12))!
+        XCTAssertEqual(TempFeverNotifications.dayKey(for: night, calendar: east),
+                       TempFeverNotifications.dayKey(for: night, calendar: west),
+                       "day key must be stable across timezone shifts of the same night")
+        // Sanity: the discarded start-of-day instants really do differ across the two zones.
+        XCTAssertNotEqual(east.startOfDay(for: night), west.startOfDay(for: night))
     }
 
     // MARK: Quiet hours (DND)


### PR DESCRIPTION
## Summary

- Add per-night dedupe for skin-temperature/fever health notifications so the same overnight summary does not re-alert after every sync.
- Reserve health-alert notifications synchronously before notification authorization awaits, closing the foreground/sync-complete double-post race.
- Add focused coverage for same-night suppression, first-time pass-through, next-night re-arm, and stale older-night suppression.

## Verification

- `git pull --ff-only`
- `brew install xcodegen`
- `softwareupdate --install 'Command Line Tools for Xcode 26.6-26.6'`
- `xcodegen generate`
- `swift build` from `ios/OpenCircuitKit`
- focused compiled Swift assertion executable linked against the built `OpenCircuitKit` object files
- `git diff --check`

## Notes

- `swift test` still cannot run on this host because the Apple Command Line Tools install does not provide `XCTest` (`no such module 'XCTest'`).
- `xcodebuild` still cannot run because full Xcode is not installed/selected; this host only has `/Library/Developer/CommandLineTools`.
