### PR TITLE
fix: narrow HealthKit step sample window

### DIFF
--- a/ios/OpenCircuit/Health/HealthKitWriter.swift
+++ b/ios/OpenCircuit/Health/HealthKitWriter.swift
@@ -156,22 +156,27 @@ final class HealthKitWriter {
         let profile = Self.storedUserProfile()
 
         // Steps + distance estimate (#81): write both atomically from the same pending delta.
-        // HealthKit SUMS stepCount / distanceWalkingRunning, so writing the delta lands the
-        // day's running total without re-adding on every sync. Distance is an ESTIMATE
-        // (steps × height-based stride — not GPS) and is labeled as such in HealthKit metadata.
+        // HealthKit stepCount is cumulative, but Apple Health resolves overlapping sources by
+        // priority. Writing the ring delta as an all-day sample can shadow Watch/iPhone steps for
+        // that whole day, so the delta is saved over a narrow window near the latest observation.
+        // Distance is an ESTIMATE (steps × height-based stride — not GPS) and is labeled as such.
         // To avoid double counting against a recorded foot-based workout's GPS distance (which
         // also writes .distanceWalkingRunning), the estimate is netted by any uncredited workout
         // GPS distance for today — preferring the accurate GPS measurement (#).
-        if let delta = try? store.pendingStepDelta(), delta > 0 {
+        if let pendingSteps = try? store.pendingStepWrite() {
             let now = Date()
+            let delta = pendingSteps.delta
             let startOfDay = Calendar.current.startOfDay(for: now)
+            let observedAt = Swift.min(Swift.max(pendingSteps.observedAt, startOfDay), now)
+            let writeStart = Swift.max(startOfDay, observedAt.addingTimeInterval(-60))
+            let writeEnd = observedAt
             let rawDistanceM = DistanceEstimate.meters(steps: delta, profile: profile)
             let (netDistanceM, gpsReduction) = Self.netDistanceEstimate(rawDistanceM, day: startOfDay)
             var toWrite: [QuantitySample] = [
-                QuantitySample(kind: .steps, start: startOfDay, end: now, value: Double(delta))
+                QuantitySample(kind: .steps, start: writeStart, end: writeEnd, value: Double(delta))
             ]
             if netDistanceM > 0 {
-                toWrite.append(QuantitySample(kind: .distance, start: startOfDay, end: now, value: netDistanceM))
+                toWrite.append(QuantitySample(kind: .distance, start: writeStart, end: writeEnd, value: netDistanceM))
             }
             do {
                 try await write(toWrite)

--- a/ios/OpenCircuit/Store/LocalStore.swift
+++ b/ios/OpenCircuit/Store/LocalStore.swift
@@ -708,6 +708,18 @@ struct LocalStore {
         return max(row.steps - row.healthWrittenSteps, 0)
     }
 
+    /// Pending step delta plus the most recent ring-step observation timestamp. HealthKit step
+    /// samples should use a narrow observation window, not an all-day range, otherwise Apple
+    /// Health's source-priority handling can let OpenCircuit shadow Watch/iPhone steps all day.
+    func pendingStepWrite(day: Date = Date()) throws -> (delta: Int, observedAt: Date)? {
+        let dayStart = Calendar.current.startOfDay(for: day)
+        let descriptor = FetchDescriptor<StoredDaily>(predicate: #Predicate { $0.day == dayStart })
+        guard let row = try? context.fetch(descriptor).first else { return nil }
+        let delta = max(row.steps - row.healthWrittenSteps, 0)
+        guard delta > 0 else { return nil }
+        return (delta, row.updatedAt)
+    }
+
     /// Record that `delta` more of today's steps are now reflected in Apple Health. Advancing
     /// by the delta just written (rather than to an external total) keeps the watermark exactly
     /// in step with what was pushed, so the next `pendingStepDelta` is correct.


### PR DESCRIPTION
## Summary

- Change HealthKit step writes from an all-day `startOfDay -> now` sample to a narrow observation window near the latest ring step update.
- Keep the existing `healthWrittenSteps` delta watermark, so repeated syncs still avoid re-writing the same OpenCircuit steps.
- Apply the same narrowed interval to the derived step-distance sample written in the same HealthKit batch.

## Why

OpenCircuit was writing a pending ring step delta as one additive `.stepCount` sample covering the whole day. Apple Health prioritizes overlapping sources for similar data, so that all-day OpenCircuit sample can shadow Apple Watch/iPhone steps for the entire day and make the Health app show only ring steps after sync.

The ring does not provide per-step timestamps, so this patch writes the delta over `observedAt - 60s ... observedAt` using the existing `StoredDaily.updatedAt` timestamp from the latest ring step observation.

## Verification

- `xcodegen generate`
- `swift build` from `ios/OpenCircuitKit`
- `git diff --check`

## Not Run / Blocked

- `swift test --package-path ios/OpenCircuitKit` still fails on this host because `XCTest` is unavailable in the installed Command Line Tools environment.
- `xcrun --sdk iphoneos --show-sdk-path` fails because the iOS SDK/full Xcode is not installed, so the iOS app target could not be compiled locally.
