### PR TITLE
fix: HealthKit auth crash after revoking Health access (BP correlation type in auth set)

### DIFF
--- a/ios/OpenCircuit/Health/HealthKitWriter.swift
+++ b/ios/OpenCircuit/Health/HealthKitWriter.swift
@@ -72,7 +72,8 @@ final class HealthKitWriter {
         }
     }
 
-    private var allTypes: Set<HKSampleType> {
+    // Internal (not private) so HealthKitShareTypesTests can guard the set's contents.
+    var allTypes: Set<HKSampleType> {
         var set = Set<HKSampleType>()
         for k in MetricKind.allCases {
             if let t = Self.quantityType(for: k) { set.insert(t) }
@@ -88,9 +89,16 @@ final class HealthKitWriter {
         // NOTE: temperature is NOT added here — it already ships via the canonical
         // `.basalBodyTemperature` path (MetricKind.temperature). No triple-write.
         set.insert(HKCategoryType(.menstrualFlow))
+        // Blood pressure (#121): authorization is granted on the two CONSTITUENT quantity
+        // types only. The `bloodPressureType` HKCorrelationType must NEVER be added here:
+        // correlation types are not authorizable, and their presence in the `toShare` set of
+        // `requestAuthorization`/`statusForAuthorizationRequest` raises an uncatchable Obj-C
+        // NSInvalidArgumentException — which crashed the app whenever the auth path ran, e.g.
+        // right after the user revoked Health access in the Health app (the #119 auth-recovery
+        // path re-requests). Saving the HKCorrelation itself needs no correlation-level grant;
+        // it is authorized through systolic + diastolic.
         set.insert(Self.systolicType)
         set.insert(Self.diastolicType)
-        set.insert(Self.bloodPressureType)
         return set
     }
 

--- a/ios/OpenCircuitTests/BackgroundRefreshSchedulerTests.swift
+++ b/ios/OpenCircuitTests/BackgroundRefreshSchedulerTests.swift
@@ -1,5 +1,6 @@
 import BackgroundTasks
 import XCTest
+import OpenCircuitKit
 @testable import OpenCircuit
 
 final class BackgroundRefreshSchedulerTests: XCTestCase {

--- a/ios/OpenCircuitTests/HealthKitShareTypesTests.swift
+++ b/ios/OpenCircuitTests/HealthKitShareTypesTests.swift
@@ -1,9 +1,24 @@
+import HealthKit
 import XCTest
 import OpenCircuitKit
 @testable import OpenCircuit
 
 @MainActor
 final class HealthKitShareTypesTests: XCTestCase {
+    /// Correlation types (blood pressure) are NOT authorizable: putting one in the `toShare`
+    /// set of `requestAuthorization`/`statusForAuthorizationRequest` raises the same
+    /// uncatchable NSInvalidArgumentException as #110 — it crashed the app whenever the auth
+    /// path ran after PR #121 added it (e.g. right after the user revoked Health access in the
+    /// Health app, when the auth-recovery path re-requests). BP auth rides on the two
+    /// constituent quantity types instead; guard against the correlation type creeping back.
+    func testAuthTypeSetContainsNoCorrelationTypes() {
+        let types = HealthKitWriter().allTypes
+        XCTAssertFalse(types.contains { $0 is HKCorrelationType },
+                       "correlation types must never enter the HealthKit auth set")
+        XCTAssertTrue(types.contains(HKQuantityType(.bloodPressureSystolic)))
+        XCTAssertTrue(types.contains(HKQuantityType(.bloodPressureDiastolic)))
+    }
+
     /// Apple Exercise Time is an Apple-COMPUTED Activity-ring metric and is NOT third-party
     /// shareable. Listing it in HealthKit's auth `toShare` set raises an Obj-C
     /// NSInvalidArgumentException (-[HKHealthStore _throwIfAuthorizationDisallowedForSharing:])


### PR DESCRIPTION
## The bug

Turn on Apple Health access in the app, then turn it off in the Health app → the app crashes on next launch/foreground.

## Root cause

PR #121 added `HKCorrelationType(.bloodPressure)` to `HealthKitWriter.allTypes` (HealthKitWriter.swift:93). Correlation types are **not authorizable** — putting one in the `toShare` set of `requestAuthorization`/`statusForAuthorizationRequest` raises an uncatchable Obj-C `NSInvalidArgumentException` (`-[HKHealthStore _throwIfAuthorizationDisallowedForSharing:]`), the same crash class this codebase already documents for `.appleExerciseTime` (TestFlight #110).

Why revoking triggers it: while share access is granted, nothing calls the auth APIs. Once revoked, `ContentView`'s `.task` (ContentView.swift:124–133) sees `isShareAuthorized == false` and automatically calls `authorizationPromptAvailable()` → `statusForAuthorizationRequest(toShare: allTypes, …)` with the poisoned set — no tap needed. The Connect button / #119 auth-recovery path (`requestAuthorization`) hits the same wall. This is also the "existing startup crash in the HealthKit blood-pressure authorization path" that blocks the simulator app-test run, noted in #126.

## The fix

- Remove the correlation type from `allTypes`. BP authorization rides on the systolic/diastolic constituent quantity types (still in the set); saving the `HKCorrelation` itself needs no correlation-level grant — nothing about BP writing changes.
- Regression test `testAuthTypeSetContainsNoCorrelationTypes` (`allTypes` made internal for the test).
- Drive-by: add the missing `import OpenCircuitKit` in `BackgroundRefreshSchedulerTests.swift` — the app test target didn't even compile on master (identical one-liner to the one in #126; they merge cleanly).

## Verification

- iPhone 17 Pro Max simulator, `-only-testing:OpenCircuitTests/HealthKitShareTypesTests`: the test host **boots** (on master it can't get through startup) and the new regression test passes.
- Known pre-existing failure left as-is: `testWritableMetricsStillMapToAType` fails on master because #121 made `quantityType(for: .activeEnergy)` nil; #126 restores that mapping and makes it pass. Not this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)