### PR TITLE
fix(ios): background sync can no longer wipe the local store (#131)

### DIFF
--- a/ios/OpenCircuit/App.swift
+++ b/ios/OpenCircuit/App.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import UIKit
 
 @main
 struct OpenCircuitApp: App {
@@ -91,6 +92,61 @@ struct OpenCircuitApp: App {
     /// last-resort wipe runs; the UI clears it after showing the notice. (#40)
     static let historyResetDefaultsKey = "localHistoryWasReset"
 
+    /// The one process-wide SwiftData container, published the moment the foreground `App` builds
+    /// it (see `makeContainer()`), so the background BGTask handler can REUSE it instead of opening
+    /// a second `ModelContainer` over the same store file. (#131)
+    ///
+    /// Why this is safe to publish and read across the launch: the `@main App` struct's stored
+    /// `container` property (`App.swift` line 8) is initialized when SwiftUI instantiates the App
+    /// type at process launch — which happens for a background launch too (iOS always creates the
+    /// App instance to establish the scene graph, even when no scene will connect). That
+    /// initializer runs `makeContainer()`, which assigns this static WHEN the on-disk store opens
+    /// (the normal case). The BGTask launch handler is only ever *invoked by BGTaskScheduler on a
+    /// later run-loop turn*, never synchronously during launch — so by the time the handler reads
+    /// this, the App init has already populated it.
+    ///
+    /// It is deliberately left `nil` when a background launch can't open the on-disk store (see
+    /// `resolveContainer`): the handler then falls through to `makeContainerOrThrow()`, which
+    /// re-throws → the run aborts-and-retries rather than draining into a throwaway in-memory
+    /// container. The `makeContainerOrThrow()` fallback also covers the theoretical gap where the
+    /// App init hasn't run yet.
+    ///
+    /// It is written exactly once, from the main thread, during the single-threaded App init
+    /// before any concurrent reader exists; `ModelContainer` is itself `Sendable` and thread-safe
+    /// to use from the `@MainActor` background handler.
+    static var sharedContainer: ModelContainer?
+
+    /// The schema + default configuration shared by BOTH container builders, so the foreground
+    /// (recovering) and background (non-destructive) paths can never drift apart. (#131)
+    private static func makeSchemaAndConfig() -> (Schema, ModelConfiguration) {
+        let schema = Schema([StoredSample.self, StoredCursor.self,
+                             StoredSleepSummary.self, StoredDaily.self, StoredNap.self,
+                             StoredPeriodEntry.self, StoredDaytimeTemp.self, StoredStepSample.self])
+        return (schema, ModelConfiguration(schema: schema))
+    }
+
+    /// Build the SwiftData container with NO destructive fallback: create the Application Support
+    /// directory, open the store through the `MigrationPlan`, and rethrow on any failure. This is
+    /// the ONLY builder the background BGTask drain may reach (#131) — a transient open failure
+    /// during a routine background wake must abort-and-retry, NEVER wipe the un-resyncable raw
+    /// sample/cursor history. It deliberately contains no `exportBeforeWipe`, no `removeStoreFiles`,
+    /// and no `fatalError`; the wipe-and-recover recovery lives only in `makeContainer()`, where the
+    /// `historyResetDefaultsKey` UI notice can be surfaced to the user.
+    ///
+    /// `storeURL` is a test-only seam (default nil → the app's default store); production always
+    /// calls it with no argument.
+    static func makeContainerOrThrow(storeURL: URL? = nil) throws -> ModelContainer {
+        // A brand-new app container (fresh install / new bundle id) has no
+        // `Library/Application Support` directory, where SwiftData's default store lives. If it's
+        // missing, store creation fails, so create it up front. (#fresh-install-crash)
+        _ = try? FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                                         appropriateFor: nil, create: true)
+        let (schema, defaultConfig) = makeSchemaAndConfig()
+        let config = storeURL.map { ModelConfiguration(schema: schema, url: $0) } ?? defaultConfig
+        return try ModelContainer(for: schema, migrationPlan: MigrationPlan.self,
+                                  configurations: config)
+    }
+
     /// Build the SwiftData container, recovering from an incompatible on-disk store.
     ///
     /// The default `.modelContainer(for:)` modifier traps if the container can't be created —
@@ -100,40 +156,114 @@ struct OpenCircuitApp: App {
     /// rollups (sleep summaries + daily steps) to a JSON backup and restore them into the fresh
     /// store, and raise `historyResetDefaultsKey` so the UI can tell the user. Raw epoch samples
     /// are not backed up — they're already in Apple Health. (#40)
+    ///
+    /// #131: the destructive wipe MUST be unreachable on a background (no-scene) launch. The
+    /// `@main App` struct's stored `container` initializer runs `makeContainer()` on EVERY cold
+    /// launch — including the background cold launches iOS performs for `bluetooth-central` /
+    /// `fetch` / `processing` BGTasks and CoreBluetooth state restoration. On such a launch,
+    /// post-reboot / pre-first-unlock, the store file is temporarily unreadable under Data
+    /// Protection (`CompleteUntilFirstUserAuthentication`), so the open throws transiently — and
+    /// wiping then would be the exact #131 silent data-loss, just relocated from the BGTask handler
+    /// to App.init. We therefore gate the wipe on real foreground presence: at launch,
+    /// `UIApplication.shared.applicationState == .background` iff the process was launched into the
+    /// background. Only a genuine foreground launch (`.inactive`) may wipe+recover (and surface the
+    /// notice); a background launch defers recovery to the next foreground launch — see
+    /// `resolveContainer`.
     static func makeContainer() -> ModelContainer {
-        // A brand-new app container (fresh install / new bundle id) has no
-        // `Library/Application Support` directory, where SwiftData's default store lives. If it's
-        // missing, store creation fails — and because `exportBeforeWipe` bails before it would
-        // create the directory, BOTH the initial and the post-wipe `ModelContainer` attempts below
-        // fail and hit the `fatalError` → black screen on first launch. Create it up front so a
-        // fresh install opens cleanly. (#fresh-install-crash)
-        _ = try? FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask,
-                                         appropriateFor: nil, create: true)
-        let schema = Schema([StoredSample.self, StoredCursor.self,
-                             StoredSleepSummary.self, StoredDaily.self, StoredNap.self,
-                             StoredPeriodEntry.self, StoredDaytimeTemp.self, StoredStepSample.self])
-        let config = ModelConfiguration(schema: schema)
+        // `UIApplication.shared.applicationState` is main-actor state. `makeContainer()` is invoked
+        // from the App struct's stored-property initializer, which runs on the main thread at
+        // launch, so this read is valid. (`assumeIsolated` would trap only if called off-main,
+        // which no caller does — AppDelegate no longer calls `makeContainer()`.)
+        let isBackground = MainActor.assumeIsolated {
+            UIApplication.shared.applicationState == .background
+        }
+        let (schema, config) = makeSchemaAndConfig()
+        let (container, publishAsShared) = resolveContainer(
+            isBackground: isBackground,
+            build: { try makeContainerOrThrow() },
+            wipeAndRecover: { wipeAndRecoverForeground(schema: schema, config: config) },
+            inMemoryFallback: { inMemoryContainer(schema: schema) })
+        if publishAsShared {
+            sharedContainer = container   // publish for the background handler to reuse (#131)
+        }
+        return container
+    }
 
+    /// The container-recovery decision, factored out of `makeContainer()` so the #131 rule — the
+    /// destructive wipe is UNREACHABLE on a background (no-scene) launch — is unit-testable without
+    /// a real launch context. Returns the container to use and whether it may be published as the
+    /// process-wide `sharedContainer`.
+    ///
+    /// - Successful open → use it, publish it.
+    /// - Open FAILS in the FOREGROUND (`isBackground == false`) → `wipeAndRecover` (export →
+    ///   removeStoreFiles → fresh + restore + reset notice), publish it. Foreground first-launch /
+    ///   migration recovery is UNCHANGED.
+    /// - Open FAILS in the BACKGROUND (`isBackground == true`) → do NOT wipe and do NOT touch the
+    ///   on-disk files; return a throwaway in-memory container (so the App struct's non-optional
+    ///   `container` stays valid) and do NOT publish it. Leaving `sharedContainer` nil makes the
+    ///   BGTask handler fall through to `makeContainerOrThrow()`, which re-throws against the still-
+    ///   unreadable store → `AppDelegate.handle`'s do/catch aborts the run with `success:false`,
+    ///   keeps the scheduler armed, and retries on the next wake. The `.store`/`-shm`/`-wal` files
+    ///   are left intact for the next FOREGROUND launch to open cleanly (once Data Protection is
+    ///   available) or to wipe+recover WITH the UI notice.
+    ///
+    /// Rare edge (documented, not over-engineered): if the process was background-launched onto the
+    /// in-memory fallback and the user then foregrounds THAT SAME process without a relaunch, they'd
+    /// see empty data until the next full relaunch, which recovers. Acceptable — no data is lost.
+    static func resolveContainer(
+        isBackground: Bool,
+        build: () throws -> ModelContainer,
+        wipeAndRecover: () -> ModelContainer,
+        inMemoryFallback: () -> ModelContainer
+    ) -> (container: ModelContainer, publishAsShared: Bool) {
         do {
-            return try ModelContainer(for: schema, migrationPlan: MigrationPlan.self,
-                                      configurations: config)
+            return (try build(), true)
         } catch {
             #if DEBUG
-            print("SwiftData store unusable (\(error)); backing up rollups, resetting cache, retrying.")
+            print("SwiftData store unusable (\(error)); isBackground=\(isBackground).")
             #endif
-            let backup = RollupBackup.exportBeforeWipe(config: config)
-            removeStoreFiles(at: config.url)
-            let fresh: ModelContainer
-            do {
-                fresh = try ModelContainer(for: schema, migrationPlan: MigrationPlan.self,
-                                           configurations: config)
-            } catch {
-                // A fresh store still failed — genuinely unrecoverable (e.g. no disk).
-                fatalError("Unrecoverable SwiftData store error: \(error)")
+            if isBackground {
+                // Post-reboot / pre-first-unlock background launch: the store file is temporarily
+                // unreadable (Data Protection). Wiping now would be catastrophic AND pointless, so
+                // defer recovery to the next foreground launch and leave the on-disk store untouched.
+                return (inMemoryFallback(), false)
             }
-            backup?.restore(into: fresh)
-            UserDefaults.standard.set(true, forKey: historyResetDefaultsKey)
-            return fresh
+            return (wipeAndRecover(), true)
+        }
+    }
+
+    /// The destructive FOREGROUND-ONLY recovery: back up durable rollups, wipe the store files,
+    /// rebuild a fresh store, restore the rollups, and raise `historyResetDefaultsKey`. Only reached
+    /// from `resolveContainer` when `isBackground == false`. (#40/#131)
+    private static func wipeAndRecoverForeground(schema: Schema, config: ModelConfiguration) -> ModelContainer {
+        // The app-support directory was already created by the failed `makeContainerOrThrow()`, so
+        // `exportBeforeWipe` (which won't create it) can still read the old store.
+        let backup = RollupBackup.exportBeforeWipe(config: config)
+        removeStoreFiles(at: config.url)
+        let fresh: ModelContainer
+        do {
+            fresh = try ModelContainer(for: schema, migrationPlan: MigrationPlan.self,
+                                       configurations: config)
+        } catch {
+            // A fresh store still failed — genuinely unrecoverable (e.g. no disk).
+            fatalError("Unrecoverable SwiftData store error: \(error)")
+        }
+        backup?.restore(into: fresh)
+        UserDefaults.standard.set(true, forKey: historyResetDefaultsKey)
+        return fresh
+    }
+
+    /// A throwaway in-memory container (same schema) that satisfies the App struct's non-optional
+    /// `container` on a background launch where the on-disk store is temporarily unreadable. Never
+    /// published as `sharedContainer`, never written to disk. (#131)
+    private static func inMemoryContainer(schema: Schema) -> ModelContainer {
+        do {
+            return try ModelContainer(for: schema,
+                                      configurations: ModelConfiguration(schema: schema,
+                                                                         isStoredInMemoryOnly: true))
+        } catch {
+            // In-memory creation essentially never fails; only here is a last resort acceptable.
+            fatalError("Unrecoverable in-memory SwiftData store error: \(error)")
         }
     }
 

--- a/ios/OpenCircuit/AppDelegate.swift
+++ b/ios/OpenCircuit/AppDelegate.swift
@@ -76,7 +76,16 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
 
         let operation = Task { @MainActor in
             do {
-                let container = OpenCircuitApp.makeContainer()
+                // #131: NEVER build the container via the destructive `makeContainer()` here — its
+                // wipe-and-recover fallback would silently delete un-resyncable raw sample/cursor
+                // history on a transient open failure during a routine background wake, with no UI
+                // to surface the reset. Reuse the process-wide container the foreground `App` built
+                // at launch (it is populated before iOS invokes this handler on a later run-loop
+                // turn — see OpenCircuitApp.sharedContainer). In the rare case it isn't built yet,
+                // fall back to the NON-destructive `makeContainerOrThrow()`, whose throw is caught
+                // below → the run aborts, the scheduler chain stays armed, and the next wake retries;
+                // the store is never touched.
+                let container = try OpenCircuitApp.sharedContainer ?? OpenCircuitApp.makeContainerOrThrow()
                 let service = RingBackgroundSyncService(
                     store: LocalStore(container.mainContext),
                     health: HealthKitWriter()

--- a/ios/OpenCircuitTests/ContainerRecoveryTests.swift
+++ b/ios/OpenCircuitTests/ContainerRecoveryTests.swift
@@ -1,0 +1,168 @@
+import SwiftData
+import XCTest
+@testable import OpenCircuit
+
+/// Regression coverage for #131 — "Background sync can wipe the local store".
+///
+/// The BGTask background-sync handler used to build its SwiftData container via the SAME
+/// `makeContainer()` whose failure path wipes+recreates the on-disk store (`exportBeforeWipe` +
+/// `removeStoreFiles`). A transient container-open failure during a routine background wake-drain
+/// (these fire ~hourly all day) therefore silently DELETED the raw `StoredSample`/`StoredStepSample`/
+/// `StoredCursor` history — none of which `RollupBackup` carries — with no UI notice.
+///
+/// The fix (a) adds a NON-destructive `makeContainerOrThrow()` and shares one process-wide container
+/// so the BGTask handler never calls the destructive builder, and (b) gates the destructive wipe on
+/// real foreground presence, so a BACKGROUND cold launch (which also runs `App.init` →
+/// `makeContainer()`) can never reach `removeStoreFiles` either. These tests pin both.
+///
+/// Every test here uses a temp-URL or in-memory store — NONE touch the app's real default store.
+///
+/// MANUAL CHECK (device repro from the issue): with a populated store, background the app, then
+/// trigger the BGTask via the debugger —
+///   e -l objc -- (void)[[BGTaskScheduler sharedScheduler]
+///     _simulateLaunchForTaskWithIdentifier:@"com.standardsoftwaresolutions.opencircuit.bgrefresh"]
+/// — and confirm the `.store`/`-shm`/`-wal` files in Library/Application Support survive and
+/// `localHistoryWasReset` stays unset even if the drain fails. Also cold-launch post-reboot (before
+/// first unlock) via a scheduled BGProcessing task and confirm the same.
+@MainActor
+final class ContainerRecoveryTests: XCTestCase {
+
+    private enum TestError: Error { case openFailed }
+
+    /// A throwaway in-memory container used as the dummy return value from injected builder
+    /// closures (its identity/contents are irrelevant — the tests assert the DECISION, not the
+    /// container).
+    private func dummyContainer() throws -> ModelContainer {
+        try ModelContainer(for: StoredSample.self,
+                           configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    }
+
+    private func uniqueTempStoreURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("bg131-\(UUID().uuidString).store")
+    }
+
+    private func removeStore(at url: URL) {
+        let base = url.deletingPathExtension()
+        for u in [url, base.appendingPathExtension("store-shm"), base.appendingPathExtension("store-wal")] {
+            try? FileManager.default.removeItem(at: u)
+        }
+    }
+
+    // MARK: The core #131 regression guard — the wipe decision (no real store, no real launch)
+
+    /// When the store open FAILS on a BACKGROUND launch, the destructive path
+    /// (`wipeAndRecover` → `removeStoreFiles`) must NEVER run: the in-memory fallback is used
+    /// instead, the result is NOT published as the shared container, and no reset notice is raised.
+    /// This is the exact hole the adversarial review found — the wipe reachable from `App.init` on
+    /// a background cold launch.
+    func testBackgroundOpenFailureNeverWipes() throws {
+        UserDefaults.standard.removeObject(forKey: OpenCircuitApp.historyResetDefaultsKey)
+        let dummy = try dummyContainer()
+        var wipeCalled = false
+        var inMemoryCalled = false
+
+        let (_, publishAsShared) = OpenCircuitApp.resolveContainer(
+            isBackground: true,
+            build: { throw TestError.openFailed },
+            wipeAndRecover: { wipeCalled = true; return dummy },
+            inMemoryFallback: { inMemoryCalled = true; return dummy })
+
+        XCTAssertFalse(wipeCalled,
+                       "a background open failure must NEVER reach wipeAndRecover/removeStoreFiles")
+        XCTAssertTrue(inMemoryCalled,
+                      "a background open failure falls back to a throwaway in-memory container")
+        XCTAssertFalse(publishAsShared,
+                       "the in-memory fallback must NOT be published — the BGTask handler must fall "
+                       + "through to makeContainerOrThrow() and abort-and-retry")
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: OpenCircuitApp.historyResetDefaultsKey),
+                       "no history-reset notice may be raised on a background launch")
+    }
+
+    /// A FOREGROUND open failure still runs the destructive wipe+recover, so first-launch /
+    /// migration recovery (and the user-facing reset notice) is unchanged.
+    func testForegroundOpenFailureRecovers() throws {
+        let dummy = try dummyContainer()
+        var wipeCalled = false
+        var inMemoryCalled = false
+
+        let (_, publishAsShared) = OpenCircuitApp.resolveContainer(
+            isBackground: false,
+            build: { throw TestError.openFailed },
+            wipeAndRecover: { wipeCalled = true; return dummy },
+            inMemoryFallback: { inMemoryCalled = true; return dummy })
+
+        XCTAssertTrue(wipeCalled,
+                      "a foreground open failure must run wipe+recover (unchanged migration recovery)")
+        XCTAssertFalse(inMemoryCalled)
+        XCTAssertTrue(publishAsShared, "the recovered on-disk container is published as shared")
+    }
+
+    /// A successful open is published as the shared container regardless of launch context, and
+    /// never touches the recovery paths.
+    func testSuccessfulOpenIsPublishedAndNeverRecovers() throws {
+        let dummy = try dummyContainer()
+        var wipeCalled = false
+        var inMemoryCalled = false
+
+        for isBackground in [true, false] {
+            let (container, publishAsShared) = OpenCircuitApp.resolveContainer(
+                isBackground: isBackground,
+                build: { dummy },
+                wipeAndRecover: { wipeCalled = true; return dummy },
+                inMemoryFallback: { inMemoryCalled = true; return dummy })
+            XCTAssertTrue(publishAsShared)
+            XCTAssertTrue(container === dummy)
+        }
+        XCTAssertFalse(wipeCalled)
+        XCTAssertFalse(inMemoryCalled)
+    }
+
+    // MARK: The non-destructive builder itself, against a temp store (never the real one)
+
+    /// `makeContainerOrThrow` opens a healthy store and never raises the history-reset notice
+    /// (that flag belongs only to the foreground wipe path).
+    func testMakeContainerOrThrowOpensHealthyStoreWithoutResetFlag() throws {
+        UserDefaults.standard.removeObject(forKey: OpenCircuitApp.historyResetDefaultsKey)
+        let url = uniqueTempStoreURL()
+        defer { removeStore(at: url) }
+
+        let container = try OpenCircuitApp.makeContainerOrThrow(storeURL: url)
+        _ = container
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
+                      "opening the store must materialize its file")
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: OpenCircuitApp.historyResetDefaultsKey),
+                       "the non-destructive builder must never raise the history-reset notice")
+    }
+
+    /// Re-opening a PRE-SEEDED healthy store (as a subsequent hourly background wake would) leaves
+    /// the store file and its seeded row intact — i.e. the non-destructive builder never wipes.
+    func testBackgroundReopenLeavesHealthyStoreIntact() throws {
+        let url = uniqueTempStoreURL()
+        defer { removeStore(at: url) }
+
+        do {
+            let first = try OpenCircuitApp.makeContainerOrThrow(storeURL: url)
+            let ctx = first.mainContext
+            ctx.insert(StoredSample(kindRaw: "heartRate",
+                                    start: Date(timeIntervalSince1970: 1_000),
+                                    end: Date(timeIntervalSince1970: 1_000),
+                                    value: 62))
+            try ctx.save()
+        }   // release `first` so the re-open below mirrors a fresh background process
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        UserDefaults.standard.removeObject(forKey: OpenCircuitApp.historyResetDefaultsKey)
+
+        let second = try OpenCircuitApp.makeContainerOrThrow(storeURL: url)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
+                      "the non-destructive builder must never remove the store files")
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: OpenCircuitApp.historyResetDefaultsKey),
+                       "re-opening a healthy store must not raise the reset notice")
+        let seeded = try second.mainContext.fetch(FetchDescriptor<StoredSample>())
+        XCTAssertTrue(seeded.contains { $0.value == 62 },
+                      "the pre-seeded sample must survive the background re-open")
+    }
+}


### PR DESCRIPTION
Fixes the P1 silent-data-loss path from the 2026-07-04 UX sweep.

Closes #131.

## Problem
The background BGTask sync handler built its SwiftData container via `OpenCircuitApp.makeContainer()` — the **same** accessor whose failure path *wipes and recreates* the on-disk store (`RollupBackup.exportBeforeWipe` → `removeStoreFiles` deletes `.store`/`-shm`/`-wal`). A transient container-open failure during a routine ~hourly background wake-drain therefore **silently deleted** the local store. `RollupBackup` only carries sleep summaries / daily steps / periods / naps — the raw `StoredSample` epoch history (HR/RR/SpO₂/temp), `StoredStepSample` deltas, and `StoredCursor` sync watermarks are **not** backed up and are gone permanently (ring history can't be re-drained past the cursor). It happened in the background with no UI, so the user never even saw the `historyResetDefaultsKey` reset notice.

## Fix
Two layers, so the destructive wipe is unreachable from **any** background (no-scene) launch:

1. **Non-destructive builder + shared container.** New `makeContainerOrThrow()` opens the store and *rethrows* on failure — no `exportBeforeWipe`, no `removeStoreFiles`, no `fatalError`. The foreground container built at `App.swift:8` is published process-wide as `sharedContainer`; the BGTask handler now uses `sharedContainer ?? makeContainerOrThrow()`, so it reuses the one healthy container in the normal case and, in the rare case it can't, aborts-and-retries instead of ever reaching the wipe.

2. **Gate the wipe on real foreground presence.** `App.swift:8`'s `makeContainer()` runs on *every* cold launch — including the background cold launches iOS performs for `bluetooth-central`/`fetch`/`processing` BGTasks and CoreBluetooth state restoration (e.g. post-reboot, before first unlock, when the store file is temporarily unreadable under Data Protection). So relocating the destructive path out of the handler alone was insufficient — an adversarial review caught that the wipe was still reachable from `App.init` on a background launch. The recovery decision is now factored into a testable `resolveContainer(isBackground:…)`:
   - **success** → use + publish;
   - **foreground open failure** (`applicationState != .background`) → `wipeAndRecoverForeground` exactly as before, with the `historyResetDefaultsKey` notice — foreground first-launch/migration recovery is byte-for-byte unchanged;
   - **background open failure** → return a throwaway **in-memory** container, do **not** touch the on-disk files, and do **not** publish it — the BGTask handler then falls through to `makeContainerOrThrow()` → throws → the existing do/catch aborts `success:false`, keeps the scheduler armed, and retries next wake. The `.store`/`-shm`/`-wal` files are left intact for the next foreground launch to open cleanly or recover with the notice.

`UIApplication.shared.applicationState == .background` is the documented at-launch discriminator (a foreground cold launch reads `.inactive`). Read via `MainActor.assumeIsolated` — safe because `makeContainer()` is only ever called from the App struct's stored-property initializer on the main thread (AppDelegate no longer calls it).

## Tests
`ContainerRecoveryTests` (all use temp-URL / in-memory stores — **none** touch the real default store):
- **`testBackgroundOpenFailureNeverWipes`** — the regression guard: `isBackground:true` + a throwing builder ⇒ `wipeAndRecover` is **never** called, the in-memory fallback is used, the result is **not** published, and `historyResetDefaultsKey` stays unset.
- `testForegroundOpenFailureRecovers` — foreground failure still wipes+recovers and publishes.
- `testSuccessfulOpenIsPublishedAndNeverRecovers` — success publishes, never recovers, in both launch contexts.
- `testMakeContainerOrThrowOpensHealthyStoreWithoutResetFlag` / `testBackgroundReopenLeavesHealthyStoreIntact` — a healthy store (and a pre-seeded row) survives a background-style re-open; the non-destructive builder never removes files or raises the notice.

Adversarially reviewed twice (a real blocker in round 1 — the background-`App.init` wipe — was found and closed). `xcodebuild` (generic/iOS, Debug) **BUILD SUCCEEDED**; `ContainerRecoveryTests` pass on-sim; `OpenCircuitKit` 632 tests pass.

## Manual check (device repro from the issue)
With a populated store, background the app and trigger the BGTask via the debugger (`_simulateLaunchForTaskWithIdentifier:`), and separately cold-launch post-reboot before first unlock via a scheduled BGProcessing task — confirm the store files in `Library/Application Support` survive and `localHistoryWasReset` stays unset even when the drain fails.

cc @bluna-ai for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
