### PR TITLE
fix: suppress stale heart rate alerts

### DIFF
--- a/ios/OpenCircuit/HealthNotificationCenter.swift
+++ b/ios/OpenCircuit/HealthNotificationCenter.swift
@@ -170,12 +170,14 @@ struct HealthNotificationCenter {
     var gate = NotificationGate()
     private var center: UNUserNotificationCenter { .current() }
 
-    /// How far back instantaneous SpO2 alerts (#73) look for a threshold crossing. Covers an
-    /// overnight sync that finishes in the morning; the de-dupe backoff stops it from re-nagging.
+    /// How far back the instantaneous HR / SpO2 alerts (#73) look for a threshold crossing. Wide on
+    /// purpose: all-day HR (and overnight SpO2) reaches the phone via ~hourly background drains whose
+    /// device timestamps are routinely 30–60+ min old on arrival, and the phone evaluates ONCE right
+    /// after each drain. A narrower device-timestamp "freshness" fetch window would permanently
+    /// silence the older half of every drain — the legitimate background alerts we most need to
+    /// deliver. De-dupe is NOT done here by sample age: the evaluator's per-notification `lastFired`
+    /// filter is the sole guard that stops an already-alerted crossing from replaying on later syncs.
     static let instantLookback: TimeInterval = 12 * 3600
-    /// HR notifications are event-like: synced history may contain valid but hours-old HR, and that
-    /// should update charts/HealthKit without replaying as a fresh phone alert.
-    static let hrFreshness = HealthAlertFreshness(maxAge: 30 * 60)
 
     /// Evaluate ALL health-alert conditions (#73 + #85) from the store (+ optional live session),
     /// then post a debounced notification for each survivor. Safe to call liberally — a no-op when
@@ -188,34 +190,34 @@ struct HealthNotificationCenter {
         let thresholds = HealthAlertDefaults.thresholds()
         let instantSince = now.addingTimeInterval(-Self.instantLookback)
         let lastFired = store.lastFired()
-        let hrSince = Self.hrFreshness.instantSince(now: now, lastFired: lastFired[.highHR])
-        let inactiveSince = Self.hrFreshness.sustainedSince(
-            now: now,
-            minDuration: thresholds.elevatedSustained,
-            lastFired: lastFired[.elevatedHRInactive])
-        // Stored readings + the just-synced in-memory batch (so a fresh sync is reflected at once).
-        var hr = ((try? localStore.recentSamples(kind: .heartRate, since: hrSince)) ?? [])
-            .filter { $0.start > hrSince && $0.start <= now }
+        // Fetch the whole recent window (stored + the just-synced in-memory batch) and let the pure
+        // evaluator's per-notification `lastFired` filter do the de-dupe. HR is fetched over the SAME
+        // wide window as SpO2 — never a 30-min device-timestamp freshness window — so a crossing that
+        // rode in on the older half of an hourly background drain (timestamps 30–60+ min old) still
+        // alerts once. The future guard (`start <= now`) is applied uniformly to HR and SpO2.
+        var hr = ((try? localStore.recentSamples(kind: .heartRate, since: instantSince)) ?? [])
+            .filter { $0.start <= now }
             .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
         var spo2 = ((try? localStore.recentSamples(kind: .spo2, since: instantSince)) ?? [])
+            .filter { $0.start <= now }
             .map { SpO2Reading(percent: Int(($0.value * 100).rounded()), time: $0.start) }
-        let inactiveHR = ((try? localStore.recentSamples(kind: .heartRate, since: inactiveSince)) ?? [])
-            .filter { $0.start > inactiveSince && $0.start <= now }
-            .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
 
         if let synced = session?.historySamples {
             hr += synced.filter {
-                $0.kind == .heartRate && $0.value > 0 && $0.start > hrSince && $0.start <= now
+                $0.kind == .heartRate && $0.value > 0 && $0.start >= instantSince && $0.start <= now
             }
                 .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
-            spo2 += synced.filter { $0.kind == .spo2 && $0.value > 0 && $0.start >= instantSince }
+            spo2 += synced.filter {
+                $0.kind == .spo2 && $0.value > 0 && $0.start >= instantSince && $0.start <= now
+            }
                 .map { SpO2Reading(percent: Int(($0.value * 100).rounded()), time: $0.start) }
         }
 
-        for hit in HealthAlertEvaluator.evaluate(hr: hr, spo2: spo2, inactiveHR: inactiveHR,
+        // The sustained-while-inactive rule reads the same HR series over the same wide window; its
+        // own `lastFired` filter inside the evaluator gives it once-per-event de-dupe.
+        for hit in HealthAlertEvaluator.evaluate(hr: hr, spo2: spo2, inactiveHR: hr,
                                                  thresholds: thresholds,
                                                  lastFired: lastFired) {
-            guard Self.hrFreshness.freshHRHit(hit, now: now) else { continue }
             candidates.append(hit.notification)
             hitByNotif[hit.notification] = hit
         }

--- a/ios/OpenCircuit/HealthNotificationCenter.swift
+++ b/ios/OpenCircuit/HealthNotificationCenter.swift
@@ -170,11 +170,12 @@ struct HealthNotificationCenter {
     var gate = NotificationGate()
     private var center: UNUserNotificationCenter { .current() }
 
-    /// How far back instantaneous HR/SpO2 alerts (#73) look for a threshold crossing. Covers an
+    /// How far back instantaneous SpO2 alerts (#73) look for a threshold crossing. Covers an
     /// overnight sync that finishes in the morning; the de-dupe backoff stops it from re-nagging.
     static let instantLookback: TimeInterval = 12 * 3600
-    /// Window for the sustained-elevated-HR-while-inactive rule.
-    static let inactiveLookback: TimeInterval = 24 * 3600
+    /// HR notifications are event-like: synced history may contain valid but hours-old HR, and that
+    /// should update charts/HealthKit without replaying as a fresh phone alert.
+    static let hrFreshness = HealthAlertFreshness(maxAge: 30 * 60)
 
     /// Evaluate ALL health-alert conditions (#73 + #85) from the store (+ optional live session),
     /// then post a debounced notification for each survivor. Safe to call liberally — a no-op when
@@ -186,34 +187,35 @@ struct HealthNotificationCenter {
         // --- #73: high HR / low SpO2 / elevated-HR-while-inactive --------------------------------
         let thresholds = HealthAlertDefaults.thresholds()
         let instantSince = now.addingTimeInterval(-Self.instantLookback)
-        let inactiveSince = now.addingTimeInterval(-Self.inactiveLookback)
         let lastFired = store.lastFired()
-        // Only consider HR/SpO2 readings NEWER than the last time that notification fired, so a
-        // single morning spike alerts ONCE rather than re-firing every backoff window (the 2h
-        // backoff is shorter than the 12h lookback, so without this the worst reading in the
-        // window would keep being re-returned and re-announced for hours). (#73 fix)
-        let hrSince = max(instantSince, lastFired[.highHR] ?? .distantPast)
-        let spo2Since = max(instantSince, lastFired[.lowSpO2] ?? .distantPast)
-
+        let hrSince = Self.hrFreshness.instantSince(now: now, lastFired: lastFired[.highHR])
+        let inactiveSince = Self.hrFreshness.sustainedSince(
+            now: now,
+            minDuration: thresholds.elevatedSustained,
+            lastFired: lastFired[.elevatedHRInactive])
         // Stored readings + the just-synced in-memory batch (so a fresh sync is reflected at once).
-        var hr = ((try? localStore.recentSamples(kind: .heartRate, since: instantSince)) ?? [])
-            .filter { $0.start > hrSince }
+        var hr = ((try? localStore.recentSamples(kind: .heartRate, since: hrSince)) ?? [])
+            .filter { $0.start > hrSince && $0.start <= now }
             .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
         var spo2 = ((try? localStore.recentSamples(kind: .spo2, since: instantSince)) ?? [])
-            .filter { $0.start > spo2Since }
             .map { SpO2Reading(percent: Int(($0.value * 100).rounded()), time: $0.start) }
         let inactiveHR = ((try? localStore.recentSamples(kind: .heartRate, since: inactiveSince)) ?? [])
+            .filter { $0.start > inactiveSince && $0.start <= now }
             .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
 
         if let synced = session?.historySamples {
-            hr += synced.filter { $0.kind == .heartRate && $0.value > 0 && $0.start > hrSince }
+            hr += synced.filter {
+                $0.kind == .heartRate && $0.value > 0 && $0.start > hrSince && $0.start <= now
+            }
                 .map { HRSample(bpm: Int($0.value), start: $0.start, end: $0.end) }
-            spo2 += synced.filter { $0.kind == .spo2 && $0.value > 0 && $0.start > spo2Since }
+            spo2 += synced.filter { $0.kind == .spo2 && $0.value > 0 && $0.start >= instantSince }
                 .map { SpO2Reading(percent: Int(($0.value * 100).rounded()), time: $0.start) }
         }
 
         for hit in HealthAlertEvaluator.evaluate(hr: hr, spo2: spo2, inactiveHR: inactiveHR,
-                                                 thresholds: thresholds) {
+                                                 thresholds: thresholds,
+                                                 lastFired: lastFired) {
+            guard Self.hrFreshness.freshHRHit(hit, now: now) else { continue }
             candidates.append(hit.notification)
             hitByNotif[hit.notification] = hit
         }

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
@@ -150,6 +150,55 @@ public struct HealthAlertHit: Equatable, Sendable {
     }
 }
 
+/// Freshness guard for event-like HR alerts. History sync can legitimately backfill hours-old HR
+/// samples; those belong in the charts/HealthKit, but they must not replay as "just happened"
+/// phone notifications. The sustained rule needs `minDuration` of lead-in samples so a run that
+/// started just before the freshness window and completed inside it still alerts.
+public struct HealthAlertFreshness: Equatable, Sendable {
+    public var maxAge: TimeInterval
+
+    public init(maxAge: TimeInterval = 30 * 60) {
+        self.maxAge = maxAge
+    }
+
+    public func contains(_ date: Date, now: Date) -> Bool {
+        date <= now && now.timeIntervalSince(date) <= maxAge
+    }
+
+    public func instantSince(now: Date, lastFired: Date? = nil) -> Date {
+        max(now.addingTimeInterval(-maxAge), lastFired ?? .distantPast)
+    }
+
+    public func sustainedSince(now: Date, minDuration: TimeInterval,
+                               lastFired: Date? = nil) -> Date {
+        let freshLeadIn = now.addingTimeInterval(-(maxAge + minDuration))
+        let firedLeadIn = lastFired?.addingTimeInterval(-minDuration) ?? .distantPast
+        return max(freshLeadIn, firedLeadIn)
+    }
+
+    public func freshInstantHR(_ samples: [HRSample], now: Date,
+                               lastFired: Date? = nil) -> [HRSample] {
+        let since = instantSince(now: now, lastFired: lastFired)
+        return samples.filter { $0.start > since && contains($0.start, now: now) }
+    }
+
+    public func freshSustainedHR(_ samples: [HRSample], now: Date,
+                                 minDuration: TimeInterval,
+                                 lastFired: Date? = nil) -> [HRSample] {
+        let since = sustainedSince(now: now, minDuration: minDuration, lastFired: lastFired)
+        return samples.filter { $0.start > since && $0.start <= now }
+    }
+
+    public func freshHRHit(_ hit: HealthAlertHit, now: Date) -> Bool {
+        switch hit.notification {
+        case .highHR, .elevatedHRInactive:
+            return contains(hit.time, now: now)
+        default:
+            return true
+        }
+    }
+}
+
 public enum HealthAlertEvaluator {
 
     /// The worst (highest) HR reading at/above the threshold, or nil. "High heart rate detected at
@@ -190,16 +239,23 @@ public enum HealthAlertEvaluator {
     /// Evaluate all three #73 rules and return the hits (disabled rules are skipped). `inactiveHR`
     /// is the HR series for the sustained-while-inactive rule; the instantaneous rules use `hr`.
     public static func evaluate(hr: [HRSample], spo2: [SpO2Reading], inactiveHR: [HRSample],
-                                thresholds: HealthAlertThresholds) -> [HealthAlertHit] {
+                                thresholds: HealthAlertThresholds,
+                                lastFired: [HealthNotification: Date] = [:]) -> [HealthAlertHit] {
         var hits: [HealthAlertHit] = []
-        if thresholds.highHREnabled, let s = highHR(hr, thresholdBpm: thresholds.highHRBpm) {
+        let freshHR = hr.filter { $0.start > (lastFired[.highHR] ?? .distantPast) }
+        let freshSpO2 = spo2.filter { $0.time > (lastFired[.lowSpO2] ?? .distantPast) }
+        let freshInactiveHR = inactiveHR.filter {
+            $0.start > (lastFired[.elevatedHRInactive] ?? .distantPast)
+        }
+
+        if thresholds.highHREnabled, let s = highHR(freshHR, thresholdBpm: thresholds.highHRBpm) {
             hits.append(HealthAlertHit(notification: .highHR, value: Double(s.bpm), time: s.start))
         }
-        if thresholds.lowSpO2Enabled, let s = lowSpO2(spo2, thresholdPercent: thresholds.lowSpO2Percent) {
+        if thresholds.lowSpO2Enabled, let s = lowSpO2(freshSpO2, thresholdPercent: thresholds.lowSpO2Percent) {
             hits.append(HealthAlertHit(notification: .lowSpO2, value: Double(s.percent), time: s.time))
         }
         if thresholds.elevatedHREnabled,
-           let s = elevatedHRInactive(inactiveHR, thresholdBpm: thresholds.elevatedHRBpm,
+           let s = elevatedHRInactive(freshInactiveHR, thresholdBpm: thresholds.elevatedHRBpm,
                                       minDuration: thresholds.elevatedSustained,
                                       maxGap: thresholds.elevatedMaxGap) {
             hits.append(HealthAlertHit(notification: .elevatedHRInactive, value: Double(s.bpm), time: s.start))

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
@@ -150,54 +150,11 @@ public struct HealthAlertHit: Equatable, Sendable {
     }
 }
 
-/// Freshness guard for event-like HR alerts. History sync can legitimately backfill hours-old HR
-/// samples; those belong in the charts/HealthKit, but they must not replay as "just happened"
-/// phone notifications. The sustained rule needs `minDuration` of lead-in samples so a run that
-/// started just before the freshness window and completed inside it still alerts.
-public struct HealthAlertFreshness: Equatable, Sendable {
-    public var maxAge: TimeInterval
-
-    public init(maxAge: TimeInterval = 30 * 60) {
-        self.maxAge = maxAge
-    }
-
-    public func contains(_ date: Date, now: Date) -> Bool {
-        date <= now && now.timeIntervalSince(date) <= maxAge
-    }
-
-    public func instantSince(now: Date, lastFired: Date? = nil) -> Date {
-        max(now.addingTimeInterval(-maxAge), lastFired ?? .distantPast)
-    }
-
-    public func sustainedSince(now: Date, minDuration: TimeInterval,
-                               lastFired: Date? = nil) -> Date {
-        let freshLeadIn = now.addingTimeInterval(-(maxAge + minDuration))
-        let firedLeadIn = lastFired?.addingTimeInterval(-minDuration) ?? .distantPast
-        return max(freshLeadIn, firedLeadIn)
-    }
-
-    public func freshInstantHR(_ samples: [HRSample], now: Date,
-                               lastFired: Date? = nil) -> [HRSample] {
-        let since = instantSince(now: now, lastFired: lastFired)
-        return samples.filter { $0.start > since && contains($0.start, now: now) }
-    }
-
-    public func freshSustainedHR(_ samples: [HRSample], now: Date,
-                                 minDuration: TimeInterval,
-                                 lastFired: Date? = nil) -> [HRSample] {
-        let since = sustainedSince(now: now, minDuration: minDuration, lastFired: lastFired)
-        return samples.filter { $0.start > since && $0.start <= now }
-    }
-
-    public func freshHRHit(_ hit: HealthAlertHit, now: Date) -> Bool {
-        switch hit.notification {
-        case .highHR, .elevatedHRInactive:
-            return contains(hit.time, now: now)
-        default:
-            return true
-        }
-    }
-}
+// NOTE: HR alerts intentionally have NO device-timestamp "freshness" gate. All-day HR reaches the
+// phone via ~hourly background drains whose device timestamps are routinely 30–60+ min old on
+// arrival, evaluated ONCE right after each drain; a freshness window would permanently silence the
+// older half of every drain. De-dupe is done here by the per-notification `lastFired` filter in
+// `evaluate` (a crossing fires once on first sight and never replays), not by the sample's age.
 
 public enum HealthAlertEvaluator {
 

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
@@ -65,6 +65,110 @@ final class HealthAlertsTests: XCTestCase {
         XCTAssertEqual(hits.map(\.notification), [.highHR])
     }
 
+    func testEvaluateSuppressesReadingsAtOrBeforeLastFired() {
+        let thresholds = HealthAlertThresholds(highHRBpm: 120,
+                                               lowSpO2Percent: 90,
+                                               elevatedHRBpm: 100)
+        let oldInactiveRun = [hr(105, 1, 0), hr(108, 1, 3), hr(110, 1, 6),
+                              hr(106, 1, 9), hr(112, 1, 12)]
+        let hits = HealthAlertEvaluator.evaluate(
+            hr: [hr(130, 2)],
+            spo2: [SpO2Reading(percent: 85, time: at(2))],
+            inactiveHR: oldInactiveRun,
+            thresholds: thresholds,
+            lastFired: [.highHR: at(3), .lowSpO2: at(3), .elevatedHRInactive: at(3)])
+
+        XCTAssertTrue(hits.isEmpty, "old threshold crossings must not replay after the backoff expires")
+    }
+
+    func testEvaluateAllowsFreshInactiveRunAfterLastFired() {
+        let thresholds = HealthAlertThresholds(highHREnabled: false,
+                                               lowSpO2Enabled: false,
+                                               elevatedHRBpm: 100)
+        let freshRun = [hr(105, 4, 0), hr(108, 4, 3), hr(110, 4, 6),
+                        hr(106, 4, 9), hr(112, 4, 12)]
+        let hits = HealthAlertEvaluator.evaluate(
+            hr: [],
+            spo2: [],
+            inactiveHR: freshRun,
+            thresholds: thresholds,
+            lastFired: [.elevatedHRInactive: at(3)])
+
+        XCTAssertEqual(hits.map(\.notification), [.elevatedHRInactive])
+        XCTAssertEqual(hits.first?.value, 112)
+    }
+
+    func testHRFreshnessDropsStaleSyncedHighAndSustainedHR() {
+        let now = at(12)
+        let freshness = HealthAlertFreshness(maxAge: 30 * 60)
+        let thresholds = HealthAlertThresholds(
+            highHREnabled: true,
+            highHRBpm: 110,
+            lowSpO2Enabled: false,
+            elevatedHREnabled: true,
+            elevatedHRBpm: 110,
+            elevatedSustained: 10 * 60)
+        let staleHigh = [hr(132, 8)]
+        let staleRun = [hr(112, 8, 0), hr(115, 8, 3), hr(118, 8, 6),
+                        hr(116, 8, 9), hr(114, 8, 12)]
+
+        let hits = HealthAlertEvaluator.evaluate(
+            hr: freshness.freshInstantHR(staleHigh, now: now),
+            spo2: [],
+            inactiveHR: freshness.freshSustainedHR(
+                staleRun, now: now, minDuration: thresholds.elevatedSustained),
+            thresholds: thresholds)
+
+        XCTAssertTrue(hits.isEmpty, "hours-old synced HR must update history without replaying a phone alert")
+    }
+
+    func testHRFreshnessKeepsFreshHighAndSustainedHR() {
+        let now = at(12)
+        let freshness = HealthAlertFreshness(maxAge: 30 * 60)
+        let thresholds = HealthAlertThresholds(
+            highHREnabled: true,
+            highHRBpm: 120,
+            lowSpO2Enabled: false,
+            elevatedHREnabled: true,
+            elevatedHRBpm: 110,
+            elevatedSustained: 10 * 60)
+        let freshHigh = [hr(132, 11, 50)]
+        let freshRun = [hr(112, 11, 35), hr(115, 11, 38), hr(118, 11, 41),
+                        hr(116, 11, 45)]
+
+        let hits = HealthAlertEvaluator.evaluate(
+            hr: freshness.freshInstantHR(freshHigh, now: now),
+            spo2: [],
+            inactiveHR: freshness.freshSustainedHR(
+                freshRun, now: now, minDuration: thresholds.elevatedSustained),
+            thresholds: thresholds)
+
+        XCTAssertEqual(Set(hits.map(\.notification)), [.highHR, .elevatedHRInactive])
+    }
+
+    func testHRFreshnessKeepsSustainedRunLeadInBeforeFreshWindow() {
+        let now = at(12)
+        let freshness = HealthAlertFreshness(maxAge: 30 * 60)
+        let thresholds = HealthAlertThresholds(
+            highHREnabled: false,
+            lowSpO2Enabled: false,
+            elevatedHREnabled: true,
+            elevatedHRBpm: 110,
+            elevatedSustained: 10 * 60)
+        // The run starts 35 minutes ago but completes 25 minutes ago, so it is still a fresh
+        // completion. The freshness helper keeps the 10-minute lead-in needed to prove it.
+        let run = [hr(112, 11, 25), hr(115, 11, 28), hr(118, 11, 31), hr(116, 11, 35)]
+
+        let hits = HealthAlertEvaluator.evaluate(
+            hr: [],
+            spo2: [],
+            inactiveHR: freshness.freshSustainedHR(
+                run, now: now, minDuration: thresholds.elevatedSustained),
+            thresholds: thresholds)
+
+        XCTAssertEqual(hits.map(\.notification), [.elevatedHRInactive])
+    }
+
     // MARK: #85 flag routing
 
     func testTempFeverRouting() {

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
@@ -98,75 +98,64 @@ final class HealthAlertsTests: XCTestCase {
         XCTAssertEqual(hits.first?.value, 112)
     }
 
-    func testHRFreshnessDropsStaleSyncedHighAndSustainedHR() {
-        let now = at(12)
-        let freshness = HealthAlertFreshness(maxAge: 30 * 60)
-        let thresholds = HealthAlertThresholds(
-            highHREnabled: true,
-            highHRBpm: 110,
-            lowSpO2Enabled: false,
-            elevatedHREnabled: true,
-            elevatedHRBpm: 110,
-            elevatedSustained: 10 * 60)
-        let staleHigh = [hr(132, 8)]
-        let staleRun = [hr(112, 8, 0), hr(115, 8, 3), hr(118, 8, 6),
-                        hr(116, 8, 9), hr(114, 8, 12)]
+    // MARK: Background-drain latency (30–60 min old timestamps) — de-dupe is the ONLY gate
 
+    func testDrainLatencyOldHighHRCrossingFiresOnFirstSight() {
+        // All-day HR arrives via an ~hourly background drain: the phone evaluates ONCE, right after
+        // the drain, and the crossing's device timestamp is already ~45 min old on arrival. With the
+        // 30-min device-timestamp freshness window removed, a not-yet-fired crossing must still alert
+        // once — otherwise every legitimate background high-HR event in the older half of a drain is
+        // permanently silenced.
+        let thresholds = HealthAlertThresholds(highHRBpm: 120,
+                                               lowSpO2Enabled: false,
+                                               elevatedHREnabled: false)
         let hits = HealthAlertEvaluator.evaluate(
-            hr: freshness.freshInstantHR(staleHigh, now: now),
+            hr: [hr(145, 9, 15)],   // ~45 min before the post-drain evaluation at ~10:00
             spo2: [],
-            inactiveHR: freshness.freshSustainedHR(
-                staleRun, now: now, minDuration: thresholds.elevatedSustained),
-            thresholds: thresholds)
-
-        XCTAssertTrue(hits.isEmpty, "hours-old synced HR must update history without replaying a phone alert")
+            inactiveHR: [],
+            thresholds: thresholds,
+            lastFired: [:])
+        XCTAssertEqual(hits.map(\.notification), [.highHR])
+        XCTAssertEqual(hits.first?.value, 145)
     }
 
-    func testHRFreshnessKeepsFreshHighAndSustainedHR() {
-        let now = at(12)
-        let freshness = HealthAlertFreshness(maxAge: 30 * 60)
-        let thresholds = HealthAlertThresholds(
-            highHREnabled: true,
-            highHRBpm: 120,
-            lowSpO2Enabled: false,
-            elevatedHREnabled: true,
-            elevatedHRBpm: 110,
-            elevatedSustained: 10 * 60)
-        let freshHigh = [hr(132, 11, 50)]
-        let freshRun = [hr(112, 11, 35), hr(115, 11, 38), hr(118, 11, 41),
-                        hr(116, 11, 45)]
-
-        let hits = HealthAlertEvaluator.evaluate(
-            hr: freshness.freshInstantHR(freshHigh, now: now),
-            spo2: [],
-            inactiveHR: freshness.freshSustainedHR(
-                freshRun, now: now, minDuration: thresholds.elevatedSustained),
-            thresholds: thresholds)
-
-        XCTAssertEqual(Set(hits.map(\.notification)), [.highHR, .elevatedHRInactive])
-    }
-
-    func testHRFreshnessKeepsSustainedRunLeadInBeforeFreshWindow() {
-        let now = at(12)
-        let freshness = HealthAlertFreshness(maxAge: 30 * 60)
-        let thresholds = HealthAlertThresholds(
-            highHREnabled: false,
-            lowSpO2Enabled: false,
-            elevatedHREnabled: true,
-            elevatedHRBpm: 110,
-            elevatedSustained: 10 * 60)
-        // The run starts 35 minutes ago but completes 25 minutes ago, so it is still a fresh
-        // completion. The freshness helper keeps the 10-minute lead-in needed to prove it.
-        let run = [hr(112, 11, 25), hr(115, 11, 28), hr(118, 11, 31), hr(116, 11, 35)]
-
+    func testDrainLatencyOldSustainedRunFiresOnFirstSight() {
+        // A sustained elevated-while-inactive run whose 10-min completion is ~40 min old on arrival.
+        // The previous 40-min fetch window collapsed the 24h lookback to now-40min and silenced
+        // exactly this run; over the restored wide window it must alert once.
+        let thresholds = HealthAlertThresholds(highHREnabled: false,
+                                               lowSpO2Enabled: false,
+                                               elevatedHRBpm: 100,
+                                               elevatedSustained: 10 * 60)
+        let run = [hr(105, 9, 0), hr(108, 9, 3), hr(110, 9, 6), hr(106, 9, 9), hr(112, 9, 12)]
         let hits = HealthAlertEvaluator.evaluate(
             hr: [],
             spo2: [],
-            inactiveHR: freshness.freshSustainedHR(
-                run, now: now, minDuration: thresholds.elevatedSustained),
-            thresholds: thresholds)
-
+            inactiveHR: run,
+            thresholds: thresholds,
+            lastFired: [:])
         XCTAssertEqual(hits.map(\.notification), [.elevatedHRInactive])
+        XCTAssertEqual(hits.first?.value, 112)
+    }
+
+    func testDrainLatencyFiredCrossingDoesNotReplayOnNextDrain() {
+        // Once a crossing has fired (its time recorded in `lastFired`), the next hourly drain
+        // re-delivers the SAME hours-old samples. The per-notification `lastFired` filter — now the
+        // entire stale-replay guard — must drop them so they don't post a second phone alert.
+        let thresholds = HealthAlertThresholds(highHRBpm: 120,
+                                               lowSpO2Enabled: false,
+                                               elevatedHRBpm: 100,
+                                               elevatedSustained: 10 * 60)
+        let redeliveredHigh = [hr(145, 9, 15)]
+        let redeliveredRun = [hr(105, 9, 0), hr(108, 9, 3), hr(110, 9, 6),
+                              hr(106, 9, 9), hr(112, 9, 12)]
+        let hits = HealthAlertEvaluator.evaluate(
+            hr: redeliveredHigh,
+            spo2: [],
+            inactiveHR: redeliveredRun,
+            thresholds: thresholds,
+            lastFired: [.highHR: at(9, 15), .elevatedHRInactive: at(9, 12)])
+        XCTAssertTrue(hits.isEmpty, "already-fired crossings must not replay on the next drain")
     }
 
     // MARK: #85 flag routing


### PR DESCRIPTION
## Summary
- limit high-HR phone alerts to fresh heart-rate samples instead of broad synced history
- keep sustained inactive-HR lead-in so a fresh 10-minute run still qualifies
- filter already-fired readings per notification and add regression tests for stale synced HR replay

## Verification
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path ios/OpenCircuitKit --filter HealthAlertsTests` (21 tests, 0 failures)
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path ios/OpenCircuitKit` (607 tests, 0 failures)
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift run --package-path ios/OpenCircuitKit RingKitVerify`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ios/OpenCircuit.xcodeproj -scheme OpenCircuit -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`\n\n## Note\nThe freshness window is currently 30 minutes. That intentionally prevents hours-old synced HR from replaying as a new phone alert; tune `HealthNotificationCenter.hrFreshness` if product wants a different grace period.