### PR TITLE
fix(ux): batch unit-consistency + alert-copy fixes (#149 #150 #158 #159)

### DIFF
--- a/ios/OpenCircuit/DayDetailView.swift
+++ b/ios/OpenCircuit/DayDetailView.swift
@@ -27,6 +27,8 @@ struct DayDetailView: View {
     @State private var stepSamples: [StoredStepSample] = []
     @State private var nightWindow: DateInterval?
     @State private var loading = true
+    // Display unit for skin temp: stored samples are °C, the chart converts (matches TrendsView #83).
+    @AppStorage("units.temperature") private var tempUnitRaw = TemperatureUnit.localeDefault.rawValue
 
     private static let dayTitle: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "EEEE, MMM d"; return f
@@ -47,10 +49,16 @@ struct DayDetailView: View {
                                   samples: hrvSamples)
                     timeSeriesCard(title: "SpO₂", unit: "%", color: .cyan,
                                   samples: spo2Samples, scale: 100)
-                    timeSeriesCard(title: "Respiratory Rate", unit: "brpm", color: .teal,
-                                  samples: rrSamples)
-                    timeSeriesCard(title: "Skin Temp", unit: "°C", color: .orange,
-                                  samples: daytimeTemps)
+                    timeSeriesCard(title: "Respiratory Rate", unit: UnitsFormatter.respiratoryRateUnit,
+                                  color: .teal, samples: rrSamples)
+                    // Convert in the body (not at load) so switching the unit re-renders live; the
+                    // card's `scale` is multiply-only and °F needs an offset, so convert upstream here.
+                    let tempUnit = TemperatureUnit(rawValue: tempUnitRaw) ?? .celsius
+                    timeSeriesCard(title: "Skin Temp", unit: tempUnit.symbol, color: .orange,
+                                  samples: daytimeTemps.map {
+                                      QuantitySample(kind: .temperature, start: $0.start,
+                                                     value: tempUnit.convert(fromCelsius: $0.value))
+                                  })
                     stepsChartCard()
                 }
             }

--- a/ios/OpenCircuit/HealthNotificationCenter.swift
+++ b/ios/OpenCircuit/HealthNotificationCenter.swift
@@ -451,11 +451,13 @@ struct HealthNotificationCenter {
                     + (pct.map { " (\($0)%)" } ?? "")
                     + (at.isEmpty ? "" : " at \(at)") + " (estimate).")
         case .elevatedHRInactive:
-            let bpm = hit.map { Int($0.value) }
+            // Cite the user's CONFIGURED threshold, not the completing sample's bpm. `hit.value` here is
+            // the reading that finished the 10-min run (HealthAlerts elevatedHRInactive), NOT the peak
+            // and NOT the threshold — phrasing it as "above N bpm" misrepresented N as the trigger.
+            let threshold = HealthAlertDefaults.thresholds().elevatedHRBpm
             return ("Elevated heart rate while inactive",
-                    "Your heart rate stayed elevated"
-                    + (bpm.map { " (above \($0) bpm)" } ?? "")
-                    + " for over 10 minutes while you were inactive. This can indicate a change in how you feel.")
+                    "Your heart rate stayed above your \(threshold) bpm threshold "
+                    + "for over 10 minutes while you were inactive. This can indicate a change in how you feel.")
         case .skinTempRise:
             return ("Skin temperature elevated",
                     "Your overnight skin temperature is well above your personal baseline (estimate).")

--- a/ios/OpenCircuit/TrendsView.swift
+++ b/ios/OpenCircuit/TrendsView.swift
@@ -41,8 +41,9 @@ struct TrendsView: View {
     @State private var points: [TrendsEngine.DailyPoint] = []
     @State private var recentMetricRows: [RecentMetricRow] = []
     @State private var loading = true
-    // Display units (#83): values are stored in °C; only the display layer converts.
+    // Display units (#83): values are stored in SI (°C, metres); only the display layer converts.
     @AppStorage("units.temperature") private var tempUnitRaw = TemperatureUnit.localeDefault.rawValue
+    @AppStorage("units.distance") private var distUnitRaw = DistanceUnit.localeDefault.rawValue
     @State private var selectedDay: Date?
 
     var body: some View {
@@ -155,16 +156,19 @@ struct TrendsView: View {
                       avg: avgs.daySpO2Avg.map { $0 * 100 },
                       formatAvg: { String(format: "%.1f", $0) })
 
-            chartCard(title: "Respiratory Rate", unit: "brpm",
+            chartCard(title: "Respiratory Rate", unit: UnitsFormatter.respiratoryRateUnit,
                       color: .teal,
                       data: points.compactMap { p in p.dayRRAvg.map { (p.date, $0) } },
                       avg: avgs.dayRRAvg,
                       formatAvg: { String(format: "%.1f", $0) })
 
-            chartCard(title: "Skin Temp (daytime)", unit: "°C",
+            // Daytime skin temp is an absolute temperature — full convert (incl. +32 for °F), not
+            // convertDelta (that's for the nightly baseline offset). Matches the nightly chart below.
+            let tempUnit = TemperatureUnit(rawValue: tempUnitRaw) ?? .celsius
+            chartCard(title: "Skin Temp (daytime)", unit: tempUnit.symbol,
                       color: .orange,
-                      data: points.compactMap { p in p.dayTempC.map { (p.date, $0) } },
-                      avg: avgs.dayTempC,
+                      data: points.compactMap { p in p.dayTempC.map { (p.date, tempUnit.convert(fromCelsius: $0)) } },
+                      avg: avgs.dayTempC.map { tempUnit.convert(fromCelsius: $0) },
                       formatAvg: { String(format: "%.1f", $0) })
         }
     }
@@ -228,7 +232,7 @@ struct TrendsView: View {
                       avg: avgs.sleepSpO2Avg.map { $0 * 100 },
                       formatAvg: { String(format: "%.1f", $0) })
 
-            chartCard(title: "Sleep-Window RR", unit: "brpm",
+            chartCard(title: "Sleep-Window RR", unit: UnitsFormatter.respiratoryRateUnit,
                       color: .teal,
                       data: points.compactMap { p in p.sleepRRAvg.map { (p.date, $0) } },
                       avg: avgs.sleepRRAvg,
@@ -251,10 +255,11 @@ struct TrendsView: View {
                       avg: avgs.activeEnergyKcal,
                       formatAvg: { "\(Int($0.rounded()))" })
 
-            chartCard(title: "Distance (est.)", unit: "km",
+            let distUnit = DistanceUnit(rawValue: distUnitRaw) ?? .metric
+            chartCard(title: "Distance (est.)", unit: distUnit.symbol,
                       color: .indigo,
-                      data: points.compactMap { p in p.distanceM.map { (p.date, $0 / 1000.0) } },
-                      avg: avgs.distanceM.map { $0 / 1000.0 },
+                      data: points.compactMap { p in p.distanceM.map { (p.date, distUnit.convert(fromMeters: $0)) } },
+                      avg: avgs.distanceM.map { distUnit.convert(fromMeters: $0) },
                       formatAvg: { String(format: "%.1f", $0) })
 
             chartCard(title: "Exercise Time (est.)", unit: "min",
@@ -502,7 +507,8 @@ struct TrendsView: View {
         daytimeTemps: [StoredDaytimeTemp],
         stepSamples: [StoredStepSample]
     ) -> [RecentMetricRow] {
-        [
+        let tempUnit = TemperatureUnit(rawValue: tempUnitRaw) ?? .celsius
+        return [
             RecentMetricRow(
                 metricKey: "steps",
                 title: "Steps",
@@ -535,13 +541,14 @@ struct TrendsView: View {
             RecentMetricRow(
                 metricKey: "temperature",
                 title: "Skin Temp",
-                unit: "°C",
+                unit: tempUnit.symbol,
                 color: .orange,
                 rows: Array(daytimeTemps
                     .filter { $0.celsius > 0 }
                     .suffix(Self.recentRowsLimit)
                     .reversed())
-                    .map { (time: $0.time, value: String(format: "%.1f °C", $0.celsius)) }
+                    .map { (time: $0.time,
+                            value: String(format: "%.1f \(tempUnit.symbol)", tempUnit.convert(fromCelsius: $0.celsius))) }
             ),
             RecentMetricRow(
                 metricKey: "hrv",
@@ -555,10 +562,10 @@ struct TrendsView: View {
             RecentMetricRow(
                 metricKey: "rr",
                 title: "Respiratory Rate",
-                unit: "brpm",
+                unit: UnitsFormatter.respiratoryRateUnit,
                 color: .teal,
                 rows: recentRows(from: rrSamples.filter { $0.value > 0 }) {
-                    String(format: "%.1f /min", $0.value)
+                    String(format: "%.1f \(UnitsFormatter.respiratoryRateUnit)", $0.value)
                 }
             )
         ]

--- a/ios/OpenCircuit/VitalsTableView.swift
+++ b/ios/OpenCircuit/VitalsTableView.swift
@@ -235,7 +235,9 @@ struct VitalsTableView: View {
             divider
             row("Steps (today)", value: stepsText, time: stepsTime)
             divider
-            nightlyMeanRow("Respiratory Rate", .respiratoryRate) { String(format: "%.1f /min", $0) }
+            nightlyMeanRow("Respiratory Rate", .respiratoryRate) {
+                String(format: "%.1f \(UnitsFormatter.respiratoryRateUnit)", $0)
+            }
         }
         .padding(.vertical, 4)
         // Resolve the (async) sleep-schedule window once the view appears. The selector

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/UnitPreferences.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/UnitPreferences.swift
@@ -86,6 +86,12 @@ public enum DistanceUnit: String, CaseIterable, Codable, Sendable {
 /// Stateless helpers that turn raw SI values into localised display strings.
 public enum UnitsFormatter {
 
+    /// Canonical on-screen unit for respiratory rate (breaths per minute). Single source of truth so
+    /// every RR surface — home Vitals row, Trends card badge + rows, trend charts, Day Detail — reads
+    /// the same string (they used to disagree: "brpm" on charts vs "/min" on rows). This is DISPLAY
+    /// copy only; the HealthKit unit identifier stays `MetricKind.respiratoryRate.unit` ("count/min").
+    public static let respiratoryRateUnit = "brpm"
+
     /// Format a Celsius value in the requested unit, e.g. "36.5 °C" or "97.7 °F".
     public static func temperature(_ celsius: Double, unit: TemperatureUnit,
                                    fractionDigits: Int = 1) -> String {

--- a/ios/OpenCircuitTests/HealthAlertCopyTests.swift
+++ b/ios/OpenCircuitTests/HealthAlertCopyTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import OpenCircuitKit
+@testable import OpenCircuit
+
+/// The elevated-HR-while-inactive alert used to word its body around the sample that COMPLETED the
+/// 10-minute run ("stayed elevated (above 143 bpm)"), which read as if 143 were the trigger threshold.
+/// It must instead cite the user's CONFIGURED threshold. (UX sweep #159)
+@MainActor
+final class HealthAlertCopyTests: XCTestCase {
+    func testElevatedHRCopyCitesConfiguredThresholdNotCompletingSample() {
+        let threshold = HealthAlertDefaults.thresholds().elevatedHRBpm   // default 100
+        // hit.value is the completing reading (e.g. 143), deliberately different from the threshold.
+        let hit = HealthAlertHit(notification: .elevatedHRInactive, value: 143, time: Date())
+        let (_, body) = HealthNotificationCenter.copy(for: .elevatedHRInactive, hit: hit)
+
+        XCTAssertTrue(body.contains("\(threshold) bpm threshold"),
+                      "copy must cite the configured threshold; got: \(body)")
+        XCTAssertFalse(body.contains("143"),
+                       "copy must NOT present the completing sample (143) as the threshold; got: \(body)")
+    }
+}


### PR DESCRIPTION
Batches four low-risk, self-contained display fixes from the [build-18 UX sweep](https://github.com/perezjuanj/OpenCircuit/issues/149). Closes #149, #150, #158, #159.

## Changes

| # | Fix |
|---|-----|
| **#149** | Trends daytime skin-temp chart, Trends Recent-Readings temp row, and the DayDetail intraday temp chart honored **°C regardless of the unit setting**. Now convert via `TemperatureUnit.convert(fromCelsius:)` + `.symbol` from `@AppStorage("units.temperature")` — matching the already-fixed nightly chart. Full convert (incl. +32), not `convertDelta`. |
| **#150** | Trends **"Distance (est.)" hardcoded km**. Now `DistanceUnit.convert(fromMeters:)` + `.symbol` from `@AppStorage("units.distance")`, matching the Workout screens. |
| **#158** | RR label disagreed across the app (**"brpm" on charts vs "/min" on rows**, even within one card). New single source of truth `UnitsFormatter.respiratoryRateUnit = "brpm"`, routed through every RR display site. |
| **#159** | Elevated-HR alert copy said "(above _N_ bpm)" where _N_ was the sample that **completed** the 10-min run — misread as the trigger threshold. Now cites the user's **configured threshold** ("above your 100 bpm threshold"). |

All temperature/distance conversions ride the existing, already-tested `UnitPreferences` API. Stored values and HealthKit writes stay in SI (°C / metres); `MetricKind.respiratoryRate.unit` (`"count/min"`, the HK identifier) is untouched. Display-only.

## Verification

- `swift test`: **632 tests, 0 failures**
- App **BUILD SUCCEEDED** (device destination)
- New `HealthAlertCopyTests` (elevated-HR copy cites the threshold, not the sample) — **passes on the iPhone 17 Pro Max simulator**
- Adversarially reviewed: **SOUND** — all four fixes correct and complete; completeness grep confirms no remaining hardcoded RR/temp/distance literals on display surfaces.

## Known minor (disclosed)

The Trends Recent-Readings **temp row** converts at data-load (into `@State`), so toggling the temperature unit while viewing Trends keeps the prior unit on that one row until the next refresh. It stays internally consistent (value + symbol from the same unit) and is strictly better than the old always-°C hardcode; the charts and DayDetail update live. Left as a scope trade-off — happy to follow up if you'd rather it live-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)