### PR TITLE
fix(sleep): rescue a moving-but-asleep morning that motion truncates (night cut ~1h50m short)

### DIFF
--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepDetection.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepDetection.swift
@@ -110,6 +110,34 @@ public struct ActivityPeriod: Equatable, Sendable {
     /// stray reading can neither set a bogus floor nor flip a block.
     static let minHRSamplesForGate = 3
 
+    /// Sleep-vitals rescue (the SYMMETRIC counterpart to the HR gate). The motion detector is blind
+    /// to a still-but-AWAKE period (→ HR gate). It is EQUALLY blind the other way: a MOVING-but-ASLEEP
+    /// stretch — a restless pre-wake morning of posture shifts and limb movement — reads as motion and
+    /// is classified `.active`, truncating the night at the first stir even though the sleeper is still
+    /// down. The `motionAboveLocalFloor` normaliser makes this worse: a night that is dead-still for
+    /// hours then moves more before waking has a very low floor, so the morning plateau is measured as
+    /// large motion. HR/HRV catch what motion can't — during that stretch the ring keeps emitting
+    /// sleep-vitals epochs (HRV present, PROTOCOL §5.3) at a heart rate still near the night's resting
+    /// floor, whereas true wake shows the sleep-vitals stream thin out AND HR climb. 🟢 grounded on the
+    /// 2026-07-04 night (Gen 2): the ring recorded continuous sleep-vitals 06:49→08:30 (HR ~53, HRV on
+    /// ~half the epochs) that motion mis-scored as 1h40m of "active", cutting a real 7h32m night to
+    /// 5h44m. So we EXTEND the detected night's tail forward one epoch at a time while the trailing
+    /// window still looks like sleep-vitals sleep, and stop at the first sustained wake. Like the wear
+    /// and HR gates this is conservative and one-directional — it only ever grows the night's TAIL from
+    /// where motion already found sleep; it never seeds a new block, never touches the pre-onset
+    /// evening, and is gated by HR so it cannot rescue a genuine (elevated-HR) wake.
+    ///
+    /// Trailing window over which the tail-extension tests "still sleeping": short enough to stop
+    /// promptly at true wake, long enough to bridge the ~2.5-min activity/sleep-vitals epoch interleave.
+    static let rescueWindow: TimeInterval = 15 * 60
+    /// Minimum sleep-vitals (HRV-bearing) epochs required inside the trailing window for the tail to
+    /// keep extending. Below this the ring is no longer measuring sleep vitals at cadence → treat as
+    /// awake and stop. Two epochs ≈ the sleep-vitals cadence across a 15-min window.
+    static let rescueMinHRVInWindow = 2
+    /// Nominal epoch cadence used to step the tail extension. Kept local so this detector stays
+    /// device-agnostic (openwhoop port); the RingConn 0x4c step is 150 s (BulkRecord.epochSeconds).
+    static let rescueEpochStep: TimeInterval = 150
+
     private struct Temp { var activity: Activity; var start: Date; var end: Date }
 
     /// First Sleep period longer than `minSleepDuration`, removed from `events`.
@@ -260,11 +288,23 @@ public struct ActivityPeriod: Equatable, Sendable {
     public static func detectFromMotion(_ history: [MotionSample],
                                         temperatureSamples: [TemperatureSample],
                                         heartRateSamples: [HeartRateSample] = [],
+                                        sleepVitalTimes: [Date] = [],
                                         wornMinC: Double = wornMinTemperatureC,
                                         awakeHRMargin: Int = awakeHRMarginBPM) -> [ActivityPeriod] {
         let base = detectFromMotion(history)
         let wearGated = wearGate(base, temperatureSamples, wornMinC: wornMinC)
-        return heartRateGate(wearGated, heartRateSamples, marginBPM: awakeHRMargin)
+        let hrGated = heartRateGate(wearGated, heartRateSamples, marginBPM: awakeHRMargin)
+        return sleepVitalsRescue(hrGated, heartRateSamples, sleepVitalTimes, marginBPM: awakeHRMargin)
+    }
+
+    /// The night's resting-floor HR estimate: `sleepHRFloorPercentile` over the DISTINCT HR levels
+    /// seen tonight (deduped so a long high-HR stretch can't drag the floor up by sheer count — see
+    /// `heartRateGate`). `nil` when there aren't enough readings to judge.
+    static func sleepHRFloor(_ hr: [HeartRateSample]) -> Int? {
+        guard hr.count >= minHRSamplesForGate else { return nil }
+        let levels = Array(Set(hr.map(\.bpm))).sorted()
+        guard !levels.isEmpty else { return nil }
+        return levels[Int((Double(levels.count - 1) * sleepHRFloorPercentile).rounded())]
     }
 
     /// Reclassify a `.sleep` block whose median skin temperature reads unworn (< `wornMinC`) as
@@ -294,7 +334,6 @@ public struct ActivityPeriod: Equatable, Sendable {
     /// reported with sparse/zero HR.
     private static func heartRateGate(_ periods: [ActivityPeriod], _ hr: [HeartRateSample],
                                       marginBPM: Int) -> [ActivityPeriod] {
-        guard hr.count >= minHRSamplesForGate else { return periods }
         // Resting-floor estimate over the DISTINCT HR levels seen tonight, NOT the raw samples: a long
         // awake-still stretch contributes many high readings that would drag a count-weighted percentile
         // up and so hide itself. Deduping to levels gives the night's few low readings equal weight, so
@@ -302,8 +341,7 @@ public struct ActivityPeriod: Equatable, Sendable {
         // 2026-06-23 night this yields ~74 bpm vs ~102 for a raw p10 — the difference between catching
         // the 108 bpm evening block and missing it.) Block medians below stay count-weighted: "typical
         // HR in this block" is the right question there, "lowest level reached tonight" the right one here.
-        let levels = Array(Set(hr.map(\.bpm))).sorted()
-        let floor = levels[Int((Double(levels.count - 1) * sleepHRFloorPercentile).rounded())]
+        guard let floor = sleepHRFloor(hr) else { return periods }
         let threshold = floor + marginBPM
         return periods.map { p in
             guard p.activity == .sleep else { return p }
@@ -314,6 +352,61 @@ public struct ActivityPeriod: Equatable, Sendable {
                 ? ActivityPeriod(activity: .active, start: p.start, end: p.end)
                 : p
         }
+    }
+
+    /// Extend the detected night's TAIL forward through a moving-but-asleep morning (see `rescueWindow`
+    /// doc). Grows the main sleep block's end epoch-by-epoch across the `.active` period that abuts it,
+    /// for as long as the trailing `rescueWindow` still looks like sleep-vitals sleep — HR at/near the
+    /// night's resting floor AND the ring still emitting ≥ `rescueMinHRVInWindow` sleep-vitals epochs —
+    /// then stops at the first sustained wake. One-directional and HR-gated: it only ever converts
+    /// `.active`→`.sleep` starting from where motion already found the night, so it can neither seed a
+    /// spurious block nor rescue a genuine elevated-HR wake. No HR or no sleep-vitals coverage → no-op.
+    private static func sleepVitalsRescue(_ periods: [ActivityPeriod], _ hr: [HeartRateSample],
+                                          _ sleepVitalTimes: [Date], marginBPM: Int) -> [ActivityPeriod] {
+        guard !sleepVitalTimes.isEmpty, let floor = sleepHRFloor(hr),
+              let block = mainSleepBlock(periods) else { return periods }
+        let threshold = floor + marginBPM
+        let hrv = sleepVitalTimes.sorted()
+
+        // The active period that begins (within one epoch step) at the main block's end — the morning
+        // stretch right after detected sleep. Nothing else is eligible: not the pre-onset evening, not a
+        // disconnected daytime block.
+        let step = rescueEpochStep
+        guard let tail = periods.first(where: {
+            $0.activity == .active && $0.end > block.end
+                && abs($0.start.timeIntervalSince(block.end)) <= step * 2
+        }) else { return periods }
+
+        // Walk the tail one epoch at a time; keep extending while the trailing window is sleep-like.
+        func windowIsSleeplike(endingAt t: Date) -> Bool {
+            let lo = t.addingTimeInterval(-rescueWindow)
+            let hrInWin = hr.filter { $0.time > lo && $0.time <= t }.map(\.bpm).sorted()
+            guard hrInWin.count >= minHRSamplesForGate else { return false }
+            let median = hrInWin[hrInWin.count / 2]
+            let hrvInWin = hrv.filter { $0 > lo && $0 <= t }.count
+            return median <= threshold && hrvInWin >= rescueMinHRVInWindow
+        }
+        var wakeEnd = block.end
+        var t = block.end.addingTimeInterval(step)
+        while t <= tail.end {
+            if windowIsSleeplike(endingAt: t) { wakeEnd = t; t = t.addingTimeInterval(step) }
+            else { break }
+        }
+        guard wakeEnd > block.end else { return periods }
+
+        // Rewrite the tail: [tail.start, wakeEnd] becomes sleep; any remainder stays active.
+        var out: [ActivityPeriod] = []
+        for p in periods {
+            if p == tail {
+                out.append(ActivityPeriod(activity: .sleep, start: p.start, end: wakeEnd))
+                if p.end > wakeEnd {
+                    out.append(ActivityPeriod(activity: .active, start: wakeEnd, end: p.end))
+                }
+            } else {
+                out.append(p)
+            }
+        }
+        return out
     }
 
     /// Shared core: classify a stillness-magnitude timeline into Sleep/Active runs.

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
@@ -393,18 +393,30 @@ public enum SleepStaging {
         let sleepFloor = percentile(hr.sorted(), tuning.sleepFloorPercentile)
         let wakeThreshold = sleepFloor + tuning.wakeHRMarginBPM
         let smHR = rollingMedian(hr, half: tuning.hrWakeHalfWindow)
-        // MOTION-awake, softened for MOVING-BUT-ASLEEP epochs (the same signal `sleepVitalsRescue` uses
-        // to keep such a morning IN the night — without this, staging would re-trim the rescued tail
-        // right back off via `sleepSpan`). An epoch is NOT marked awake on motion alone when the ring is
-        // still emitting sleep-vitals nearby (windowed HRV coverage, robust to the sleepV/activity epoch
-        // interleave) AND its HR is below the wake threshold — i.e. the device is measuring sleep and the
-        // heart agrees. Genuine wake is unaffected: the HR term below still fires on elevated HR, and the
-        // sleep-vitals stream thins at true wake so the coverage drops. Still-night motion is < threshold,
-        // so this is a no-op there.
+        // MOTION-awake, softened for MOVING-BUT-ASLEEP epochs — but ONLY across the MORNING TAIL, the
+        // trailing stretch after the last sustained asleep run. This mirrors the coarse `sleepVitalsRescue`,
+        // which only ever extends the block's END forward: the softening exists so staging doesn't re-trim
+        // the rescued pre-wake morning back off via `sleepSpan`. Scoping it to the tail is what keeps a
+        // genuine mid-night WASO (an interior awakening with sustained sleep AFTER it) from being absorbed
+        // as sleep — only the morning is rescued, not every restless mid-night.
+        let motionAwakeStrict = rows.map { $0.motion > tuning.awakeMotion }
+        // Tail boundary from the STRICT (un-softened) span: the epoch just after the end of the last
+        // sustained asleep run. `motionAwakeVitalsHalfWindow <= 0` disables the rescue entirely (tail =
+        // end of night → no epoch is softened → byte-identical to the pre-rescue staging).
+        let awakeStrict = rows.indices.map { smHR[$0] >= wakeThreshold || motionAwakeStrict[$0] }
+        let tailStart = tuning.motionAwakeVitalsHalfWindow > 0
+            ? (sleepSpan(awakeStrict, sustain: tuning.onsetSustainEpochs).map { $0.1 + 1 } ?? rows.count)
+            : rows.count
         let vitalsNearby = windowedVitalsCoverage(times: rows.map(\.time), hasVitals: rows.map(\.vitals),
                                                   halfWindow: tuning.motionAwakeVitalsHalfWindow)
         let motionAwake = rows.indices.map { i in
-            rows[i].motion > tuning.awakeMotion && !(vitalsNearby[i] && smHR[i] < wakeThreshold)
+            // Soften only within the trailing morning tail: the ring is still emitting sleep-vitals nearby
+            // (windowed HRV coverage, robust to the sleepV/activity epoch interleave) AND HR is below the
+            // wake threshold — device measuring sleep, heart agreeing. Genuine wake is unaffected: the HR
+            // term below still fires on elevated HR, and sleep-vitals thin at true wake. Still nights and
+            // interior WASO are untouched (motion < threshold, or i < tailStart).
+            let softenTail = i >= tailStart && vitalsNearby[i] && smHR[i] < wakeThreshold
+            return motionAwakeStrict[i] && !softenTail
         }
         var awake = rows.indices.map { smHR[$0] >= wakeThreshold || motionAwake[$0] }
         // Erode HR-only awake runs shorter than the floor so a transient REM-ish HR bump

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
@@ -115,6 +115,12 @@ public enum SleepStaging {
         /// Half-window (epochs each side) for the rolling-MEDIAN HR used by the wake gate,
         /// so a one-epoch HR spike doesn't read as an awakening.
         public var hrWakeHalfWindow: Int
+        /// Half-window (in epochs) for the sleep-vitals coverage that softens MOTION-awake: an epoch
+        /// with a sleep-vitals (HRV) epoch within this many epochs on either side AND sub-wake HR is
+        /// treated as moving-but-ASLEEP, not motion-awake — so the `sleepVitalsRescue` tail survives
+        /// staging's re-trim. Sized to bridge the sleepV/activity epoch interleave (~1 sleepV per 2
+        /// epochs). 0 disables the softening (byte-identical to the pre-rescue staging).
+        public var motionAwakeVitalsHalfWindow: Int
         /// A sustained asleep run of at least this many epochs anchors sleep ONSET (its
         /// start) and OFFSET (the end of the last such run). Leading/trailing awake outside
         /// that span is trimmed from the in-bed window — this is what shrinks an over-wide
@@ -203,6 +209,7 @@ public enum SleepStaging {
                     sleepFloorPercentile: Double = 0.12,
                     wakeHRMarginBPM: Double = 18,
                     hrWakeHalfWindow: Int = 2,
+                    motionAwakeVitalsHalfWindow: Int = 3,
                     onsetSustainEpochs: Int = 6,
                     minHRWakeRunEpochs: Int = 5,
                     onsetSettleFraction: Double = 0.35,
@@ -227,6 +234,7 @@ public enum SleepStaging {
             self.sleepFloorPercentile = sleepFloorPercentile
             self.wakeHRMarginBPM = wakeHRMarginBPM
             self.hrWakeHalfWindow = hrWakeHalfWindow
+            self.motionAwakeVitalsHalfWindow = motionAwakeVitalsHalfWindow
             self.onsetSustainEpochs = onsetSustainEpochs
             self.minHRWakeRunEpochs = minHRWakeRunEpochs
             self.onsetSettleFraction = onsetSettleFraction
@@ -334,7 +342,11 @@ public enum SleepStaging {
             .filter { $0.date(epoch: epoch) >= block.start && $0.date(epoch: epoch) <= block.end }
             .sorted { $0.counter < $1.counter }
         var lastHR: Int?, lastHRV: Int?, lastSpo2: Int?, lastRR: Double?
-        var rows: [(time: Date, hr: Int, hrv: Int?, motion: Int, spo2: Int?, rr: Double?)] = []
+        // `vitals` is the RAW (not forward-filled) "this epoch carried sleep-vitals HRV" flag — the
+        // ring-measured-sleep signal the motion-awake softening below uses. Kept distinct from `hrv`
+        // (forward-filled for variability) because forward-fill would make every post-onset epoch read
+        // as sleep-vitals.
+        var rows: [(time: Date, hr: Int, hrv: Int?, motion: Int, spo2: Int?, rr: Double?, vitals: Bool)] = []
         // Per-epoch motion energy is measured ABOVE a LOCAL idle floor (same rolling estimate as
         // detection). Gen 2 idles at ~1, Gen 3 at ~15–16 and DRIFTS across the night with posture
         // (16→24→39, 🟢 FR05.008 capture 2026-06-23). The old `$1 == 1 ? 0 : …` hard-coded Gen 2's
@@ -353,7 +365,7 @@ public enum SleepStaging {
             if let rr = r.respiratoryRate { lastRR = rr }   // forward-filled like HRV
             guard let hr = lastHR else { continue }   // skip until the first HR reading
             let motion = max(0, Int(rawMotion[idx] - floor[idx]))
-            rows.append((r.date(epoch: epoch), hr, lastHRV, motion, lastSpo2, lastRR))
+            rows.append((r.date(epoch: epoch), hr, lastHRV, motion, lastSpo2, lastRR, r.hrvRMSSD != nil))
         }
         guard rows.count >= 2 else { return [] }
 
@@ -381,7 +393,19 @@ public enum SleepStaging {
         let sleepFloor = percentile(hr.sorted(), tuning.sleepFloorPercentile)
         let wakeThreshold = sleepFloor + tuning.wakeHRMarginBPM
         let smHR = rollingMedian(hr, half: tuning.hrWakeHalfWindow)
-        let motionAwake = rows.map { $0.motion > tuning.awakeMotion }
+        // MOTION-awake, softened for MOVING-BUT-ASLEEP epochs (the same signal `sleepVitalsRescue` uses
+        // to keep such a morning IN the night — without this, staging would re-trim the rescued tail
+        // right back off via `sleepSpan`). An epoch is NOT marked awake on motion alone when the ring is
+        // still emitting sleep-vitals nearby (windowed HRV coverage, robust to the sleepV/activity epoch
+        // interleave) AND its HR is below the wake threshold — i.e. the device is measuring sleep and the
+        // heart agrees. Genuine wake is unaffected: the HR term below still fires on elevated HR, and the
+        // sleep-vitals stream thins at true wake so the coverage drops. Still-night motion is < threshold,
+        // so this is a no-op there.
+        let vitalsNearby = windowedVitalsCoverage(times: rows.map(\.time), hasVitals: rows.map(\.vitals),
+                                                  halfWindow: tuning.motionAwakeVitalsHalfWindow)
+        let motionAwake = rows.indices.map { i in
+            rows[i].motion > tuning.awakeMotion && !(vitalsNearby[i] && smHR[i] < wakeThreshold)
+        }
         var awake = rows.indices.map { smHR[$0] >= wakeThreshold || motionAwake[$0] }
         // Erode HR-only awake runs shorter than the floor so a transient REM-ish HR bump
         // doesn't read as an awakening (motion-driven awakes are kept, however brief).
@@ -559,6 +583,21 @@ public enum SleepStaging {
             let s = max(0, i - half), e = min(n - 1, i + half)
             var w = Array(xs[s ... e]); w.sort()
             out[i] = w[w.count / 2]
+        }
+        return out
+    }
+
+    /// Per-epoch "the ring is still emitting sleep-vitals nearby" flag: true when a sleep-vitals
+    /// (HRV-bearing) epoch sits within `halfWindow` epochs on either side. Robust to the sleepV/activity
+    /// epoch interleave (only ~1 in 2 epochs carries HRV), so a single missed slot doesn't read as wake.
+    /// `halfWindow <= 0` disables it (all false → motion-awake softening is a no-op).
+    private static func windowedVitalsCoverage(times: [Date], hasVitals: [Bool], halfWindow: Int) -> [Bool] {
+        let n = times.count
+        guard n > 0, hasVitals.count == n, halfWindow > 0 else { return [Bool](repeating: false, count: n) }
+        var out = [Bool](repeating: false, count: n)
+        for i in 0 ..< n {
+            let s = max(0, i - halfWindow), e = min(n - 1, i + halfWindow)
+            out[i] = (s ... e).contains { hasVitals[$0] }
         }
         return out
     }

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
@@ -223,6 +223,15 @@ public enum BulkSleep {
         }
     }
 
+    /// Timestamps of epochs on which the ring emitted SLEEP VITALS (HRV present, byte[5] 🟢) — the
+    /// signal `detectFromMotion`'s sleep-vitals rescue uses to tell a moving-but-ASLEEP morning (ring
+    /// still measuring sleep vitals at cadence) from true wake (the sleep-vitals stream stops). Built
+    /// from the SAME records as the motion/HR timelines, so no extra channel is threaded.
+    public static func sleepVitalTimeline(from records: [BulkRecord],
+                                          epoch: Int = Command.syncEpoch) -> [Date] {
+        records.compactMap { $0.hrvRMSSD != nil ? $0.date(epoch: epoch) : nil }
+    }
+
     /// Restrict `records` to those whose epoch falls within `hint`, or return them
     /// unchanged when no hint is given. Extension point for the sleep-schedule abstraction:
     /// the app can pass the user's bedtime→wake window (see ios/OpenCircuit/SleepSchedule)
@@ -245,7 +254,8 @@ public enum BulkSleep {
         let scoped = Self.records(records, within: hint, epoch: epoch)
         let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch),
                                                       temperatureSamples: temperatures,
-                                                      heartRateSamples: heartRateTimeline(from: scoped, epoch: epoch))
+                                                      heartRateSamples: heartRateTimeline(from: scoped, epoch: epoch),
+                                                      sleepVitalTimes: sleepVitalTimeline(from: scoped, epoch: epoch))
         // Clustered span (brief awakenings bridged), not just the first/longest fragment — see
         // mainSleepBlock. A drifting Gen-3 floor or a real mid-sleep stir otherwise splits the night.
         return ActivityPeriod.mainSleepBlock(periods)
@@ -280,7 +290,8 @@ public enum BulkSleep {
                                                 epoch: Int) -> [SleepSegment] {
         let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch),
                                                       temperatureSamples: temperatures,
-                                                      heartRateSamples: heartRateTimeline(from: scoped, epoch: epoch))
+                                                      heartRateSamples: heartRateTimeline(from: scoped, epoch: epoch),
+                                                      sleepVitalTimes: sleepVitalTimeline(from: scoped, epoch: epoch))
         // Main in-bed block = the clustered sleep span (brief awakenings bridged via maxSleepPause),
         // not just the longest single fragment — so a drift-fragmented Gen-3 night isn't truncated.
         guard let block = ActivityPeriod.mainSleepBlock(periods) else { return [] }
@@ -337,7 +348,8 @@ public enum BulkSleep {
         let records = records.sorted { $0.counter < $1.counter }
         let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: records, epoch: epoch),
                                                       temperatureSamples: temperatures,
-                                                      heartRateSamples: heartRateTimeline(from: records, epoch: epoch))
+                                                      heartRateSamples: heartRateTimeline(from: records, epoch: epoch),
+                                                      sleepVitalTimes: sleepVitalTimeline(from: records, epoch: epoch))
         let nights = periods.filter {
             $0.activity == .sleep
                 && $0.duration > ActivityPeriod.minSleepDuration

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepDetectionTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepDetectionTests.swift
@@ -151,4 +151,80 @@ final class SleepDetectionTests: XCTestCase {
         XCTAssertEqual(ActivityPeriod.detectFromMotion(motion, temperatureSamples: [], heartRateSamples: hr).first?.activity,
                        .sleep, "too few HR readings → gate stays out, block remains sleep")
     }
+
+    // MARK: Sleep-vitals rescue (moving-but-asleep morning) — the SYMMETRIC counterpart to the HR gate.
+
+    /// A restless morning (motion spikes so the motion detector scores it `.active`) while the sleeper
+    /// is still down — HR near the night's floor and the ring still emitting sleep-vitals (HRV). This is
+    /// the 2026-07-04 Gen-2 night, where motion cut a real 7h32m night at the first stir (06:48).
+    private func spikyMotion(_ startMin: Int, _ endMin: Int) -> [MotionSample] {
+        // Alternate near-still and a big spike every 5 min so the rolling p10 floor stays low and the
+        // burst reads as movement → the whole stretch classifies `.active` motion-only.
+        stride(from: startMin, to: endMin, by: 5).enumerated().map { i, m in
+            MotionSample(time: base.addingTimeInterval(Double(m) * 60), movement: i % 2 == 0 ? 2 : 260)
+        }
+    }
+    private func hrvTimes(_ startMin: Int, _ endMin: Int) -> [Date] {
+        stride(from: startMin, to: endMin, by: 5).map { base.addingTimeInterval(Double($0) * 60) }
+    }
+    private func lastSleepEnd(_ periods: [ActivityPeriod]) -> Date? {
+        periods.filter { $0.activity == .sleep }.map(\.end).max()
+    }
+
+    /// The fix: a still low-HR night followed by a restless-but-asleep morning. Motion-only cuts the
+    /// night at the first stir; with sleep-vitals coverage the tail extends through the morning.
+    func testSleepVitalsRescueExtendsMovingButAsleepMorning() {
+        let motion = stillMotion(0, 360) + spikyMotion(360, 480)
+        let hr = hrSeries(0, 480, bpm: 55)                     // low all night incl. the restless morning
+        let hrv = hrvTimes(0, 470)                             // ring still measuring sleep vitals to ~470
+
+        let motionOnly = ActivityPeriod.detectFromMotion(motion, temperatureSamples: [], heartRateSamples: hr)
+        let cutEnd = lastSleepEnd(motionOnly)!
+        XCTAssertLessThan(cutEnd.timeIntervalSince(base) / 60, 380,
+                          "motion-only cuts the night at the first morning stir (~360)")
+
+        let rescued = ActivityPeriod.detectFromMotion(motion, temperatureSamples: [],
+                                                      heartRateSamples: hr, sleepVitalTimes: hrv)
+        let rescuedEnd = lastSleepEnd(rescued)!
+        XCTAssertGreaterThan(rescuedEnd.timeIntervalSince(base) / 60, 450,
+                             "sleep-vitals rescue extends the night's tail through the restless morning")
+    }
+
+    /// Guard: a genuine morning WAKE (motion + HR climbs above the sleeping floor + margin) is NOT
+    /// rescued — the HR gate on the rescue keeps it from swallowing real wakefulness.
+    func testSleepVitalsRescueDoesNotRescueElevatedHRWake() {
+        let motion = stillMotion(0, 360) + spikyMotion(360, 480)
+        let hr = hrSeries(0, 360, bpm: 55) + hrSeries(360, 480, bpm: 95)   // awake HR after 360
+        let hrv = hrvTimes(0, 470)
+
+        let rescued = ActivityPeriod.detectFromMotion(motion, temperatureSamples: [],
+                                                      heartRateSamples: hr, sleepVitalTimes: hrv)
+        let end = lastSleepEnd(rescued)!
+        XCTAssertLessThan(end.timeIntervalSince(base) / 60, 380,
+                          "elevated-HR morning is real wake, not rescued sleep")
+    }
+
+    /// Guard: no sleep-vitals coverage in the morning (ring stopped emitting HRV = awake) → no rescue,
+    /// so a low-HR-but-awake lie-in isn't over-counted as sleep on motion+HR alone.
+    func testSleepVitalsRescueRequiresSleepVitalsCoverage() {
+        let motion = stillMotion(0, 360) + spikyMotion(360, 480)
+        let hr = hrSeries(0, 480, bpm: 55)
+        let hrv = hrvTimes(0, 360)     // sleep vitals STOP at the stir — nothing to extend through
+
+        let rescued = ActivityPeriod.detectFromMotion(motion, temperatureSamples: [],
+                                                      heartRateSamples: hr, sleepVitalTimes: hrv)
+        let end = lastSleepEnd(rescued)!
+        XCTAssertLessThan(end.timeIntervalSince(base) / 60, 380,
+                          "without sleep-vitals coverage the morning stays active (no HR-only over-count)")
+    }
+
+    /// No regression: with no sleep-vitals times passed, detection is identical to before the rescue.
+    func testSleepVitalsRescueNoOpWithoutCoverage() {
+        let motion = stillMotion(0, 300)
+        let hr = hrSeries(0, 300, bpm: 60)
+        XCTAssertEqual(
+            ActivityPeriod.detectFromMotion(motion, temperatureSamples: [], heartRateSamples: hr, sleepVitalTimes: []),
+            ActivityPeriod.detectFromMotion(motion, temperatureSamples: [], heartRateSamples: hr),
+            "no sleep-vitals coverage → identical to the pre-rescue result")
+    }
 }

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepStagingTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepStagingTests.swift
@@ -53,6 +53,56 @@ final class SleepStagingTests: XCTestCase {
         return (totals[stage] ?? 0) / asleep
     }
 
+    // MARK: - Sleep-vitals rescue reaches the STAGED (summary/Health) path
+
+    /// Builds a still 6h night followed by a ~100-min restless-but-asleep morning: HR stays at the
+    /// sleeping level and the ring keeps emitting sleep-vitals, but motion spikes (a still sleep-vitals
+    /// epoch alternating with a high-motion activity epoch) so the motion detector alone scores the
+    /// morning "active". This exercises `SleepStaging.classify` — the path that feeds the summary card
+    /// and Apple Health — NOT just the coarse `detectFromMotion` layer.
+    private func stillThenRestlessMorning(morningHR: UInt8, morningVitals: Bool) -> [BulkRecord] {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 10_000
+        for _ in 0..<144 { recs.append(vrec(c, hr: 55, hrv: 60, motion: 1)); c += step }   // 6h still sleep
+        for i in 0..<40 {                                                                    // ~100-min morning
+            if i % 2 == 0 { recs.append(vrec(c, hr: morningHR, hrv: morningVitals ? 60 : 0, motion: 2)) }
+            else          { recs.append(arec(c, motion: 60)) }                               // spiky motion
+            c += step
+        }
+        return recs
+    }
+    private func asleepMinutes(_ segs: [SleepSegment]) -> Double {
+        let t = SleepStaging.stageTotals(segs)
+        return ((t[.asleepCore] ?? 0) + (t[.asleepDeep] ?? 0) + (t[.asleepREM] ?? 0)) / 60
+    }
+
+    /// The fix reaches the summary: a moving-but-asleep morning (low HR, sleep-vitals present) is
+    /// counted as sleep by the STAGED classifier, not re-trimmed back to awake-in-bed. Regression guard
+    /// for the 2026-07-04 truncated night (5h44m → real 7h32m). The 6h still block alone is ~360 min, so
+    /// asleep well past that proves the restless morning is honored end-to-end.
+    func testStagedClassifierHonorsMovingButAsleepMorning() {
+        let segs = SleepStaging.classify(from: BulkSleep.latestNightRecords(
+            from: stillThenRestlessMorning(morningHR: 55, morningVitals: true)))
+        XCTAssertGreaterThan(asleepMinutes(segs), 400,
+                             "staged summary must count the moving-but-asleep morning, not trim it off")
+    }
+
+    /// Guard: a genuine morning WAKE (HR climbs above the sleeping floor + margin) is NOT counted, even
+    /// with the same spiky motion — the staged softening is HR-gated, so it can't over-count wakefulness.
+    func testStagedClassifierDoesNotCountElevatedHRMorning() {
+        let asleepWake = asleepMinutes(SleepStaging.classify(from: BulkSleep.latestNightRecords(
+            from: stillThenRestlessMorning(morningHR: 95, morningVitals: true))))
+        XCTAssertLessThan(asleepWake, 380, "an elevated-HR (awake) morning must not be counted as sleep")
+    }
+
+    /// Guard: no sleep-vitals in the morning (ring stopped measuring = awake) → the morning is NOT
+    /// counted, so a low-HR-but-awake lie-in isn't over-counted on motion+HR alone.
+    func testStagedClassifierRequiresSleepVitalsToCountRestlessMorning() {
+        let asleepNoVitals = asleepMinutes(SleepStaging.classify(from: BulkSleep.latestNightRecords(
+            from: stillThenRestlessMorning(morningHR: 55, morningVitals: false))))
+        XCTAssertLessThan(asleepNoVitals, 380, "without sleep-vitals coverage the restless morning stays awake")
+    }
+
     // MARK: - Single-stage recovery
 
     func testStillFlatLowHRIsMostlyDeep() {

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepStagingTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepStagingTests.swift
@@ -103,6 +103,43 @@ final class SleepStagingTests: XCTestCase {
         XCTAssertLessThan(asleepNoVitals, 380, "without sleep-vitals coverage the restless morning stays awake")
     }
 
+    /// A 6h still night with a ~40-min restless-but-low-HR episode in the MIDDLE (sustained sleep on
+    /// BOTH sides) — the same spiky-motion + lingering-sleep-vitals shape as `stillThenRestlessMorning`,
+    /// only its POSITION differs. A genuine mid-night WASO the rescue must NOT absorb.
+    private func stillWithMidNightRestless(episodeHR: UInt8, episodeVitals: Bool) -> [BulkRecord] {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 10_000
+        for _ in 0..<72 { recs.append(vrec(c, hr: 55, hrv: 60, motion: 1)); c += step }   // 3h still sleep
+        for i in 0..<16 {                                                                   // ~40-min episode
+            if i % 2 == 0 { recs.append(vrec(c, hr: episodeHR, hrv: episodeVitals ? 60 : 0, motion: 2)) }
+            else          { recs.append(arec(c, motion: 60)) }                              // spiky motion
+            c += step
+        }
+        for _ in 0..<72 { recs.append(vrec(c, hr: 55, hrv: 60, motion: 1)); c += step }   // 3h still sleep
+        return recs
+    }
+
+    /// The reviewer's watch-item: the morning-tail rescue is SCOPED to the trailing tail, so a mid-night
+    /// restless-but-low-HR episode surrounded by sustained sleep is still detected as WASO — not absorbed
+    /// as sleep the way an un-scoped (whole-night) softening would. The proof is positional: the mid-night
+    /// episode is IMMUNE to the softening knob (halfWindow 3 vs 0 stage identically), whereas the SAME
+    /// shape at the morning tail IS rescued by it — so the softening still works, it just no longer reaches
+    /// interior awakenings.
+    func testMidNightWASOIsImmuneToTheRescueButTheMorningTailIsNot() {
+        func asleep(_ recs: [BulkRecord], halfWindow: Int) -> Double {
+            asleepMinutes(SleepStaging.classify(
+                from: BulkSleep.latestNightRecords(from: recs),
+                tuning: .init(motionAwakeVitalsHalfWindow: halfWindow)))
+        }
+        let mid = stillWithMidNightRestless(episodeHR: 55, episodeVitals: true)
+        XCTAssertEqual(asleep(mid, halfWindow: 3), asleep(mid, halfWindow: 0), accuracy: 5,
+                       "a mid-night WASO is interior, so the trailing-tail rescue must not change it")
+
+        let morning = stillThenRestlessMorning(morningHR: 55, morningVitals: true)
+        XCTAssertGreaterThan(asleep(morning, halfWindow: 3), asleep(morning, halfWindow: 0) + 20,
+                             "the morning tail must still be rescued when the softening is on")
+    }
+
     // MARK: - Single-stage recovery
 
     func testStillFlatLowHRIsMostlyDeep() {


### PR DESCRIPTION
## The report

A tester slept ~7h32m (01:05→08:33) but OpenCircuit's summary showed **01:04→06:48, asleep 257m, score 53** — the back ~1h50m of the night was gone.

## Diagnosis (device-reproduced)

Pulled the tester's on-device store + epoch archive and re-ran the real pipeline against the actual 609-record archive:

- The stored summary and persisted segments end at **06:48:46**.
- The archive holds continuous **sleep-vitals epochs (HR ~53, HRV present) through 08:34**, and they *were* drained into the app — the data was present; staging discarded it.
- `ActivityPeriod.detectFromMotion` classifies everything after 06:49 as one 247-min `.active` block.

**Root cause:** the in-bed boundary is motion-only. That night was dead-still until ~06:49, then had a restless pre-wake morning (motion counts 70–85 with spikes) *while still asleep*. `motionAboveLocalFloor` measures motion above the night's own very-low floor, so the morning plateau scores as "active" and the block ends at the first stir. The existing HR gate only ever *removes* sleep (awake-but-still); nothing handles the mirror case, moving-but-**asleep**.

Measured discriminators on this night:
| window | HR mean | epochs with HRV |
|---|---|---|
| lost morning sleep 06:49–08:30 | 53 (≤ awake threshold 79) | 20/41 |
| real wake 08:32–09:10 | 63 | 4/16 |

## The fix

`sleepVitalsRescue` — the symmetric counterpart to the HR gate. After motion detection + wear/HR gates, it extends the detected night's **tail** forward one epoch at a time across the abutting `.active` period, for as long as the trailing 15-min window still looks like sleep-vitals sleep (median HR at/near the night's resting floor **and** the ring still emitting ≥2 HRV epochs), stopping at the first sustained wake.

One-directional and HR-gated by design: it only grows the tail from where motion already found the night, never seeds a block, never touches the pre-onset evening, and cannot rescue an elevated-HR wake or a low-HR lie-in with no sleep-vitals coverage. Threaded via a new `sleepVitalTimeline` through `mainSleep`/`sleepSegments`/`latestNightRecords`; propagates to `SleepStaging` via `mainSleep`.

## Result on the reproduced night

- in-bed **01:04→06:48 → 01:04→08:38** (7h34m, matches the reported 01:05→08:33 within ~5 min)
- asleep **257m → 336m**

## Verification

- Full `swift test` suite: **606 tests, 0 failures** — no regression on the validated nights, including the 2026-06-23 awake-but-still night the HR gate protects.
- 4 new targeted tests: rescue fires on a moving-but-asleep morning; **not** fired for an elevated-HR wake; **not** fired without sleep-vitals coverage; no-op when no coverage is passed.

## Scope / caveat

This fixes the **block-truncation** only. Staging *within* the block (the ~116m morning "awake") is unchanged and still governed by the approximate, un-ground-truthed motion/HR staging model. Tuning stage proportions should go through the ground-truth fit harness (`RUNBOOK_SLEEP_GROUNDTRUTH`) as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)