### PR TITLE
chore: dispatch Bluna GitHub mentions

### DIFF
--- a/.github/workflows/bluna-mentions.yml
+++ b/.github/workflows/bluna-mentions.yml
@@ -1,0 +1,100 @@
+name: Bluna Mentions
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted, edited]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: bluna-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch tagged request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGER_SECRET: ${{ secrets.BLUNA_TRIGGER_SECRET }}
+          TRIGGER_URL: https://trigger.standardsoftware.io/trigger
+        run: |
+          set -euo pipefail
+
+          event_name="${GITHUB_EVENT_NAME}"
+          event_path="${GITHUB_EVENT_PATH}"
+          repo="${GITHUB_REPOSITORY}"
+
+          text="$(jq -r '.comment.body // .review.body // ""' "$event_path")"
+          if ! grep -qi '@bluna-ai' <<<"$text"; then
+            echo "No @bluna-ai mention; skipping."
+            exit 0
+          fi
+
+          if [[ -z "${TRIGGER_SECRET}" ]]; then
+            echo "BLUNA_TRIGGER_SECRET is not configured." >&2
+            exit 1
+          fi
+
+          number="$(jq -r '.issue.number // .pull_request.number' "$event_path")"
+          title="$(jq -r '.issue.title // .pull_request.title' "$event_path")"
+          body="$(jq -r '.issue.body // .pull_request.body // ""' "$event_path")"
+          url="$(jq -r '.issue.html_url // .pull_request.html_url' "$event_path")"
+          labels="$(jq -c '[((.issue.labels // .pull_request.labels // [])[]?.name)]' "$event_path")"
+
+          is_pr="false"
+          if jq -e '(.issue.pull_request? != null) or (.pull_request? != null)' "$event_path" >/dev/null; then
+            is_pr="true"
+          fi
+          subject_type="$([[ "$is_pr" == "true" ]] && echo PR || echo issue)"
+
+          if [[ "$is_pr" != "true" ]] && jq -e '((.issue.labels // [])[]?.name == "bluna-queued")' "$event_path" >/dev/null; then
+            echo "Issue already queued; skipping duplicate dispatch."
+            exit 0
+          fi
+
+          gh label create bluna-queued \
+            --repo "$repo" \
+            --color 0075ca \
+            --description "Picked up by Bluna AI" \
+            2>/dev/null || true
+
+          gh issue edit "$number" --repo "$repo" --add-label bluna-queued
+          gh issue comment "$number" \
+            --repo "$repo" \
+            --body "Picked up by Bluna AI. Dispatching now — will address this ${subject_type} and report back when done."
+
+          complexity="simple"
+          if grep -Eiq 'architect|refactor|redesign|infrastructure|database|schema|migration|performance|security|api design' <<<"${title} ${body} ${text}"; then
+            complexity="complex"
+          fi
+
+          payload="$(
+            jq -nc \
+              --argjson number "$number" \
+              --arg title "$title" \
+              --arg body "$body" \
+              --arg commentBody "$text" \
+              --arg url "$url" \
+              --argjson labels "$labels" \
+              --arg complexity "$complexity" \
+              --arg repo "$repo" \
+              --arg subjectType "$subject_type" \
+              '{number:$number,title:$title,body:$body,commentBody:$commentBody,url:$url,labels:$labels,complexity:$complexity,repo:$repo,subjectType:$subjectType}'
+          )"
+
+          sig="$(printf '%s' "$payload" | openssl dgst -sha256 -hmac "$TRIGGER_SECRET" -binary | xxd -p -c 256)"
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Content-Type: application/json" \
+            --header "X-Trigger-Secret: ${sig}" \
+            --data "$payload" \
+            "$TRIGGER_URL"


### PR DESCRIPTION
Adds a repo-local GitHub Actions bridge so @bluna-ai mentions on PR conversation comments, PR review comments, and PR reviews dispatch to the existing Bluna trigger server. Also supports issue comments for parity with the existing webhook path.