### PR TITLE
fix: restore calories energy surface

### DIFF
--- a/ios/OpenCircuit/ContentView.swift
+++ b/ios/OpenCircuit/ContentView.swift
@@ -234,6 +234,7 @@ struct ContentView: View {
         case .vitals:       vitalsCard
         case .vitalsStatus: vitalsStatusCard
         case .sleep:        sleepCard
+        case .calories:     caloriesCard
         case .goals:        card { GoalsCardView() }
         case .workout:      workoutCard
         case .cycle:        cycleCalendarCard
@@ -790,6 +791,12 @@ struct ContentView: View {
         .buttonStyle(.plain)
     }
 
+    /// Calories on the home page. Headline is today's estimated burn; secondary lines break out
+    /// resting BMR + active energy so the app stays honest about derived calories.
+    private var caloriesCard: some View {
+        card { CaloriesCardView() }
+    }
+
     // MARK: Sync + Health
 
     /// Prominent "is this thing actually working?" line (#44): when we last pulled from the ring
@@ -1185,6 +1192,8 @@ struct ContentView: View {
                     + (r.steps > 0 ? ", \(r.steps) steps" : "")
                     + (r.distanceM > 0 ? ", \(Int(r.distanceM.rounded()))m est." : "")
                     + (r.restingDays > 0 ? ", \(r.restingDays) resting HR" : "")
+                    + (r.passiveHours > 0 ? ", \(r.passiveHours)h basal" : "")
+                    + (r.activeKcal > 0 ? ", \(Int(r.activeKcal.rounded())) active kcal" : "")
                     + (r.exerciseMinutes > 0 ? ", \(Int(r.exerciseMinutes.rounded()))min exercise est." : "")
                     + (r.naps > 0 ? ", \(r.naps) nap\(r.naps == 1 ? "" : "s")" : "")
             } else {
@@ -1226,7 +1235,7 @@ struct ContentView: View {
 /// `dashboard.sectionOrder`, so keep these stable across releases; `allCases` order is the default
 /// (first-run) layout.
 private enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
-    case vitals, vitalsStatus, sleep, goals, workout, cycle, trends, sync
+    case vitals, vitalsStatus, sleep, calories, goals, workout, cycle, trends, sync
     var id: String { rawValue }
 }
 
@@ -1235,4 +1244,75 @@ private enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
 /// cards' custom ones.
 private enum Route: Hashable {
     case trends, cycle, deviceInfo, activityLog
+}
+
+/// Home-page calories card. Headline = today's estimated burn; secondary lines break it
+/// into resting (BMR prorated over the elapsed day) + active (HR/step estimate), then the
+/// static BMR/max-HR reference figures. Body inputs come from the profile page — the ring
+/// transmits none of them.
+struct CaloriesCardView: View {
+    // Shared @AppStorage keys with UserProfileSettingsView (single source of truth).
+    @AppStorage("userProfile.age") private var age = 35
+    @AppStorage("userProfile.weightKg") private var weightKg = 70.0
+    @AppStorage("userProfile.heightCm") private var heightCm = 170.0
+    @AppStorage("userProfile.sex") private var sexRaw = BiologicalSex.male.rawValue
+
+    /// Today's HR samples (for the active-calorie TRIMP estimate). Predicate-limited to
+    /// heart rate since start-of-day so the fetch stays small.
+    @Query private var hrSamples: [StoredSample]
+    /// Today's step rollup — drives the step/distance active-calorie fallback when HR is sparse.
+    @Query private var todayDaily: [StoredDaily]
+
+    init() {
+        let hr = MetricKind.heartRate.rawValue
+        let dayStart = Calendar.current.startOfDay(for: Date())
+        _hrSamples = Query(
+            filter: #Predicate { $0.kindRaw == hr && $0.start >= dayStart },
+            sort: \.start)
+        _todayDaily = Query(filter: #Predicate<StoredDaily> { $0.day == dayStart }, sort: \.day)
+    }
+
+    private var profile: UserProfile {
+        UserProfile(age: age, weightKg: max(weightKg, 1), heightCm: max(heightCm, 1),
+                    sex: BiologicalSex(rawValue: sexRaw) ?? .male)
+    }
+    private var maxHR: Int { max(220 - age, 1) }
+
+    /// Resting kcal accrued so far today: full-day BMR scaled by the elapsed fraction of today.
+    private var restingToday: Double {
+        let dayStart = Calendar.current.startOfDay(for: Date())
+        let fraction = Date().timeIntervalSince(dayStart) / 86_400
+        return Calories.bmrKcalPerDay(profile: profile) * fraction
+    }
+
+    /// Active kcal today — the larger of the HR-TRIMP estimate (sparse; ~0 without dense HR) and a
+    /// step/distance estimate, so a day with walking still shows honest active calories instead of
+    /// 0. Both are clearly-labeled estimates (the ring transmits no active-energy value).
+    private var activeToday: Double {
+        let samples = hrSamples.map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
+        let hrKcal = Calories.activeKcal(hrSamples: samples, maxHR: maxHR)
+        let stepKcal = Calories.activeKcalFromSteps(steps: todayDaily.first?.steps ?? 0, profile: profile)
+        return max(hrKcal, stepKcal)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "flame.fill").foregroundStyle(.orange)
+                Text("CALORIES").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            }
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("\(Int((restingToday + activeToday).rounded()))")
+                    .font(.system(size: 40, weight: .bold, design: .rounded))
+                    .monospacedDigit().contentTransition(.numericText())
+                Text("kcal today").font(.subheadline.weight(.semibold)).foregroundStyle(.secondary)
+            }
+            Text("resting \(Int(restingToday.rounded())) · active \(Int(activeToday.rounded()))")
+                .font(.caption).foregroundStyle(.secondary)
+            // "max HR" here is the 220-age zone/calorie reference, NOT an observed peak.
+            Text("BMR \(Int(Calories.bmrKcalPerDay(profile: profile).rounded())) kcal/day · est. max HR \(maxHR) bpm (220-age)")
+                .font(.caption2).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
 }

--- a/ios/OpenCircuit/ContentView.swift
+++ b/ios/OpenCircuit/ContentView.swift
@@ -1266,8 +1266,11 @@ struct CaloriesCardView: View {
     init() {
         let hr = MetricKind.heartRate.rawValue
         let dayStart = Calendar.current.startOfDay(for: Date())
+        // Match GoalsCardView's HR query exactly: same start-of-day lower bound AND the `value > 0`
+        // guard, so a stray 0-bpm sample can't skew the active-calorie estimate and the two cards
+        // read the same today's-HR set.
         _hrSamples = Query(
-            filter: #Predicate { $0.kindRaw == hr && $0.start >= dayStart },
+            filter: #Predicate { $0.kindRaw == hr && $0.start >= dayStart && $0.value > 0 },
             sort: \.start)
         _todayDaily = Query(filter: #Predicate<StoredDaily> { $0.day == dayStart }, sort: \.day)
     }

--- a/ios/OpenCircuit/Health/HealthKitWriter.swift
+++ b/ios/OpenCircuit/Health/HealthKitWriter.swift
@@ -41,7 +41,7 @@ final class HealthKitWriter {
         case .temperature: id = .basalBodyTemperature
         case .respiratoryRate: id = .respiratoryRate
         case .steps: id = .stepCount
-        case .activeEnergy: return nil
+        case .activeEnergy: id = .activeEnergyBurned
         case .sleep: return nil
         // ESTIMATE — steps × RingConn's own per-step constant. See DistanceEstimate.swift (#81).
         case .distance: id = .distanceWalkingRunning
@@ -78,6 +78,7 @@ final class HealthKitWriter {
         for k in MetricKind.allCases {
             if let t = Self.quantityType(for: k) { set.insert(t) }
         }
+        set.insert(HKQuantityType(.basalEnergyBurned))
         set.insert(HKCategoryType(.sleepAnalysis))
         // Workout types (#75): HKWorkout + GPS route (workout sessions feature).
         set.insert(HKWorkoutType.workoutType())
@@ -138,14 +139,15 @@ final class HealthKitWriter {
     /// was nothing pending or share access isn't granted.
     struct FlushResult: Equatable {
         var samples = 0, sleepSegments = 0, steps = 0
-        var restingDays = 0
+        var restingDays = 0, passiveHours = 0
+        var activeKcal = 0.0
         var naps = 0
         var distanceM = 0.0         // estimated distance written (#81)
         var exerciseMinutes = 0.0   // estimated exercise minutes written (#82)
         var menstrualFlowEntries = 0  // user-logged period entries written (#78)
         var wroteAnything: Bool {
             samples > 0 || sleepSegments > 0 || steps > 0
-                || restingDays > 0 || naps > 0
+                || restingDays > 0 || passiveHours > 0 || activeKcal > 0 || naps > 0
                 || distanceM > 0 || exerciseMinutes > 0 || menstrualFlowEntries > 0
         }
     }
@@ -185,10 +187,10 @@ final class HealthKitWriter {
         // Gated by each entry's own `healthWritten` flag — independent of all other writes.
         result.menstrualFlowEntries = await flushMenstrualFlow(localStore: store)
 
-        // Profile is used for active-kcal weight + exercise-minute thresholds — resolved once here
-        // so the derived writes use the same snapshot. Body inputs come from the shared profile
-        // defaults; the ring transmits none of them. Distance (below) no longer needs it — PROTOCOL.md
-        // §5.3.1 confirms RingConn's distance derivation is a fixed per-step constant, not height/sex.
+        // Profile is used for calories + exercise-minute thresholds — resolved once here so the
+        // derived writes use the same snapshot. Body inputs come from the shared profile defaults;
+        // the ring transmits none of them. Distance (below) no longer needs it — PROTOCOL.md §5.3.1
+        // confirms RingConn's distance derivation is a fixed per-step constant, not height/sex.
         let profile = Self.storedUserProfile()
 
         // Steps + distance estimate (#81, #steps-history): write each pending TIMESTAMPED step
@@ -227,6 +229,11 @@ final class HealthKitWriter {
         // UserDefaults day-watermark, NOT the store cursor: RHR isn't a stored sample, and the
         // `hk:` cursor rows belong to the raw-sample mirror above.
         result.restingDays = await flushRestingHR(local: store, sleepSegments: sleepSegments)
+
+        // Energy: passive (hourly BMR) + active (HR-derived or steps-derived estimate).
+        // Watermark-gated (#37) and labeled as derived estimates in HealthKit metadata.
+        result.passiveHours = await flushPassiveCalories(profile: profile)
+        result.activeKcal = await flushActiveCalories(local: store, profile: profile)
 
         // Exercise minutes estimate (#82): elevated-HR minutes outside the sleep window.
         // ESTIMATE — basic 50% maxHR threshold. Full 4-level intensity follows #93 decode.
@@ -460,6 +467,8 @@ final class HealthKitWriter {
     // accurate measurement is kept; only the estimate is reduced for the overlapping window).
     static let workoutWalkRunDistanceDayKey    = "hk.workoutWalkRunDistance.day"
     static let workoutWalkRunDistanceMetersKey = "hk.workoutWalkRunDistance.meters"
+    static let workoutActiveKcalDayKey         = "hk.workoutActiveKcal.day"
+    static let workoutActiveKcalKey            = "hk.workoutActiveKcal.kcal"
     private static let estimateGPSCreditedDayKey    = "hk.distanceEstimate.gpsCreditedDay"
     private static let estimateGPSCreditedMetersKey = "hk.distanceEstimate.gpsCreditedMeters"
 
@@ -476,6 +485,35 @@ final class HealthKitWriter {
         total += meters
         defaults.set(today.timeIntervalSince1970, forKey: workoutWalkRunDistanceDayKey)
         defaults.set(total, forKey: workoutWalkRunDistanceMetersKey)
+    }
+
+    /// Record workout active energy that was successfully committed to HealthKit. The daily
+    /// active-energy estimate uses this to avoid double-counting workout HR that #121 now also
+    /// persists into LocalStore for Goals/Trends.
+    static func recordWorkoutActiveKcal(_ kcal: Double, day: Date = Date(),
+                                        _ defaults: UserDefaults = .standard) {
+        guard kcal > 0 else { return }
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: day)
+        let storedDay = Date(timeIntervalSince1970: defaults.double(forKey: workoutActiveKcalDayKey))
+        let prior = cal.startOfDay(for: storedDay) == today
+            ? defaults.double(forKey: workoutActiveKcalKey) : 0
+        defaults.set(today.timeIntervalSince1970, forKey: workoutActiveKcalDayKey)
+        defaults.set(prior + kcal, forKey: workoutActiveKcalKey)
+    }
+
+    private static func workoutActiveKcalCredited(day today: Date,
+                                                  _ defaults: UserDefaults = .standard) -> Double {
+        let cal = Calendar.current
+        let storedDay = Date(timeIntervalSince1970: defaults.double(forKey: workoutActiveKcalDayKey))
+        return cal.startOfDay(for: storedDay) == today
+            ? defaults.double(forKey: workoutActiveKcalKey) : 0
+    }
+
+    static func netDailyActiveKcalEstimate(hrKcal: Double, stepKcal: Double,
+                                           workoutActiveKcal: Double) -> Double {
+        let netHRKcal = max(0, hrKcal - max(workoutActiveKcal, 0))
+        return max(netHRKcal, max(stepKcal, 0))
     }
 
     /// Reduce a raw steps×stride distance estimate by however much workout GPS walk/run distance
@@ -611,14 +649,20 @@ final class HealthKitWriter {
         let hrKcal = hrSamples.isEmpty ? 0 : Calories.activeKcal(hrSamples: hrSamples, maxHR: maxHR)
 
         // Step/distance-derived estimate — works even with no HR — NETTED against any in-app
-        // workout's own active-energy already written to Health today (HealthKit SUMS active
-        // energy, so the recorded walk/run must not be counted twice). Mirrors the steps×stride
-        // distance netting. Day total minus workout total ⇒ stable, no separate credit ledger.
+        // workout's foot-distance already written to Health today, so walking/running workouts
+        // don't double-count the same distance.
         let steps = (try? local.todaySteps(day: today)) ?? 0
         let stepKcal = Self.netActiveKcalEstimate(
             Calories.activeKcalFromSteps(steps: steps, profile: profile), profile: profile, day: today)
 
-        let total = Swift.max(hrKcal, stepKcal)
+        // #121 started persisting workout HR into LocalStore for Goals/Trends. Since workouts also
+        // write their own activeEnergyBurned sample, subtract committed workout active kcal only
+        // from the HR-derived side before choosing the larger daily estimate.
+        let total = Self.netDailyActiveKcalEstimate(
+            hrKcal: hrKcal,
+            stepKcal: stepKcal,
+            workoutActiveKcal: Self.workoutActiveKcalCredited(day: today)
+        )
         let delta = total - written
         guard delta >= 1.0 else {  // ignore sub-kcal churn; still persist the (reset) day marker
             defaults.set(today.timeIntervalSince1970, forKey: Self.activeDayKey)

--- a/ios/OpenCircuit/Health/HealthKitWriter.swift
+++ b/ios/OpenCircuit/Health/HealthKitWriter.swift
@@ -395,6 +395,10 @@ final class HealthKitWriter {
         }
     }
 
+    /// Metadata flag marking basal (passive) energy samples as a derived ESTIMATE — a BMR formula
+    /// prorated per hour, NOT a value the ring measured — so Health readers can label or filter it.
+    static let basalEnergyEstimateMetadataKey = "OpenCircuitBasalEnergyEstimated"
+
     func writePassiveCalories(profile: UserProfile, date: Date) async throws {
         let type = HKQuantityType(.basalEnergyBurned)
         let quantity = HKQuantity(
@@ -405,7 +409,9 @@ final class HealthKitWriter {
             type: type,
             quantity: quantity,
             start: date,
-            end: date.addingTimeInterval(3600)
+            end: date.addingTimeInterval(3600),
+            metadata: [Self.basalEnergyEstimateMetadataKey: true,
+                       HKMetadataKeyWasUserEntered: false]
         )
         try await store.save(sample)
     }
@@ -510,10 +516,20 @@ final class HealthKitWriter {
             ? defaults.double(forKey: workoutActiveKcalKey) : 0
     }
 
+    /// Net a completed workout's committed active energy out of today's daily active-energy
+    /// estimate. The daily estimate is `max(hrKcal, stepKcal)` — whichever channel is larger for
+    /// the day — and the workout ALREADY wrote its own `activeEnergyBurned` sample to Health. So we
+    /// subtract the committed workout kcal from the CHOSEN daily estimate, not from one channel:
+    ///   • HR-locked outdoor run → HR channel dominates → credit nets the HR side,
+    ///   • indoor/treadmill (steps counted, HR sparse) → step channel dominates → credit STILL nets
+    ///     (the old "HR side only" netting left indoor sessions double-counted — reviewer #1),
+    ///   • distance-derived workout (HR never locked) → credit nets whichever channel is chosen,
+    ///     never over-subtracting a channel that never held the workout (reviewer #2).
+    /// Clamped at 0 so a workout larger than the whole-day estimate can't push it negative.
     static func netDailyActiveKcalEstimate(hrKcal: Double, stepKcal: Double,
                                            workoutActiveKcal: Double) -> Double {
-        let netHRKcal = max(0, hrKcal - max(workoutActiveKcal, 0))
-        return max(netHRKcal, max(stepKcal, 0))
+        let dailyEstimate = max(max(hrKcal, 0), max(stepKcal, 0))
+        return max(0, dailyEstimate - max(workoutActiveKcal, 0))
     }
 
     /// Reduce a raw steps×stride distance estimate by however much workout GPS walk/run distance
@@ -546,25 +562,6 @@ final class HealthKitWriter {
         defaults.set(credited + reduction, forKey: estimateGPSCreditedMetersKey)
     }
 
-    /// Reduce a raw step/distance active-kcal estimate by the active-energy a recorded foot-based
-    /// workout already contributed to Health today, expressed in the SAME step/distance economy as
-    /// `raw`. We net the workout's WALK/RUN DISTANCE energy (reusing the committed `workoutWalkRun
-    /// Distance` accumulator), NOT its full intensity kcal — so:
-    ///   • a walk nets out exactly its own step energy (no double count),
-    ///   • cycling (records no walk/run distance) never erases genuine walking energy,
-    ///   • an intense run's HR-bonus kcal isn't over-subtracted from the daily step estimate.
-    /// Residual note: the daily estimate is written against a monotonic per-day accumulator
-    /// (`writtenKcal`), so if step energy is banked BEFORE a same-day workout commits its distance,
-    /// a small pre-workout overlap can't be retracted — a bounded over-count on a labeled estimate.
-    private static func netActiveKcalEstimate(_ raw: Double, profile: UserProfile, day today: Date,
-                                              _ defaults: UserDefaults = .standard) -> Double {
-        let cal = Calendar.current
-        let wDay = Date(timeIntervalSince1970: defaults.double(forKey: workoutWalkRunDistanceDayKey))
-        let wMeters = cal.startOfDay(for: wDay) == today
-            ? defaults.double(forKey: workoutWalkRunDistanceMetersKey) : 0
-        let workoutStepEnergy = Calories.activeKcalFromDistance(meters: wMeters, profile: profile)
-        return max(0, raw - workoutStepEnergy)
-    }
     /// A day's resting HR is finalized once the day is ~half over, so a pre-dawn flush can't
     /// freeze a partial-night value, yet last night's RHR still lands the same day (by midday).
     private static let restingFinalizationDelay: TimeInterval = 12 * 3600
@@ -648,16 +645,16 @@ final class HealthKitWriter {
         let maxHR = max(220 - profile.age, 1)
         let hrKcal = hrSamples.isEmpty ? 0 : Calories.activeKcal(hrSamples: hrSamples, maxHR: maxHR)
 
-        // Step/distance-derived estimate — works even with no HR — NETTED against any in-app
-        // workout's foot-distance already written to Health today, so walking/running workouts
-        // don't double-count the same distance.
+        // Step/distance-derived estimate — works even with no HR. The workout's foot-distance is
+        // netted out of the daily estimate below (via the committed workout kcal), so no per-channel
+        // distance netting is needed here.
         let steps = (try? local.todaySteps(day: today)) ?? 0
-        let stepKcal = Self.netActiveKcalEstimate(
-            Calories.activeKcalFromSteps(steps: steps, profile: profile), profile: profile, day: today)
+        let stepKcal = Calories.activeKcalFromSteps(steps: steps, profile: profile)
 
-        // #121 started persisting workout HR into LocalStore for Goals/Trends. Since workouts also
-        // write their own activeEnergyBurned sample, subtract committed workout active kcal only
-        // from the HR-derived side before choosing the larger daily estimate.
+        // #121 started persisting workout HR into LocalStore for Goals/Trends, and workouts also
+        // write their own activeEnergyBurned sample. Subtract the committed workout active kcal from
+        // whichever daily channel (HR or step) is chosen, so both HR-locked and indoor/step-only
+        // workouts are netted exactly once (see `netDailyActiveKcalEstimate`).
         let total = Self.netDailyActiveKcalEstimate(
             hrKcal: hrKcal,
             stepKcal: stepKcal,

--- a/ios/OpenCircuit/UserProfile.swift
+++ b/ios/OpenCircuit/UserProfile.swift
@@ -54,6 +54,7 @@ struct UserProfileSettingsView: View {
     // Daily goals (#77). Keys/defaults shared with GoalsCardView via `GoalDefaults`.
     @AppStorage(GoalDefaults.workdaySteps)    private var workdaySteps    = GoalDefaults.defaultWorkdaySteps
     @AppStorage(GoalDefaults.weekendSteps)    private var weekendSteps    = GoalDefaults.defaultWeekendSteps
+    @AppStorage(GoalDefaults.activeKcal)      private var activeKcalGoal  = GoalDefaults.defaultActiveKcal
     @AppStorage(GoalDefaults.activityMinutes) private var actMinGoal      = GoalDefaults.defaultActivityMinutes
     @AppStorage(GoalDefaults.workdaySleepMin) private var workdaySleepMin = GoalDefaults.defaultWorkdaySleepMin
     @AppStorage(GoalDefaults.weekendSleepMin) private var weekendSleepMin = GoalDefaults.defaultWeekendSleepMin
@@ -267,6 +268,9 @@ struct UserProfileSettingsView: View {
                 Stepper(value: $weekendSteps, in: 1_000...30_000, step: 500) {
                     LabeledContent("Weekend steps", value: weekendSteps.formatted())
                 }
+                Stepper(value: $activeKcalGoal, in: 50...1_500, step: 25) {
+                    LabeledContent("Active calories", value: "\(Int(activeKcalGoal)) kcal")
+                }
                 Stepper(value: $actMinGoal, in: 5...180, step: 5) {
                     LabeledContent("Exercise minutes", value: "\(Int(actMinGoal)) min")
                 }
@@ -276,7 +280,7 @@ struct UserProfileSettingsView: View {
                 Stepper(value: $weekendSleepMin, in: 240...600, step: 15) {
                     LabeledContent("Weekend sleep", value: formatGoalSleep(weekendSleepMin))
                 }
-                Text("Progress rings on the dashboard show today's goal vs. actual. Exercise minutes = elevated-HR minutes (basic threshold estimate).")
+                Text("Progress rings on the dashboard show today's goal vs. actual. Exercise minutes = elevated-HR minutes (basic threshold estimate), independent of steps/calories.")
                     .font(.caption).foregroundStyle(.secondary)
             }
 

--- a/ios/OpenCircuit/WorkoutSessionManager.swift
+++ b/ios/OpenCircuit/WorkoutSessionManager.swift
@@ -259,19 +259,6 @@ final class WorkoutSessionManager: NSObject {
             agg.backfill(backfillHR, window: DateInterval(start: start, end: max(endDate, start)))
         }
 
-        // Persist this workout's continuous HR into LocalStore — same store the ring's history
-        // sync writes to. These samples carry REAL start/end spans (unlike the zero-duration point
-        // samples live-monitoring/history-sync persist elsewhere), so GoalsCardView's
-        // ExerciseMinutes estimate can credit them directly without needing two elevated point
-        // samples within one epoch of each other. `ingest` is cursor-gated, so re-running a workout
-        // (or this code path firing twice) can't double-count.
-        if let store {
-            let toIngest = agg.collectedSamples.map {
-                QuantitySample(kind: .heartRate, start: $0.start, end: $0.end, value: Double($0.bpm))
-            }
-            _ = try? store.ingest(toIngest)
-        }
-
         let hasRoute = !routeLocations.isEmpty && selectedSport.isOutdoor
         let summary = agg.finalize(
             sport: selectedSport,
@@ -285,6 +272,29 @@ final class WorkoutSessionManager: NSObject {
         await writeWorkout(summary: summary,
                            hrSamples: agg.collectedSamples,
                            routeLocations: hasRoute ? routeLocations : [])
+
+        // Persist this workout's continuous HR into LocalStore — same store the ring's history
+        // sync writes to. These samples carry REAL start/end spans (unlike the zero-duration point
+        // samples live-monitoring/history-sync persist elsewhere), so GoalsCardView's
+        // ExerciseMinutes estimate can credit them directly without needing two elevated point
+        // samples within one epoch of each other. `ingest` is cursor-gated, so re-running a workout
+        // (or this code path firing twice) can't double-count.
+        //
+        // ORDERING (double-count guard): this ingest MUST run AFTER `writeWorkout` returns — i.e.
+        // after the workout's active-energy credit is banked via `recordWorkoutActiveKcal` — and in
+        // this suspension-free stretch. `endWorkoutHR()` above flipped `monitoring` false, which
+        // fires ContentView's `flushHealth()`. That flush computes the day's active-energy delta
+        // from LocalStore HR. If we ingested the workout HR BEFORE the credit was banked, a flush
+        // could observe the workout HR with `workoutActiveKcalCredited == 0`, write the workout's
+        // TRIMP kcal as the daily active-energy delta AND let the workout's own `activeEnergyBurned`
+        // sample land too — a permanent, unretractable double-count. Ingesting only now guarantees
+        // any flush that sees the workout HR also sees the banked credit and nets it out.
+        if let store {
+            let toIngest = agg.collectedSamples.map {
+                QuantitySample(kind: .heartRate, start: $0.start, end: $0.end, value: Double($0.bpm))
+            }
+            _ = try? store.ingest(toIngest)
+        }
 
         recordingState = .finished(summary: summary)
     }
@@ -447,17 +457,30 @@ final class WorkoutSessionManager: NSObject {
         }
 
         // Add active energy (ESTIMATE — HR-TRIMP or, when HR didn't lock, a distance estimate).
-        // The daily step/distance active-energy estimate nets this workout's foot-distance out
-        // below, so Health's Move total does not double-count the same walking/running distance.
+        // The daily active-energy estimate nets this workout's committed kcal out below, so
+        // Health's Move total does not double-count the same workout energy.
+        //
+        // Track whether the sample actually landed: the daily estimate is netted by the credit
+        // `recordWorkoutActiveKcal` banks AFTER `finishWorkout`. If we banked that credit while the
+        // energy sample silently failed to write (the old unconditional `try?`), the workout's kcal
+        // would be subtracted from the daily estimate WITHOUT any workout sample in Health — a
+        // permanent under-count. So credit only when the sample was accepted by the builder.
+        var energySampleWritten = false
         if let kcal = summary.estimatedActiveKcal, kcal > 0 {
             let energyType = HKQuantityType(.activeEnergyBurned)
             let q = HKQuantity(unit: .kilocalorie(), doubleValue: kcal)
             let energySample = HKQuantitySample(
                 type: energyType, quantity: q,
                 start: summary.startDate, end: summary.endDate,
-                metadata: ["OpenCircuitActiveEnergyEstimated": true,
+                metadata: [HealthKitWriter.activeEnergyEstimateMetadataKey: true,
                            HKMetadataKeyWasUserEntered: false])
-            try? await builder.addSamples([energySample])
+            do {
+                try await builder.addSamples([energySample])
+                energySampleWritten = true
+            } catch {
+                // Energy sample failed to add — leave `energySampleWritten` false so the credit
+                // below is skipped and the daily estimate isn't netted for energy never written.
+            }
         }
 
         // Add distance (GPS — only for outdoor with route). Pick the correct HK type by sport:
@@ -495,7 +518,10 @@ final class WorkoutSessionManager: NSObject {
         if walkRunDistanceToCredit > 0 {
             HealthKitWriter.recordWorkoutWalkRunDistance(walkRunDistanceToCredit)
         }
-        if let kcal = summary.estimatedActiveKcal, kcal > 0 {
+        // Credit the daily estimate ONLY when the active-energy sample actually landed in Health
+        // (see `energySampleWritten` above) — otherwise netting would subtract energy Health never
+        // received, permanently under-counting the day.
+        if energySampleWritten, let kcal = summary.estimatedActiveKcal, kcal > 0 {
             HealthKitWriter.recordWorkoutActiveKcal(kcal, day: summary.endDate)
         }
 

--- a/ios/OpenCircuit/WorkoutSessionManager.swift
+++ b/ios/OpenCircuit/WorkoutSessionManager.swift
@@ -446,6 +446,20 @@ final class WorkoutSessionManager: NSObject {
             try? await builder.addSamples(hkHRSamples)
         }
 
+        // Add active energy (ESTIMATE — HR-TRIMP or, when HR didn't lock, a distance estimate).
+        // The daily step/distance active-energy estimate nets this workout's foot-distance out
+        // below, so Health's Move total does not double-count the same walking/running distance.
+        if let kcal = summary.estimatedActiveKcal, kcal > 0 {
+            let energyType = HKQuantityType(.activeEnergyBurned)
+            let q = HKQuantity(unit: .kilocalorie(), doubleValue: kcal)
+            let energySample = HKQuantitySample(
+                type: energyType, quantity: q,
+                start: summary.startDate, end: summary.endDate,
+                metadata: ["OpenCircuitActiveEnergyEstimated": true,
+                           HKMetadataKeyWasUserEntered: false])
+            try? await builder.addSamples([energySample])
+        }
+
         // Add distance (GPS — only for outdoor with route). Pick the correct HK type by sport:
         // cycling → .distanceCycling; walking/running/hiking → .distanceWalkingRunning. Writing
         // a cycling ride to the walk/run type would pollute that total (and never show as cycling
@@ -480,6 +494,9 @@ final class WorkoutSessionManager: NSObject {
         // Health permanently under-counted for the day).
         if walkRunDistanceToCredit > 0 {
             HealthKitWriter.recordWorkoutWalkRunDistance(walkRunDistanceToCredit)
+        }
+        if let kcal = summary.estimatedActiveKcal, kcal > 0 {
+            HealthKitWriter.recordWorkoutActiveKcal(kcal, day: summary.endDate)
         }
 
         // Write GPS route if available

--- a/ios/OpenCircuit/WorkoutView.swift
+++ b/ios/OpenCircuit/WorkoutView.swift
@@ -281,6 +281,11 @@ struct WorkoutView: View {
                     } else {
                         statCell("Max HR", "--")
                     }
+                    if let kcal = summary.estimatedActiveKcal {
+                        statCell("Active Cal (est.)", "\(Int(kcal.rounded())) kcal")
+                    } else {
+                        statCell("Active Cal (est.)", "--")
+                    }
                     statCell("HR Readings", "\(summary.hrSampleCount)")
                     if let dist = summary.distanceMeters {
                         statCell("Distance", UnitsFormatter.distance(dist, unit: distanceUnit, fractionDigits: 2))
@@ -311,6 +316,14 @@ struct WorkoutView: View {
                     if summary.hrSampleCount < 30 {
                         noteRow(icon: "exclamationmark.triangle", color: .orange,
                                 text: "Few HR readings captured (\(summary.hrSampleCount)). Live HR polling is best-effort — the ring may have missed updates (issue #45).")
+                    }
+                    if summary.estimatedActiveKcal != nil {
+                        // Label the ACTUAL source: HR-TRIMP when HR locked, else the GPS-distance
+                        // fallback (a zero-HR walk's calories come from distance x body mass).
+                        noteRow(icon: "info.circle", color: .secondary,
+                                text: summary.hrSampleCount > 0
+                                    ? "Active calories are an ESTIMATE (Edwards-TRIMP from HR — not ring sensor data)."
+                                    : "Active calories are an ESTIMATE (from GPS distance x body mass — HR didn't lock; not ring sensor data).")
                     }
                     if summary.hasRoute {
                         noteRow(icon: "location.fill", color: .blue,

--- a/ios/OpenCircuitTests/HealthKitShareTypesTests.swift
+++ b/ios/OpenCircuitTests/HealthKitShareTypesTests.swift
@@ -37,4 +37,42 @@ final class HealthKitShareTypesTests: XCTestCase {
             XCTAssertNotNil(HealthKitWriter.quantityType(for: kind), "\(kind) should be writable")
         }
     }
+
+    func testEnergyWritesCountAsFlushOutput() {
+        var basal = HealthKitWriter.FlushResult()
+        basal.passiveHours = 1
+        XCTAssertTrue(basal.wroteAnything)
+
+        var active = HealthKitWriter.FlushResult()
+        active.activeKcal = 12.5
+        XCTAssertTrue(active.wroteAnything)
+    }
+
+    func testWorkoutActiveKcalLedgerIsDayScopedAndAccumulates() {
+        let suite = "HealthKitShareTypesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let day = Date(timeIntervalSince1970: 10_000)
+        HealthKitWriter.recordWorkoutActiveKcal(80, day: day, defaults)
+        HealthKitWriter.recordWorkoutActiveKcal(20, day: day.addingTimeInterval(60), defaults)
+
+        XCTAssertEqual(defaults.double(forKey: HealthKitWriter.workoutActiveKcalKey), 100)
+
+        HealthKitWriter.recordWorkoutActiveKcal(30, day: day.addingTimeInterval(86_400), defaults)
+        XCTAssertEqual(defaults.double(forKey: HealthKitWriter.workoutActiveKcalKey), 30)
+    }
+
+    func testDailyActiveEnergyNetsWorkoutCaloriesOnlyFromHRSide() {
+        XCTAssertEqual(
+            HealthKitWriter.netDailyActiveKcalEstimate(hrKcal: 300, stepKcal: 80, workoutActiveKcal: 125),
+            175,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            HealthKitWriter.netDailyActiveKcalEstimate(hrKcal: 100, stepKcal: 80, workoutActiveKcal: 125),
+            80,
+            accuracy: 0.001
+        )
+    }
 }

--- a/ios/OpenCircuitTests/HealthKitShareTypesTests.swift
+++ b/ios/OpenCircuitTests/HealthKitShareTypesTests.swift
@@ -63,15 +63,30 @@ final class HealthKitShareTypesTests: XCTestCase {
         XCTAssertEqual(defaults.double(forKey: HealthKitWriter.workoutActiveKcalKey), 30)
     }
 
-    func testDailyActiveEnergyNetsWorkoutCaloriesOnlyFromHRSide() {
+    func testDailyActiveEnergyNetsWorkoutCaloriesFromChosenDailyEstimate() {
+        // HR channel dominates → credit nets the HR-derived daily estimate.
         XCTAssertEqual(
             HealthKitWriter.netDailyActiveKcalEstimate(hrKcal: 300, stepKcal: 80, workoutActiveKcal: 125),
             175,
             accuracy: 0.001
         )
+        // HR channel dominates but the workout kcal exceeds it → clamp at 0 (never negative).
         XCTAssertEqual(
             HealthKitWriter.netDailyActiveKcalEstimate(hrKcal: 100, stepKcal: 80, workoutActiveKcal: 125),
+            0,
+            accuracy: 0.001
+        )
+        // Step channel dominates (indoor/treadmill: steps counted, HR sparse) → credit STILL nets
+        // the step-derived estimate. The old "HR side only" netting left this double-counted.
+        XCTAssertEqual(
+            HealthKitWriter.netDailyActiveKcalEstimate(hrKcal: 50, stepKcal: 200, workoutActiveKcal: 120),
             80,
+            accuracy: 0.001
+        )
+        // No workout → the plain daily estimate (larger of the two channels) passes through.
+        XCTAssertEqual(
+            HealthKitWriter.netDailyActiveKcalEstimate(hrKcal: 90, stepKcal: 140, workoutActiveKcal: 0),
+            140,
             accuracy: 0.001
         )
     }


### PR DESCRIPTION
## Summary
- restore the Home Calories card and Active calories goal setting removed by PR #121
- restore basal + active energy HealthKit authorization and foreground/background flush call sites
- restore workout active-calorie summary UI plus activeEnergyBurned samples on saved workouts
- add a daily workout active-kcal credit so daily HR-derived active energy does not double-count workout HR persisted by PR #121

## Verification
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path ios/OpenCircuitKit (602 tests, 0 failures)
- xcodegen generate
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ios/OpenCircuit.xcodeproj -scheme OpenCircuit -configuration Debug -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build

## Notes
- This is intentionally separate from PR #125, which restores the on-demand HR/SpO2 buttons.
- The app test target was attempted on iPhone 17 Simulator but is currently blocked by an existing startup crash in the HealthKit blood-pressure authorization path: HKCorrelationTypeIdentifierBloodPressure is disallowed without the HealthKit entitlement in that simulator run.
- Existing Swift 6 isolation warnings remain in LocalStore.swift and RingBackgroundSyncService.swift.