### PR TITLE
fix(ios): calibration disconnect detection + background body-vital alert dispatch (#138 #146)

### DIFF
--- a/ios/OpenCircuit/BLE/RingSession.swift
+++ b/ios/OpenCircuit/BLE/RingSession.swift
@@ -319,6 +319,22 @@ final class RingSession: NSObject {
     private var calibrationSampleCount = 0
     private var calibrationLastFrameAt = Date.distantPast
     private var calibrationMissCount = 0
+    /// #138: how many times the stall watchdog has re-entered PPG mode WITHOUT a frame arriving
+    /// since. Reset to 0 whenever a real frame lands (`handleCalibrationPPGFrame`). If it crosses
+    /// `calibrationMaxReenters` the link is up but permanently silent → fail the capture instead of
+    /// looping `enterCalibrationPPGMode()` forever.
+    private var calibrationReenterCount = 0
+    /// Ceiling of consecutive stall re-entries with no recovered frames before we declare the
+    /// capture dead. Each re-entry follows 5 misses × 1.5 s ≈ 7.5 s of silence, so this is
+    /// ~30 s of continuous, unrecovered silence — unreachable by a healthy capture (which streams
+    /// continuously and resets the counter on every frame).
+    private static let calibrationMaxReenters = 4
+    /// #138: minimum average sample rate a genuine capture sustains, used only as a stop-time
+    /// backstop against a link that limped to the duration mark with a trickle of frames. The
+    /// watchdog's liveness contract already requires a 25-sample frame at least every ~1.4 s
+    /// (≈18 samples/s) or it acts; this floor is ~20 % of that (a 5× margin) so a real capture can
+    /// never trip it — only one that streamed for a tiny fraction of the window.
+    private static let calibrationMinSamplesPerSecond: Double = 3.5
 
     // MARK: Activity-channel probe (debug / RE — issue #93)
     //
@@ -617,6 +633,17 @@ final class RingSession: NSObject {
     /// reading via `stopLiveMonitoring()` BEFORE this where that matters; `invalidate()` itself is
     /// a pure cancel + detach. Idempotent.
     func invalidate() {
+        // #138: a ring drop mid raw-PPG calibration capture MUST fail the in-flight capture. Without
+        // this the fixed-duration `calibrationStopTask` survives teardown and still fires
+        // `success: true` on whatever partial/zero frames arrived, so the flow advances to upload a
+        // bogus (or empty) capture. Route through the (previously dead) failure branch so the awaiting
+        // `startPPGCalibrationCapture` throws "ring disconnected". Do this FIRST, before the task
+        // cancels below, so any device-status refresh it schedules is torn down with the rest. Gated
+        // on `calibrationCapturing`, so a NORMAL finish (which already cleared the flag and resumed
+        // the continuation) is untouched — this only fires for a genuine mid-capture teardown.
+        if calibrationCapturing {
+            finishCalibrationPPGCapture(success: false)
+        }
         // Persist the charging inference BEFORE cancelling tasks (#60): the session is about
         // to be nil-ed by the scanner; ContentView reads from UserDefaults during the
         // reconnect-backoff window so the hint stays live while reconnecting.
@@ -1618,6 +1645,7 @@ final class RingSession: NSObject {
             calibrationFrameSink = onFrame
             calibrationSampleCount = 0
             calibrationMissCount = 0
+            calibrationReenterCount = 0
             calibrationLastFrameAt = Date()
             calibrationCapturing = true
             syncTask?.cancel(); syncTask = nil
@@ -1645,12 +1673,28 @@ final class RingSession: NSObject {
                 while let self, !Task.isCancelled, self.calibrationCapturing {
                     try? await Task.sleep(for: .milliseconds(1500))
                     guard !Task.isCancelled, self.calibrationCapturing else { return }
+                    // #138: the ring dropped but CoreBluetooth hasn't fired `didDisconnect` yet (or
+                    // frames just stopped on a half-open link). Fail promptly instead of re-entering
+                    // PPG mode against a dead peripheral forever (its writes only no-op).
+                    if self.peripheral.state != .connected {
+                        ringLog.notice("calibration: link down mid-capture (state != connected) — failing")
+                        self.finishCalibrationPPGCapture(success: false)
+                        return
+                    }
                     let silentFor = Date().timeIntervalSince(self.calibrationLastFrameAt)
                     if silentFor < 1.4 { continue }
                     self.calibrationMissCount += 1
                     self.write([0x96, 0x01, 0x00, 0x00, 0x00])
                     if self.calibrationMissCount >= 5 {
-                        ringLog.notice("calibration: raw PPG stalled; re-enter mode10+mode01")
+                        // #138: give up after too many re-entries with no recovered frames — the link
+                        // reads as connected but the ring stopped streaming for good (~30 s silence).
+                        self.calibrationReenterCount += 1
+                        if self.calibrationReenterCount > Self.calibrationMaxReenters {
+                            ringLog.notice("calibration: raw PPG stalled through \(Self.calibrationMaxReenters) re-entries with no frames — failing")
+                            self.finishCalibrationPPGCapture(success: false)
+                            return
+                        }
+                        ringLog.notice("calibration: raw PPG stalled; re-enter mode10+mode01 (\(self.calibrationReenterCount)/\(Self.calibrationMaxReenters))")
                         await self.enterCalibrationPPGMode()
                         self.calibrationMissCount = 0
                         self.calibrationLastFrameAt = Date()
@@ -1659,7 +1703,24 @@ final class RingSession: NSObject {
             }
             self.calibrationStopTask = Task { [weak self] in
                 try? await Task.sleep(for: .seconds(duration))
-                self?.finishCalibrationPPGCapture(success: true)
+                guard let self else { return }
+                // #138: don't report success blindly at the duration mark. If the link silently
+                // dropped near the end (no `didDisconnect` yet) or the capture only trickled a few
+                // frames, this is not a usable capture — fail so it isn't uploaded as valid.
+                if self.peripheral.state != .connected {
+                    ringLog.notice("calibration: stop mark reached but link is down — failing")
+                    self.finishCalibrationPPGCapture(success: false)
+                    return
+                }
+                let minSamples = Int(duration * Self.calibrationMinSamplesPerSecond)
+                if self.calibrationSampleCount < minSamples {
+                    ringLog.notice("calibration: stop mark reached with only \(self.calibrationSampleCount) samples (< \(minSamples)) — failing (partial)")
+                    self.finishCalibrationPPGCapture(
+                        success: false,
+                        failureReason: "The ring streamed too few PPG samples — try again and keep still.")
+                    return
+                }
+                self.finishCalibrationPPGCapture(success: true)
             }
         }
     }
@@ -1762,6 +1823,18 @@ final class RingSession: NSObject {
                 kind: .cbWake,
                 success: epochs > 0 || wrote,
                 detail: "\(trigger): \(lastDrainSummary ?? "no summary")")
+            // #146: evaluate body-vital alerts on THIS background wake-drain's data. The BGTask path
+            // (AppDelegate) already evaluates after its drain; the hourly 0x11-wake path — the primary
+            // all-day delivery — did not, so an over-threshold HR/SpO2/temp crossing that arrives on a
+            // wake-drain would otherwise sit silent in the store until app-open. Pass `session: self`
+            // so the evaluator also sees this drain's freshly-decoded `historySamples` on top of the
+            // just-committed store batch. Placed OUTSIDE the HealthKit-available guard: alerts post
+            // local notifications and are independent of Health-mirror authorization. The evaluator's
+            // quiet-hours gate + per-notification `lastFired` backoff dedupe any overlap with the
+            // BGTask path, and the whole await is covered by the surrounding drain assertion.
+            if let localStore {
+                await HealthNotificationCenter().evaluate(store: localStore, session: self)
+            }
         }
         await postMorningSummaryIfNeeded()
     }
@@ -2609,6 +2682,7 @@ extension RingSession: CBPeripheralDelegate {
         guard bytes.count >= 156 else { return }
         calibrationLastFrameAt = Date()
         calibrationMissCount = 0
+        calibrationReenterCount = 0   // #138: a real frame recovered the stream — re-arm the stall ceiling
         let seq = bytes[2]
         let wallClockS = Date().timeIntervalSince1970
         var chA: [Int] = []
@@ -2631,14 +2705,18 @@ extension RingSession: CBPeripheralDelegate {
         calibrationFrameSink?(frame)
     }
 
-    private func finishCalibrationPPGCapture(success: Bool) {
+    private func finishCalibrationPPGCapture(success: Bool, failureReason: String? = nil) {
         calibrationKeepaliveTask?.cancel()
         calibrationKeepaliveTask = nil
         calibrationWatchdogTask?.cancel()
         calibrationWatchdogTask = nil
         calibrationStopTask?.cancel()
         calibrationStopTask = nil
-        if calibrationCapturing {
+        // #138: only exit raw-PPG mode on the ring if the link is still up. On a disconnect the
+        // peripheral is gone and `invalidate()` may have already nil-ed the delegate, so this write
+        // would just no-op with a noisy "unusable link" warning. (`write()` itself also guards on
+        // `.connected`; this makes the intent explicit and keeps the failure path quiet.)
+        if calibrationCapturing, peripheral.state == .connected {
             write([0x06, 0x00, 0x00])
         }
         calibrationCapturing = false
@@ -2646,11 +2724,16 @@ extension RingSession: CBPeripheralDelegate {
         let count = calibrationSampleCount
         calibrationSampleCount = 0
         calibrationMissCount = 0
+        calibrationReenterCount = 0
         calibrationLastFrameAt = .distantPast
         if success {
             calibrationContinuation?.resume(returning: count)
         } else {
-            calibrationContinuation?.resume(throwing: NSError(domain: "OpenCircuit.Calibration", code: 3, userInfo: [NSLocalizedDescriptionKey: "PPG capture failed"]))
+            // #138: make the (previously dead) failure branch real and specific. Default to the
+            // disconnect message — that is the dominant failure (official-app contention, charger,
+            // out of range) — but let callers pass a more precise reason (e.g. a partial capture).
+            let message = failureReason ?? "Ring disconnected — try again"
+            calibrationContinuation?.resume(throwing: NSError(domain: "OpenCircuit.Calibration", code: 3, userInfo: [NSLocalizedDescriptionKey: message]))
         }
         calibrationContinuation = nil
         scheduleDeviceStatusRefresh(reason: "calibration-stop")

--- a/ios/OpenCircuit/CalibrationSessionView.swift
+++ b/ios/OpenCircuit/CalibrationSessionView.swift
@@ -325,12 +325,29 @@ struct CalibrationSessionView: View {
             Text(message)
                 .font(.subheadline)
                 .padding(.horizontal)
-            Button("Start over") {
-                manager.step = .idle
-                manager.statusMessage = ""
+            // #138: if the user already entered cuff readings (i.e. they failed at/after PPG capture),
+            // offer a "Try again" that returns to the capture step with those readings intact instead
+            // of forcing a full restart. "Start over" (fresh session) stays available as a secondary.
+            if !manager.session.bpReadings.isEmpty {
+                Button("Try again") {
+                    manager.retryCapture()
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.horizontal)
+                Button("Start over") {
+                    manager.step = .idle
+                    manager.statusMessage = ""
+                }
+                .buttonStyle(.bordered)
+                .padding(.horizontal)
+            } else {
+                Button("Start over") {
+                    manager.step = .idle
+                    manager.statusMessage = ""
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.horizontal)
             }
-            .buttonStyle(.borderedProminent)
-            .padding(.horizontal)
         }
     }
 

--- a/ios/OpenCircuit/CalibrationSupport.swift
+++ b/ios/OpenCircuit/CalibrationSupport.swift
@@ -262,10 +262,30 @@ final class CalibrationSessionManager: ObservableObject {
                 await fetchAppleWatchHeartRate(start: start, end: end)
                 step = .appleWatchECG
             } catch {
+                // #138: stop the wall-clock countdown the instant the capture throws (a mid-capture
+                // disconnect resolves the continuation immediately, so the countdown must not run on
+                // to 0). The thrown calibration errors are already self-contained, user-facing
+                // messages ("Ring disconnected — try again", "The ring streamed too few PPG
+                // samples…"), so surface them directly rather than double-wrapping.
                 countdownTimer?.invalidate()
-                step = .failed("PPG capture failed: \(error.localizedDescription)")
+                step = .failed(error.localizedDescription)
             }
         }
+    }
+
+    /// #138: retry after a mid-capture failure (e.g. the ring dropped during PPG streaming) WITHOUT
+    /// discarding the SpO2 reference and cuff readings the user already entered — return to the
+    /// blood-pressure step, whose "Start raw PPG capture" button re-runs only the capture once the
+    /// ring reconnects. A full reset stays available via "Start over" (→ `.idle`).
+    func retryCapture() {
+        session.ppgFrames = []
+        session.ppgCaptureStartedAt = nil
+        session.ppgCaptureEndedAt = nil
+        ppgFrameCount = 0
+        step = .bloodPressure
+        statusMessage = session.bpReadings.isEmpty
+            ? "Enter at least one cuff reading before capturing raw PPG."
+            : "\(session.bpReadings.count) blood-pressure reading(s) recorded. Tap Start raw PPG capture to try again."
     }
 
     func skipAppleWatchECG() {


### PR DESCRIPTION
Two BLE-reliability fixes from the 2026-07-04 UX sweep.

Closes #138, closes #146.

## What changed
**#138 — mid-calibration disconnect is now detected.** A ring disconnect during a PPG/BP calibration capture used to report SUCCESS on partial frames and advance to ECG/upload. Now a genuine disconnect (via the scanner's identity-guarded `didDisconnect` → `invalidate()`), a dropped link (watchdog on `peripheral.state != .connected`), or an insufficient-frame trickle ends the capture as a **failure** with a "Ring disconnected — try again" message. "Try again" returns to the BP step with the cuff readings intact and is gated on reconnect.

**#146 — body-vital alerts now evaluate after the hourly `0x11`-wake drains** that actually deliver the data. Added a single `HealthNotificationCenter().evaluate(store:session:)` call in `RingSession.deliverBackgroundResults`, on the wake-drain (`trigger != nil`) path, after the batch is persisted.

## Review & verification
Adversarially reviewed — **SOUND**:
- A normal capture cannot spuriously fail: all three fail paths key off genuine signals (the `calibrationCapturing` guard means a completed capture is never re-failed; `.connected` reflects the real link, not a frame gap; the sample floor sits ~5× below the watchdog's own liveness rate).
- No double-resume crash (continuation resumed once, nil'd atomically on the MainActor) and the countdown Timer is invalidated on the failure path.
- **No double-alert:** the BGTask path calls `deliverBackgroundResults(trigger: nil)` and skips the new evaluate entirely — only the 0x11-wake path fires it — and the evaluator's `lastFired` backoff + quiet-hours gate dedupe regardless.
- `xcodebuild` (generic/iOS, Debug) **BUILD SUCCEEDED**.

## Manual checks (need a physical ring)
Disconnect the ring mid-calibration → capture fails with retry (not a false success); force a 0x11-wake drain carrying a threshold crossing → the body-vital alert fires.

cc @bluna-ai for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
