### PR TITLE
fix(a11y): accessibility cluster — VoiceOver, Dynamic Type, non-color cues, tap targets (#153 #154 #155 #156 #160)

### DIFF
--- a/ios/OpenCircuit/CycleCalendarView.swift
+++ b/ios/OpenCircuit/CycleCalendarView.swift
@@ -136,6 +136,27 @@ struct CycleCalendarView: View {
         return .primary
     }
 
+    /// A day's cycle state as (spoken description, non-colour glyph), or nil for a plain day. Same
+    /// first-match priority as `tileFill` so the tile fill, the glyph, and the VoiceOver label always
+    /// agree even when a day matches several predicates (e.g. an ovulation day inside the fertile
+    /// window). Glyphs are shape-distinct so the four states read in greyscale / with colour filters:
+    /// drops = period (fill=logged, outline=predicted), diamond = ovulation peak, dot = fertile.
+    private func dayState(_ date: Date) -> (desc: String, glyph: String)? {
+        if isLoggedPeriod(date) { return ("Logged period", "drop.fill") }
+        if isPredictedPeriod(date) { return ("Predicted period", "drop") }
+        if isOvulation(date) { return ("Ovulation estimate", "diamond.fill") }
+        if isFertile(date) { return ("Fertile", "circle.fill") }
+        return nil
+    }
+
+    /// VoiceOver label for a day tile: full date (was just the bare day number) + Today + cycle state.
+    private func dayAccessibilityLabel(_ date: Date, state: (desc: String, glyph: String)?) -> String {
+        var parts = [date.formatted(.dateTime.weekday(.wide).month(.wide).day())]
+        if isToday(date) { parts.append("Today") }
+        if let s = state { parts.append(s.desc) }
+        return parts.joined(separator: ", ")
+    }
+
     // MARK: Body
 
     var body: some View {
@@ -225,6 +246,7 @@ struct CycleCalendarView: View {
         let dayNum = cal.component(.day, from: date)
         let fill = tileFill(date)
         let textColor = tileTextColor(date)
+        let state = dayState(date)
 
         return ZStack {
             // Today gets a solid circle
@@ -246,27 +268,41 @@ struct CycleCalendarView: View {
                 .foregroundStyle(textColor)
         }
         .frame(width: 36, height: 36)
+        // Non-colour cue: a small shape badge per state so the four states are distinguishable in
+        // greyscale / under a colour-blindness filter, not by hue alone.
+        .overlay(alignment: .bottomTrailing) {
+            if let glyph = state?.glyph {
+                Image(systemName: glyph)
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(isLoggedPeriod(date) ? Color.white : Color.primary)
+                    .padding(1)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(dayAccessibilityLabel(date, state: state))
     }
 
     private var legendRow: some View {
         HStack(spacing: 12) {
-            legendItem(color: .red.opacity(0.75), label: "Period")
-            legendItem(color: .orange.opacity(0.25), label: "Predicted", outlined: .orange)
-            legendItem(color: .green.opacity(0.15), label: "Fertile")
-            legendItem(color: .green.opacity(0.35), label: "Ovulation est.")
+            legendItem(color: .red.opacity(0.75), glyph: "drop.fill", label: "Period")
+            legendItem(color: .orange.opacity(0.25), glyph: "drop", label: "Predicted", outlined: .orange)
+            legendItem(color: .green.opacity(0.15), glyph: "circle.fill", label: "Fertile")
+            legendItem(color: .green.opacity(0.35), glyph: "diamond.fill", label: "Ovulation est.")
         }
         .font(.caption2)
         .foregroundStyle(.secondary)
     }
 
-    private func legendItem(color: Color, label: String,
+    private func legendItem(color: Color, glyph: String, label: String,
                              outlined: Color? = nil) -> some View {
         HStack(spacing: 4) {
+            // Swatch carries the SAME shape glyph as the tiles, so the key works without colour too.
             ZStack {
-                Circle().fill(color).frame(width: 12, height: 12)
+                Circle().fill(color).frame(width: 14, height: 14)
                 if let outline = outlined {
-                    Circle().stroke(outline.opacity(0.8), lineWidth: 1).frame(width: 12, height: 12)
+                    Circle().stroke(outline.opacity(0.8), lineWidth: 1).frame(width: 14, height: 14)
                 }
+                Image(systemName: glyph).font(.system(size: 8, weight: .bold)).foregroundStyle(.primary)
             }
             Text(label)
         }

--- a/ios/OpenCircuit/GoalsCardView.swift
+++ b/ios/OpenCircuit/GoalsCardView.swift
@@ -143,6 +143,13 @@ struct GoalsCardView: View {
     @ViewBuilder
     private func goalRing(progress p: GoalProgress, label: String,
                           current: String, goal: String, color: Color) -> some View {
+        // Percent computed independently of the `p.met` branch below, so a met goal (which swaps the
+        // percent Text for a checkmark) still exposes an accessible progress value instead of silence.
+        // Truncate (not round) to match the visible ring percent (Int(p.fraction * 100)) exactly.
+        let pct = Int(p.fraction * 100)
+        let percentText = p.met ? "goal met" : "\(pct) percent"
+        // Spoken metric name without the estimate superscript (¹), which VoiceOver reads awkwardly.
+        let spokenLabel = label.replacingOccurrences(of: "\u{B9}", with: "")
         VStack(spacing: 4) {
             ZStack {
                 Circle()
@@ -175,6 +182,10 @@ struct GoalsCardView: View {
                 .font(.caption2).foregroundStyle(.tertiary)
         }
         .frame(maxWidth: .infinity)
+        // One VoiceOver stop per ring: "Steps, 4,321 of 10,000, 47 percent" (was ~4 orphaned tokens).
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(spokenLabel)
+        .accessibilityValue("\(current) of \(goal), \(percentText)")
     }
 
     private func formatDuration(_ minutes: Int) -> String {

--- a/ios/OpenCircuit/SleepCardView.swift
+++ b/ios/OpenCircuit/SleepCardView.swift
@@ -204,8 +204,9 @@ struct SleepCardView: View {
             VStack(alignment: .leading, spacing: 1) {
                 HStack(alignment: .firstTextBaseline, spacing: 6) {
                     Text("\(m.asleep / 60)h \(m.asleep % 60)m")
-                        .font(.system(size: 36, weight: .bold, design: .rounded))
+                        .font(.system(.largeTitle, design: .rounded).weight(.bold))
                         .monospacedDigit().contentTransition(.numericText())
+                        .lineLimit(1).minimumScaleFactor(0.6)
                     Text("asleep").font(.subheadline.weight(.semibold)).foregroundStyle(.secondary)
                 }
                 Text("\(m.inBed / 60)h \(m.inBed % 60)m in bed")
@@ -328,7 +329,8 @@ struct SleepCardView: View {
     private func scoreBadge(_ score: Int) -> some View {
         VStack(spacing: 0) {
             Text("\(score)")
-                .font(.system(size: 22, weight: .bold, design: .rounded)).monospacedDigit()
+                .font(.system(.title2, design: .rounded).weight(.bold)).monospacedDigit()
+                .lineLimit(1).minimumScaleFactor(0.6)
             Text("score").font(.system(size: 9)).foregroundStyle(.secondary)
         }
         .padding(.horizontal, 10).padding(.vertical, 4)
@@ -476,7 +478,21 @@ struct SleepCardView: View {
                 }
             }
             .frame(height: 24)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Skin temperature vs baseline, last \(points.count) nights")
+            .accessibilityValue(tempChartSummary(points))
         }
+    }
+
+    /// VoiceOver summary for the skin-temp baseline chart: tonight's offset direction/size and how
+    /// many of the shown nights fell outside the normal band. `offsets` are °C from the rolling baseline.
+    private func tempChartSummary(_ offsets: [Double]) -> String {
+        guard let tonight = offsets.last else { return "" }
+        let abnormal = offsets.filter { SkinTempBaseline.deviationBand(offset: $0) != .normal }.count
+        // Reuse the unit-aware delta formatter (signed, °C/°F per the user's setting) so a °F user
+        // doesn't hear a raw Celsius magnitude.
+        return "Tonight \(skinTempDeltaString(tonight)) from baseline; "
+            + "\(abnormal) of \(offsets.count) nights outside the normal band"
     }
 
     // MARK: Body-movement chart (#70)
@@ -485,20 +501,53 @@ struct SleepCardView: View {
     private func movementSection() -> some View {
         let levels = latest?.movementLevels ?? []
         if !levels.isEmpty {
+            let summary = movementSummary(levels)
             VStack(alignment: .leading, spacing: 4) {
                 Text("Movement").font(.caption2).foregroundStyle(.secondary)
+                // Encode level in BAR HEIGHT as well as colour (still=short, light=mid, active=full)
+                // so the strip is legible in greyscale — yellow-vs-orange is a hard colourblind pair.
                 GeometryReader { geo in
-                    HStack(spacing: 1) {
+                    HStack(alignment: .bottom, spacing: 1) {
                         ForEach(Array(levels.enumerated()), id: \.offset) { _, lvl in
                             Rectangle().fill(movementColor(lvl))
-                                .frame(width: max(geo.size.width / CGFloat(levels.count) - 1, 0.5))
+                                .frame(width: max(geo.size.width / CGFloat(levels.count) - 1, 0.5),
+                                       height: max(geo.size.height * movementHeightFraction(lvl), 1))
                         }
                     }
+                    .frame(maxHeight: .infinity, alignment: .bottom)
                 }
                 .frame(height: 16)
                 .clipShape(RoundedRectangle(cornerRadius: 3))
+                // Text summary for sighted colourblind users (and the VoiceOver value below).
+                Text(summary).font(.caption2).foregroundStyle(.tertiary)
             }
             .padding(.top, 2)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Movement")
+            .accessibilityValue(summary)
+        }
+    }
+
+    /// One-line movement summary (dominant level + count of restless runs) shared by the visible
+    /// caption and the VoiceOver value. `levels`: 0=still, 1=light, 2=active (may be a partial night).
+    private func movementSummary(_ levels: [Int]) -> String {
+        let still = levels.filter { $0 == 0 }.count
+        let moving = levels.count - still
+        guard moving > 0 else { return "Still all night" }
+        var runs = 0, inRun = false
+        for l in levels {
+            if l >= 1 { if !inRun { runs += 1; inRun = true } } else { inRun = false }
+        }
+        let lead = still >= moving ? "Mostly still" : "Restless"
+        return "\(lead) · \(runs) restless period\(runs == 1 ? "" : "s")"
+    }
+
+    /// Bar-height fraction per movement level (the non-colour cue): still low, active full.
+    private func movementHeightFraction(_ level: Int) -> CGFloat {
+        switch level {
+        case 2: return 1.0     // active
+        case 1: return 0.65    // light
+        default: return 0.35   // still
         }
     }
 
@@ -534,14 +583,32 @@ struct SleepCardView: View {
         if let latest {
             VStack(alignment: .leading, spacing: 4) {
                 Text("How did you sleep?").font(.caption2).foregroundStyle(.secondary)
-                HStack(spacing: 6) {
+                // Each dot is a Button filling an equal share of the row at ≥44pt tall so the whole
+                // cell is a valid tap target (was a 16pt circle at 22pt pitch); maxWidth:.infinity keeps
+                // all 9 reachable without clipping on the narrowest device (SE), edge-to-edge (no dead
+                // gaps). Selection carries a non-color ring + VoiceOver label/value/selected trait.
+                HStack(spacing: 0) {
                     ForEach(1...9, id: \.self) { n in
-                        Circle()
-                            .fill(n <= latest.feelScore ? Color.indigo : Color.secondary.opacity(0.18))
-                            .frame(width: 16, height: 16)
-                            .overlay(Text("\(n)").font(.system(size: 9))
-                                .foregroundStyle(n <= latest.feelScore ? .white : .secondary))
-                            .onTapGesture { setFeel(n, night: latest.night) }
+                        let filled = n <= latest.feelScore
+                        let isCurrent = n == latest.feelScore
+                        Button {
+                            setFeel(n, night: latest.night)
+                        } label: {
+                            Circle()
+                                .fill(filled ? Color.indigo : Color.secondary.opacity(0.18))
+                                .frame(width: 16, height: 16)
+                                .overlay(Text("\(n)").font(.system(size: 9))
+                                    .foregroundStyle(filled ? .white : .secondary))
+                                .overlay(isCurrent
+                                    ? Circle().stroke(Color.primary, lineWidth: 2).frame(width: 24, height: 24)
+                                    : nil)
+                                .frame(maxWidth: .infinity, minHeight: 44)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Sleep quality")
+                        .accessibilityValue("\(n) of 9")
+                        .accessibilityAddTraits(isCurrent ? .isSelected : [])
                     }
                 }
             }

--- a/ios/OpenCircuit/WorkoutView.swift
+++ b/ios/OpenCircuit/WorkoutView.swift
@@ -23,6 +23,11 @@ struct WorkoutView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
 
+    // Headline metrics scale with Dynamic Type while keeping their deliberately-large base size
+    // (was fixed .system(size:), so the numbers users came to read stayed frozen while labels grew).
+    @ScaledMetric(relativeTo: .largeTitle) private var timerSize: CGFloat = 56
+    @ScaledMetric(relativeTo: .title) private var hrSize: CGFloat = 40
+
     // Distance display unit (#83) — same key/default as UserProfileSettingsView. Storage stays in
     // metres (manager.distanceMeters); only the display converts. @AppStorage re-renders the live
     // and summary distance when the user flips the toggle. `?? .metric` mirrors the temp sites.
@@ -146,9 +151,10 @@ struct WorkoutView: View {
             // Duration
             VStack(spacing: 4) {
                 Text(formattedElapsed)
-                    .font(.system(size: 56, weight: .bold, design: .monospaced))
+                    .font(.system(size: timerSize, weight: .bold, design: .monospaced))
                     .monospacedDigit()
                     .contentTransition(.numericText())
+                    .lineLimit(1).minimumScaleFactor(0.5)
                 Text(manager.selectedSport.displayName.uppercased())
                     .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
             }
@@ -161,12 +167,14 @@ struct WorkoutView: View {
                         // Show the last REAL reading; dim it once it ages out (the ring's spot-read
                         // can't lock under motion — we never pretend a held value is live, #45).
                         if let hr = manager.currentHR {
-                            Text("\(hr)").font(.system(size: 40, weight: .bold, design: .rounded))
+                            Text("\(hr)").font(.system(size: hrSize, weight: .bold, design: .rounded))
                                 .monospacedDigit().contentTransition(.numericText())
+                                .lineLimit(1).minimumScaleFactor(0.5)
                                 .foregroundStyle(manager.currentHRIsStale ? AnyShapeStyle(.secondary)
                                                                           : AnyShapeStyle(.red))
                         } else {
-                            Text("--").font(.system(size: 40, weight: .bold, design: .rounded))
+                            Text("--").font(.system(size: hrSize, weight: .bold, design: .rounded))
+                                .lineLimit(1).minimumScaleFactor(0.5)
                                 .foregroundStyle(.secondary)
                         }
                         Text("bpm").font(.subheadline).foregroundStyle(.secondary)


### PR DESCRIPTION
Batches the five accessibility findings from the [build-18 UX sweep](https://github.com/perezjuanj/OpenCircuit/issues/153) into one PR. Closes #153, #154, #155, #156, #160. All changes are presentation-layer (VoiceOver labels, Dynamic Type, non-color cues, hit targets) — no data-path or logic changes.

## Changes

| # | Fix |
|---|-----|
| **#153** | Sleep feel-rating dots were 16pt circles at 22pt pitch (half Apple's 44pt min), selected by color alone. Now each dot is a `Button` filling an equal share of the row at **≥44pt** tall, reachable/unclipped to SE width; the current score gets a **non-color stroke ring**; VoiceOver announces "Sleep quality, N of 9" + Selected trait. |
| **#154** | Daily-goal rings read as ~4 orphaned VoiceOver fragments and lost the percent when a goal was met. Now **one grouped element per ring** ("Steps, 4,321 of 10,000, 47 percent"), percent computed independent of the met/checkmark branch, estimate superscript stripped from the spoken label. |
| **#155** | Cycle-calendar day state was hue-only and VoiceOver read only the day number. Added a **shape glyph per state** (drop.fill / drop / circle.fill / diamond.fill — greyscale-distinguishable), mirrored in the legend, plus a **full per-day accessibility label** (date + Today + state) using the same first-match priority as the fill. |
| **#156** | Headline numbers (sleep duration, sleep score, workout timer, live HR) used fixed `.system(size:)` so they stayed frozen while captions scaled. Now **relative styles / `@ScaledMetric`** with `lineLimit(1)` + `minimumScaleFactor`; HR value and "--" share one size (no jump). |
| **#160** | Sleep movement strip was color-only (yellow/orange = hard colorblind pair). Now encodes level in **bar height** too, adds a **visible text summary** ("Mostly still · 3 restless periods" / "Still all night") and a matching VoiceOver value; temp mini-chart got an accessible label + unit-aware value. |

## Verification

- App **BUILD SUCCEEDED** (device destination).
- **Adversarially reviewed** (two passes): **SOUND** — all five complete, edge cases handled (goal met, all-still night, empty `movementLevels`, `prediction == nil`, ovulation-inside-fertile all verified), no functional bugs. Two review nits fixed before commit: spoken goal percent now matches the visible (truncated) percent; the temp-chart VoiceOver summary now uses the unit-aware delta formatter (°F users no longer hear a raw Celsius magnitude).

## Recommended manual checks (a11y is hard to unit-test)

Live **VoiceOver** sweep of the Sleep card, Daily Goals, and Cycle Calendar; **greyscale / color-filter** check of the movement strip and cycle tiles; **Dynamic Type at AX5** on the Sleep and Workout headlines. These need a device + a night of data, which CI can't exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)