### PR TITLE
fix: restore on-demand vitals controls

### DIFF
--- a/ios/OpenCircuit/BLE/RingSession.swift
+++ b/ios/OpenCircuit/BLE/RingSession.swift
@@ -1414,7 +1414,10 @@ final class RingSession: NSObject {
         case .ignore:
             break                // auto refresh in the same mode — don't disturb a converging read
         case .switchMode(let armDeadline):
-            setLiveMode(mode)
+            // `armDeadline` is set iff the switch is user-initiated, so it doubles as the stale-clear
+            // signal: a user switch drops the target mode's prior lock (#125), an auto switch keeps
+            // its last value on screen until the new one re-locks.
+            setLiveMode(mode, clearStaleValue: armDeadline)
             // `userMeasuring` is already true when the switch is user-initiated (a user tap only
             // reaches here having skipped the takeover branch, which falls through only when a user
             // measurement was already in flight). Just re-arm the deadline for the new mode (#125).
@@ -1499,11 +1502,23 @@ final class RingSession: NSObject {
     /// Switch live measurement between HR (`06 01 00`) and SpO2 (`06 02 00`). The ring
     /// measures one at a time; the other metric keeps its last value. No-op until the
     /// next start if not currently monitoring.
-    func setLiveMode(_ mode: LiveMode) {
+    func setLiveMode(_ mode: LiveMode, clearStaleValue: Bool = false) {
         guard liveMode != mode else { return }
         liveMode = mode
         liveHRTrend.removeAll()   // restarting the HR window
         liveHRWarmup = nil
+        if clearStaleValue {
+            // User switched INTO this mode for a fresh read — the SpO2→HR→SpO2 toggle path that
+            // `startLiveMonitoring(clearStaleValue:)` / `rearmUserMeasure` don't cover (#125). Drop
+            // the TARGET mode's prior lock so it can't masquerade as live before the ring re-enters
+            // the mode (skipping preparing/measuring) or count as a lock at the user-measure deadline
+            // — without this, an off-finger read after the toggle times out with no failure banner.
+            // Only on a user switch (`armDeadline`); auto keeps its prior value on screen.
+            switch mode {
+            case .hr:   liveHR = nil;   liveHRAt = nil
+            case .spo2: liveSpO2 = nil; liveSpO2At = nil
+            }
+        }
         userMeasureFailed = false   // mode switch = fresh start, dismiss any prior failure (#55)
         userMeasureFailedMessage = nil
         guard monitoring else { return }

--- a/ios/OpenCircuit/BLE/RingSession.swift
+++ b/ios/OpenCircuit/BLE/RingSession.swift
@@ -674,7 +674,6 @@ final class RingSession: NSObject {
         bulkFinalized = false
         drainSawPage = false
         drainDone = false
-        let modeCmd = liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
         // Quick live reads no longer open a synthetic history session first. The device log showed
         // frequent reads repeatedly entering through `syncAll` (`02 .. ff ff ff ff ..`) before live
         // mode, entangling dense sampling with history/open-state churn. Overnight/background reads
@@ -726,6 +725,7 @@ final class RingSession: NSObject {
                 self.commitDrainedRecords()   // archive merge + stitched re-stage + persist (shared path)
             }
             // 3. Leave bulk mode and enter the selected live mode.
+            let modeCmd = s0.liveMode == .hr ? Command.liveHRMode : Command.liveSpO2Mode
             for cmd in [Command.statusQuery, modeCmd, Command.fetch] {
                 guard let self, !Task.isCancelled else { return }
                 self.write(cmd)
@@ -1057,10 +1057,13 @@ final class RingSession: NSObject {
         let deadline = Date().addingTimeInterval(timeout)
         var locked = false
         while !Task.isCancelled && Date() < deadline {
+            // Bail if a user tap took ownership or switched the mode out from under us — don't fight them.
+            if !autoMeasuring || !monitoring || liveMode != mode || calibrationCapturing {
+                autoMeasuring = false
+                return nil
+            }
             if mode == .hr, liveHR != nil { locked = true; break }
             if mode == .spo2, liveSpO2 != nil { locked = true; break }
-            // Bail if a user tap switched the mode out from under us — don't fight them.
-            if !monitoring || liveMode != mode || calibrationCapturing { autoMeasuring = false; return nil }
             try? await Task.sleep(for: .seconds(1))
         }
         // Only tear down if WE still own the live read (user didn't take over).
@@ -1378,10 +1381,26 @@ final class RingSession: NSObject {
     ///   background capture passes `false` for the full sleep drain (see `startLiveMonitoring`).
     func startMonitoring(mode: LiveMode, userInitiated: Bool = true, quickLiveRead: Bool = true) {
         if monitoring {
+            if userInitiated, !userMeasuring {
+                // Promote an auto/background live read into an explicit user measurement so the
+                // progress/failure UX and deadline belong to the tap instead of the previous owner.
+                autoMeasuring = false
+                stopLiveMonitoring(scheduleStatusRefresh: false)
+                liveMode = mode
+                userMeasuring = true
+                userMeasureFailed = false
+                userMeasureFailedMessage = nil
+                startLiveMonitoring(quickLiveRead: quickLiveRead, clearStaleValue: true)
+                return
+            }
             if liveMode == mode {
                 if userInitiated { rearmUserMeasure() }   // re-poll on demand; auto leaves it alone
             } else {
                 setLiveMode(mode)
+                if userInitiated {
+                    userMeasuring = true
+                    armUserMeasureDeadline()
+                }
             }
         } else {
             liveMode = mode

--- a/ios/OpenCircuit/BLE/RingSession.swift
+++ b/ios/OpenCircuit/BLE/RingSession.swift
@@ -666,7 +666,14 @@ final class RingSession: NSObject {
         monitoring = true
         monitoringStartedAt = Date()
         livePreparing = true
-        if clearStaleValue { liveHR = nil; liveHRAt = nil }   // fresh user read — don't let a stale value look live (#45 C)
+        if clearStaleValue {
+            // Fresh user read — don't let a stale value look live (#45 C). Clear BOTH metrics: an
+            // old liveSpO2 lock (never cleared while monitoring) would otherwise masquerade as live
+            // before the ring enters SpO2 mode, skipping preparing/measuring, and count as a lock at
+            // the deadline check so an off-finger read never surfaces the failure banner (#125).
+            liveHR = nil; liveHRAt = nil
+            liveSpO2 = nil; liveSpO2At = nil
+        }
         liveHRTrend.removeAll()   // fresh convergence window
         liveHRWarmup = nil
         flushDrainedToArchive()   // an in-flight sync just cancelled above — bank its pages before the wipe (#119)
@@ -1057,8 +1064,12 @@ final class RingSession: NSObject {
         let deadline = Date().addingTimeInterval(timeout)
         var locked = false
         while !Task.isCancelled && Date() < deadline {
-            // Bail if a user tap took ownership or switched the mode out from under us — don't fight them.
-            if !autoMeasuring || !monitoring || liveMode != mode || calibrationCapturing {
+            // Bail if a user tap took ownership or switched the mode out from under us — don't fight
+            // them. Same test-locked ownership model as `startMonitoring` (#125).
+            if LiveMeasureOwnership.autoShouldStandDown(autoMeasuring: autoMeasuring,
+                                                        monitoring: monitoring,
+                                                        modeMatches: liveMode == mode,
+                                                        calibrationCapturing: calibrationCapturing) {
                 autoMeasuring = false
                 return nil
             }
@@ -1380,29 +1391,35 @@ final class RingSession: NSObject {
     /// - `quickLiveRead`: prompt live-read entry (the default for foreground/auto). The overnight
     ///   background capture passes `false` for the full sleep drain (see `startLiveMonitoring`).
     func startMonitoring(mode: LiveMode, userInitiated: Bool = true, quickLiveRead: Bool = true) {
-        if monitoring {
-            if userInitiated, !userMeasuring {
-                // Promote an auto/background live read into an explicit user measurement so the
-                // progress/failure UX and deadline belong to the tap instead of the previous owner.
-                autoMeasuring = false
-                stopLiveMonitoring(scheduleStatusRefresh: false)
-                liveMode = mode
-                userMeasuring = true
-                userMeasureFailed = false
-                userMeasureFailedMessage = nil
-                startLiveMonitoring(quickLiveRead: quickLiveRead, clearStaleValue: true)
-                return
-            }
-            if liveMode == mode {
-                if userInitiated { rearmUserMeasure() }   // re-poll on demand; auto leaves it alone
-            } else {
-                setLiveMode(mode)
-                if userInitiated {
-                    userMeasuring = true
-                    armUserMeasureDeadline()
-                }
-            }
-        } else {
+        // Ownership decision lives in a pure, test-locked model (`LiveMeasureOwnership`) so the
+        // "don't fight the current owner" contract can't silently regress (#125).
+        let action = LiveMeasureOwnership.decide(monitoring: monitoring,
+                                                 userInitiated: userInitiated,
+                                                 userMeasuring: userMeasuring,
+                                                 workoutHolding: workoutHolding,
+                                                 sameMode: liveMode == mode)
+        switch action {
+        case .takeover:
+            // Promote an auto/background live read into an explicit user measurement so the
+            // progress/failure UX and deadline belong to the tap instead of the previous owner.
+            autoMeasuring = false
+            stopLiveMonitoring(scheduleStatusRefresh: false)
+            liveMode = mode
+            userMeasuring = true
+            userMeasureFailed = false
+            userMeasureFailedMessage = nil
+            startLiveMonitoring(quickLiveRead: quickLiveRead, clearStaleValue: true)
+        case .rearm:
+            rearmUserMeasure()   // re-poll on demand; auto leaves it alone
+        case .ignore:
+            break                // auto refresh in the same mode — don't disturb a converging read
+        case .switchMode(let armDeadline):
+            setLiveMode(mode)
+            // `userMeasuring` is already true when the switch is user-initiated (a user tap only
+            // reaches here having skipped the takeover branch, which falls through only when a user
+            // measurement was already in flight). Just re-arm the deadline for the new mode (#125).
+            if armDeadline { armUserMeasureDeadline() }
+        case .start(let clearStale):
             liveMode = mode
             // User-initiated: arm the timeout UX state so the poll loop can self-terminate (#55).
             if userInitiated {
@@ -1410,7 +1427,7 @@ final class RingSession: NSObject {
                 userMeasureFailed = false
                 userMeasureFailedMessage = nil
             }
-            startLiveMonitoring(quickLiveRead: quickLiveRead, clearStaleValue: userInitiated)
+            startLiveMonitoring(quickLiveRead: quickLiveRead, clearStaleValue: clearStale)
         }
     }
 
@@ -1462,6 +1479,9 @@ final class RingSession: NSObject {
         liveHRAt = nil
         liveHRTrend.removeAll()
         liveHRWarmup = nil
+        // Re-tap on a live SpO2 read: drop the prior SpO2 lock too, else it counts as live/locked
+        // for the fresh cycle (skips measuring UX; a failed retry never times out) (#125).
+        if liveMode == .spo2 { liveSpO2 = nil; liveSpO2At = nil }
         userMeasureFailed = false        // retry: dismiss the prior error naturally (#55)
         userMeasureFailedMessage = nil
         armUserMeasureDeadline()         // fresh budget from THIS re-tap, not the original (#65)

--- a/ios/OpenCircuit/ContentView.swift
+++ b/ios/OpenCircuit/ContentView.swift
@@ -704,7 +704,7 @@ struct ContentView: View {
         card {
             Text("VITALS").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
             VitalsTableView(session: session)
-            Text("Home shows the latest recorded readings and when they were recorded. New heart-rate and SpO₂ samples arrive from ring syncs, periodic background recording while connected, and workouts rather than a live stream on this screen.")
+            Text("Home shows the latest recorded readings and when they were recorded. Heart-rate and SpO₂ also support on-demand reads while the ring link is ready.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .padding(.top, 8)

--- a/ios/OpenCircuit/VitalsTableView.swift
+++ b/ios/OpenCircuit/VitalsTableView.swift
@@ -218,7 +218,7 @@ struct VitalsTableView: View {
         VStack(alignment: .leading, spacing: 0) {
             measurableRow("Heart Rate", value: hrText, mode: .hr, active: hrActive,
                           time: hrActive && session?.liveHR == nil
-                              ? (session?.livePreparing == true ? "preparing..." : "measuring...")
+                              ? (session?.livePreparing == true ? "preparing…" : "measuring…")
                               : timeFor(.heartRate, live: hrLive))
             divider
             spo2Row
@@ -246,7 +246,7 @@ struct VitalsTableView: View {
     }
 
     /// SpO₂ row with estimate caveat. Time logic mirrors `measurableRow` so the
-    /// "preparing..."/"measuring..." split is preserved for user-initiated reads.
+    /// "preparing…"/"measuring…" split is preserved for user-initiated reads.
     @ViewBuilder private var spo2Row: some View {
         HStack(spacing: 10) {
             Text("SpO₂").font(.subheadline).foregroundStyle(.primary)
@@ -255,7 +255,7 @@ struct VitalsTableView: View {
                 Text(spo2Text).font(.subheadline.weight(.semibold)).monospacedDigit()
                 Text("est.").font(.caption2).foregroundStyle(.tertiary)
                 if let time = (spo2Active && session?.liveSpO2 == nil
-                    ? (session?.livePreparing == true ? "preparing..." : "measuring...")
+                    ? (session?.livePreparing == true ? "preparing…" : "measuring…")
                     : timeFor(.spo2, live: spo2Live)) {
                     Text(time).font(.caption2).foregroundStyle(.secondary)
                 }

--- a/ios/OpenCircuit/VitalsTableView.swift
+++ b/ios/OpenCircuit/VitalsTableView.swift
@@ -216,7 +216,10 @@ struct VitalsTableView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            row("Heart Rate", value: hrText, time: timeFor(.heartRate))
+            measurableRow("Heart Rate", value: hrText, mode: .hr, active: hrActive,
+                          time: hrActive && session?.liveHR == nil
+                              ? (session?.livePreparing == true ? "preparing..." : "measuring...")
+                              : timeFor(.heartRate, live: hrLive))
             divider
             spo2Row
             divider
@@ -242,8 +245,8 @@ struct VitalsTableView: View {
         }
     }
 
-    /// SpO₂ row with estimate caveat. The home screen shows the latest RECORDED reading and when
-    /// it was recorded, not an in-progress measurement session.
+    /// SpO₂ row with estimate caveat. Time logic mirrors `measurableRow` so the
+    /// "preparing..."/"measuring..." split is preserved for user-initiated reads.
     @ViewBuilder private var spo2Row: some View {
         HStack(spacing: 10) {
             Text("SpO₂").font(.subheadline).foregroundStyle(.primary)
@@ -251,10 +254,13 @@ struct VitalsTableView: View {
             VStack(alignment: .trailing, spacing: 1) {
                 Text(spo2Text).font(.subheadline.weight(.semibold)).monospacedDigit()
                 Text("est.").font(.caption2).foregroundStyle(.tertiary)
-                if let time = timeFor(.spo2) {
+                if let time = (spo2Active && session?.liveSpO2 == nil
+                    ? (session?.livePreparing == true ? "preparing..." : "measuring...")
+                    : timeFor(.spo2, live: spo2Live)) {
                     Text(time).font(.caption2).foregroundStyle(.secondary)
                 }
             }
+            measureButton(.spo2, active: spo2Active)
         }
         .padding(.vertical, 8)
     }
@@ -273,14 +279,83 @@ struct VitalsTableView: View {
         .padding(.vertical, 8)
     }
 
+    // MARK: On-demand metrics (HR / SpO2)
+
+    /// The stop button belongs only to a user-initiated measurement. Auto-measure and workout
+    /// cycles keep ownership of the link, so their live reads cannot be stopped from this row.
+    private var hrActive: Bool { userMeasureActive(.hr) }
+    private var spo2Active: Bool { userMeasureActive(.spo2) }
+
+    private func userMeasureActive(_ mode: RingSession.LiveMode) -> Bool {
+        session?.userMeasuring == true
+            && session?.monitoring == true
+            && session?.liveMode == mode
+    }
+
+    /// True when the link has gone quiet so a lingering live value must not read as current (#36).
+    private var liveStale: Bool { session?.liveReadingsStale == true }
+
+    /// A vitals row carrying an inline start/stop measure control for an on-demand metric.
+    private func measurableRow(_ label: String, value: String, mode: RingSession.LiveMode,
+                               active: Bool, time: String?) -> some View {
+        HStack(spacing: 10) {
+            Text(label).font(.subheadline).foregroundStyle(.primary)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(value).font(.subheadline.weight(.semibold)).monospacedDigit()
+                if let time { Text(time).font(.caption2).foregroundStyle(.secondary) }
+            }
+            measureButton(mode, active: active)
+        }
+        .padding(.vertical, 8)
+    }
+
+    /// Small circular start/stop control. Appears only when the ring link is ready. Starting one
+    /// user measurement can switch between HR and SpO2, but auto/workout/calibration-owned live
+    /// cycles are left alone.
+    @ViewBuilder
+    private func measureButton(_ mode: RingSession.LiveMode, active: Bool) -> some View {
+        if session?.ready == true {
+            let color: Color = mode == .hr ? .red : .blue
+            let icon = mode == .hr ? "heart.fill" : "lungs.fill"
+            Button {
+                if active { session?.stopLiveMonitoring() }
+                else { session?.startMonitoring(mode: mode, userInitiated: true, quickLiveRead: true) }
+            } label: {
+                Image(systemName: active ? "stop.fill" : icon)
+                    .font(.caption2.weight(.bold))
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(active ? color : Color(.systemGray5)))
+                    .foregroundStyle(active ? .white : color)
+                    .symbolEffect(.pulse, isActive: active)
+            }
+            .buttonStyle(.plain)
+            .disabled(measureDisabled())
+        }
+    }
+
+    private func measureDisabled() -> Bool {
+        guard let session else { return true }
+        if session.syncing || session.notStreaming || session.calibrationCapturing { return true }
+        if session.capturingHistoricPull || session.capturingForensicSweep || session.probing { return true }
+        return session.workoutHolding
+    }
+
     private var divider: some View { Divider().opacity(0.4) }
 
-    // MARK: value formatting (recorded values only on the home screen)
+    // MARK: value formatting (live user reads override stored values)
+
+    /// HR/SpO2 count as "live" only for user-initiated reads whose frames are still fresh.
+    /// Auto-measure/workout cycles persist their samples through the existing owner paths.
+    private var hrLive: Bool { hrActive && session?.liveHR != nil && !liveStale }
+    private var spo2Live: Bool { spo2Active && session?.liveSpO2 != nil && !liveStale }
 
     private var hrText: String {
+        if hrLive, let hr = session?.liveHR { return "\(hr) bpm" }
         return valueText(.heartRate) { "\(Int($0)) bpm" }
     }
     private var spo2Text: String {
+        if spo2Live, let s = session?.liveSpO2 { return "\(s) %" }
         return valueText(.spo2) { "\(Int(($0 * 100).rounded())) %" }
     }
     // MARK: Skin temp (headline = latest reading; overnight average shown as context)
@@ -402,7 +477,8 @@ struct VitalsTableView: View {
     private static let rel: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter(); f.unitsStyle = .abbreviated; return f
     }()
-    private func timeFor(_ kind: MetricKind) -> String? {
+    private func timeFor(_ kind: MetricKind, live: Bool = false) -> String? {
+        if live { return "live" }
         guard let r = latestReading(kind) else { return nil }
         return Self.rel.localizedString(for: r.start, relativeTo: Date())
     }

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/LiveMeasureOwnership.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/LiveMeasureOwnership.swift
@@ -1,0 +1,67 @@
+// LiveMeasureOwnership — the pure state machine deciding who owns the single live-measure link
+// when `RingSession.startMonitoring` is called, and when an in-flight auto-measure must stand
+// down for a higher-priority owner (a user tap, a workout, calibration) (#125).
+//
+// Why this exists: the ring measures ONE metric at a time over ONE live link, so a Measure tap, a
+// periodic auto/background refresh, and a workout all contend for it. The ownership rules used to
+// live inline in `startMonitoring`/`autoMeasureOnce` as nested conditionals that were easy to get
+// subtly wrong (e.g. a user tap wresting the link from an active workout, or a takeover firing
+// while a measurement the user already started was mid-flight). Extracting the decision into a
+// pure, injectable enum — mirroring `WorkoutHRGate`/`AutoMeasureGate` — lets the "don't fight the
+// current owner" contract be locked by tests instead of re-verified by hand on every change.
+
+import Foundation
+
+public enum LiveMeasureOwnership {
+
+    /// What `startMonitoring` should do for a given request, given the current link state.
+    public enum Action: Equatable {
+        /// Nothing is live → begin a fresh cycle. `clearStale` drops the prior value up front for a
+        /// user read so an old lock can't masquerade as live while the new one warms up (#45 C/#125).
+        case start(clearStale: Bool)
+        /// An auto/background read is live and the user tapped Measure → promote it to an explicit
+        /// user measurement (stop the foreign cycle, then start a fresh user-owned one).
+        case takeover
+        /// Already live in the SAME mode on a user-owned read and the user tapped again → re-poll.
+        case rearm
+        /// Already live in the same mode on an auto read → leave the converging read alone.
+        case ignore
+        /// Already live in a DIFFERENT mode → switch the mode in place. `armDeadline` when the switch
+        /// was user-initiated (the user now owns the timeout UX for the new mode).
+        case switchMode(armDeadline: Bool)
+    }
+
+    /// Decide the ownership action for one `startMonitoring(mode:userInitiated:)` call.
+    ///
+    /// - Parameters:
+    ///   - monitoring: is a live cycle currently running?
+    ///   - userInitiated: is this a real Measure tap (vs an auto/background refresh)?
+    ///   - userMeasuring: is the CURRENT cycle already a user-owned measurement?
+    ///   - workoutHolding: does an active workout hold the HR link? A user tap must NOT wrest it —
+    ///     the workout owns HR for its whole duration (previously enforced only by hiding the button).
+    ///   - sameMode: does the requested mode match the mode currently being measured?
+    public static func decide(monitoring: Bool,
+                              userInitiated: Bool,
+                              userMeasuring: Bool,
+                              workoutHolding: Bool,
+                              sameMode: Bool) -> Action {
+        guard monitoring else { return .start(clearStale: userInitiated) }
+        // Promote an auto/background read into a user measurement — but never take the link from an
+        // active workout, and never re-takeover a measurement the user already started.
+        if userInitiated, !userMeasuring, !workoutHolding { return .takeover }
+        if sameMode { return userInitiated ? .rearm : .ignore }
+        return .switchMode(armDeadline: userInitiated)
+    }
+
+    /// Whether an in-flight `autoMeasureOnce` cycle should abandon its wait because a
+    /// higher-priority owner took the link (a user takeover clears `autoMeasuring`; a mode switch or
+    /// a stop clears the match/monitoring; calibration grabs the sensor). Mirrors the bail check in
+    /// `autoMeasureOnce` so "don't fight the current owner" is test-locked, and an aborted cycle is
+    /// never miscounted toward the not-worn inference (#56/#125).
+    public static func autoShouldStandDown(autoMeasuring: Bool,
+                                           monitoring: Bool,
+                                           modeMatches: Bool,
+                                           calibrationCapturing: Bool) -> Bool {
+        !autoMeasuring || !monitoring || !modeMatches || calibrationCapturing
+    }
+}

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/LiveMeasureOwnershipTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/LiveMeasureOwnershipTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import OpenCircuitKit
+
+// Ownership/takeover state machine for the single live-measure link (#125). Locks the
+// "don't fight the current owner" contract: a user tap promotes an auto read but never wrests an
+// active workout, an auto refresh never disturbs a user's converging read, and an in-flight
+// auto-measure stands down the moment a higher-priority owner takes over.
+final class LiveMeasureOwnershipTests: XCTestCase {
+
+    typealias Action = LiveMeasureOwnership.Action
+
+    // MARK: nothing live → fresh start
+
+    func testIdleUserTapStartsWithStaleCleared() {
+        // A user read clears the stale value up front so an old lock can't look live while warming.
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: false, userInitiated: true,
+                                        userMeasuring: false, workoutHolding: false, sameMode: true),
+            .start(clearStale: true))
+    }
+
+    func testIdleAutoStartKeepsLastValue() {
+        // Auto/background refresh leaves the prior value on screen until the new one locks.
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: false, userInitiated: false,
+                                        userMeasuring: false, workoutHolding: false, sameMode: true),
+            .start(clearStale: false))
+    }
+
+    func testIdleWorkoutStartKeepsLastValue() {
+        // beginWorkoutHR starts a fresh cycle (userInitiated:false) — no stale clear.
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: false, userInitiated: false,
+                                        userMeasuring: false, workoutHolding: true, sameMode: true),
+            .start(clearStale: false))
+    }
+
+    // MARK: takeover
+
+    func testUserTapTakesOverAnAutoRead() {
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: true, userInitiated: true,
+                                        userMeasuring: false, workoutHolding: false, sameMode: true),
+            .takeover)
+    }
+
+    func testUserTapTakesOverAnAutoReadEvenInADifferentMode() {
+        // Takeover is checked before the same/different-mode split — a tap in the other mode still
+        // promotes to a fresh user-owned cycle rather than an in-place switch.
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: true, userInitiated: true,
+                                        userMeasuring: false, workoutHolding: false, sameMode: false),
+            .takeover)
+    }
+
+    // MARK: workout hold is inviolable
+
+    func testUserTapDoesNotWrestAnActiveWorkout() {
+        // The blocker's MINOR fix: a workout owns HR; a Measure tap must NOT take over in the state
+        // machine (previously relied only on the view hiding the button).
+        let action = LiveMeasureOwnership.decide(monitoring: true, userInitiated: true,
+                                                 userMeasuring: false, workoutHolding: true,
+                                                 sameMode: true)
+        XCTAssertNotEqual(action, .takeover)
+        XCTAssertEqual(action, .rearm, "same-mode user tap during a workout re-polls, never takes over")
+    }
+
+    func testUserTapDuringWorkoutInOtherModeSwitchesRatherThanTakesOver() {
+        let action = LiveMeasureOwnership.decide(monitoring: true, userInitiated: true,
+                                                 userMeasuring: false, workoutHolding: true,
+                                                 sameMode: false)
+        XCTAssertNotEqual(action, .takeover)
+        XCTAssertEqual(action, .switchMode(armDeadline: true))
+    }
+
+    // MARK: same-mode re-tap vs auto no-op
+
+    func testSameModeUserRetapRearms() {
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: true, userInitiated: true,
+                                        userMeasuring: true, workoutHolding: false, sameMode: true),
+            .rearm)
+    }
+
+    func testSameModeAutoRefreshIsIgnored() {
+        // A periodic auto-measure must never disturb a user's converging read.
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: true, userInitiated: false,
+                                        userMeasuring: true, workoutHolding: false, sameMode: true),
+            .ignore)
+    }
+
+    // MARK: mode switch
+
+    func testUserModeSwitchArmsDeadline() {
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: true, userInitiated: true,
+                                        userMeasuring: true, workoutHolding: false, sameMode: false),
+            .switchMode(armDeadline: true))
+    }
+
+    func testAutoModeSwitchDoesNotArmDeadline() {
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: true, userInitiated: false,
+                                        userMeasuring: false, workoutHolding: false, sameMode: false),
+            .switchMode(armDeadline: false))
+    }
+
+    // MARK: stop-ownership — auto-measure stands down for a higher-priority owner
+
+    func testAutoHoldsWhileItStillOwnsTheLink() {
+        XCTAssertFalse(LiveMeasureOwnership.autoShouldStandDown(
+            autoMeasuring: true, monitoring: true, modeMatches: true, calibrationCapturing: false))
+    }
+
+    func testAutoStandsDownWhenUserTookOwnership() {
+        // A user takeover clears `autoMeasuring`.
+        XCTAssertTrue(LiveMeasureOwnership.autoShouldStandDown(
+            autoMeasuring: false, monitoring: true, modeMatches: true, calibrationCapturing: false))
+    }
+
+    func testAutoStandsDownWhenMonitoringStopped() {
+        XCTAssertTrue(LiveMeasureOwnership.autoShouldStandDown(
+            autoMeasuring: true, monitoring: false, modeMatches: true, calibrationCapturing: false))
+    }
+
+    func testAutoStandsDownWhenModeSwitchedOutFromUnderIt() {
+        XCTAssertTrue(LiveMeasureOwnership.autoShouldStandDown(
+            autoMeasuring: true, monitoring: true, modeMatches: false, calibrationCapturing: false))
+    }
+
+    func testAutoStandsDownWhenCalibrationGrabsTheSensor() {
+        XCTAssertTrue(LiveMeasureOwnership.autoShouldStandDown(
+            autoMeasuring: true, monitoring: true, modeMatches: true, calibrationCapturing: true))
+    }
+}

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/LiveMeasureOwnershipTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/LiveMeasureOwnershipTests.swift
@@ -100,10 +100,36 @@ final class LiveMeasureOwnershipTests: XCTestCase {
     }
 
     func testAutoModeSwitchDoesNotArmDeadline() {
+        // armDeadline:false also means "keep the prior value on screen" — setLiveMode does NOT clear
+        // the target mode's latch on an auto switch, mirroring startLiveMonitoring's contract.
         XCTAssertEqual(
             LiveMeasureOwnership.decide(monitoring: true, userInitiated: false,
                                         userMeasuring: false, workoutHolding: false, sameMode: false),
             .switchMode(armDeadline: false))
+    }
+
+    func testUserModeToggleSignalsStaleClearAtEveryStep() {
+        // #125 blocker repro: a user SpO2 read, then toggling HR and back to SpO2, must never let the
+        // prior liveSpO2 masquerade as live or count as a deadline lock. Every user-owned entry into
+        // a mode signals a stale-clear — the initial start clears it, and each cross-mode switch
+        // reports armDeadline:true, which setLiveMode uses to drop the TARGET mode's stale latch.
+        // (Before the fix, the switchMode path left liveSpO2 set, so an off-finger read after the
+        // toggle timed out with no failure banner.)
+        // 1. idle → user taps SpO2
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: false, userInitiated: true,
+                                        userMeasuring: false, workoutHolding: false, sameMode: true),
+            .start(clearStale: true))
+        // 2. live SpO2 (user-owned) → user taps HR
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: true, userInitiated: true,
+                                        userMeasuring: true, workoutHolding: false, sameMode: false),
+            .switchMode(armDeadline: true))
+        // 3. live HR (user-owned) → user taps SpO2 again — the toggle that regressed
+        XCTAssertEqual(
+            LiveMeasureOwnership.decide(monitoring: true, userInitiated: true,
+                                        userMeasuring: true, workoutHolding: false, sameMode: false),
+            .switchMode(armDeadline: true))
     }
 
     // MARK: stop-ownership — auto-measure stands down for a higher-priority owner


### PR DESCRIPTION
## What Problem This Solves

PR #121 removed the home-screen on-demand Heart Rate and SpO2 controls while keeping the underlying `RingSession.startMonitoring(...)` user-measurement machinery. Users lost the manual buttons even though the BLE flow still supports explicit HR/SpO2 reads.

## Why This Change Was Made

Restores the inline vitals-row controls as a focused regression fix, separate from the issue #38 HRV/sleep-staging branch.

## User Impact

- Heart Rate and SpO2 rows once again show small on-demand controls when the ring link is ready.
- A user tap starts a user-owned quick live read and shows `preparing...`, `measuring...`, or `live` state.
- Stop controls only stop user-owned measurements, not background auto-measure or workout-owned live HR.
- Manual measure remains allowed even when charger/off-wrist is suspected, matching the existing session policy.

## Implementation Notes

- Restores HR/SpO2 measure buttons in `VitalsTableView`.
- Updates `ContentView` copy so it no longer says Home has no on-demand reads.
- Fixes manual takeover during an existing auto/background live read in `RingSession` so the user tap owns progress/failure state and auto-measure does not later tear down the user-owned read.

## Evidence

- `git diff --check HEAD~1..HEAD` passed.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path ios/OpenCircuitKit` passed: 602 tests, 0 failures.
- `xcodegen generate` from `ios/` succeeded for the fresh worktree.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ios/OpenCircuit.xcodeproj -scheme OpenCircuit -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed with `BUILD SUCCEEDED`.

## Related

Regression introduced by PR #121's home/vitals UI rewrite.
