### PR TITLE
fix(ios): sleep recency — stale-night credit guard + sync-aware missed-night banner (#147 #148)

### DIFF
--- a/ios/OpenCircuit/ContentView.swift
+++ b/ios/OpenCircuit/ContentView.swift
@@ -828,7 +828,7 @@ struct ContentView: View {
     /// so the most recent night stays on screen all day — across reconnects and syncs — and
     /// reflects a just-finished sync instantly via the live staged segments. (See SleepCardView.)
     private var sleepCard: some View {
-        SleepCardView(liveSegments: session?.stagedSegments ?? [])
+        SleepCardView(liveSegments: session?.stagedSegments ?? [], lastSyncAt: lastSyncAt)
     }
 
     /// Workout session card — taps through to WorkoutView (#75).

--- a/ios/OpenCircuit/GoalsCardView.swift
+++ b/ios/OpenCircuit/GoalsCardView.swift
@@ -89,7 +89,21 @@ struct GoalsCardView: View {
         return ExerciseMinutes.estimate(hrSamples: samples, maxHR: maxHR, sleepWindow: sleepWindow)
     }
 
-    private var lastNightSleepMin: Int { latestSleep.first?.asleepMin ?? 0 }
+    /// True when the newest stored night actually ended TODAY, so its minutes may be credited to
+    /// today's Sleep ring. A days-old night (no overnight sync landed) is NOT credited — the ring
+    /// stays empty rather than silently reading a stale night as last night (#147). Uses the SAME
+    /// recency test as the Sleep card's missed-night banner (`MissedNight.endedToday`), so the two
+    /// surfaces can never disagree about what counts as last night.
+    private var sleepCredited: Bool {
+        guard let s = latestSleep.first else { return false }
+        let inBedEnd = s.inBedEnd > s.inBedStart ? s.inBedEnd : nil
+        return MissedNight.endedToday(inBedEnd: inBedEnd, nightKey: s.night)
+    }
+
+    /// Asleep minutes credited to today's ring — the stored night's `asleepMin` only when it ended
+    /// today, else 0 (empty ring). Don't gate on `asleepMin > 0`: a stale night has positive
+    /// minutes too, so recency (not magnitude) is what decides.
+    private var creditedLastNightMin: Int { sleepCredited ? (latestSleep.first?.asleepMin ?? 0) : 0 }
 
     private var sleepGoalMin: Int {
         GoalDefaults.isWeekend() ? weekendSleepMin : workdaySleepMin
@@ -100,7 +114,7 @@ struct GoalsCardView: View {
             steps:           GoalProgress(current: Double(currentSteps),     goal: Double(stepsGoal)),
             activeKcal:      GoalProgress(current: currentActiveKcal,        goal: activeKcalGoal),
             activityMinutes: GoalProgress(current: currentActivityMin,       goal: actMinGoal),
-            sleepMinutes:    GoalProgress(current: Double(lastNightSleepMin), goal: Double(sleepGoalMin))
+            sleepMinutes:    GoalProgress(current: Double(creditedLastNightMin), goal: Double(sleepGoalMin))
         )
     }
 
@@ -130,7 +144,9 @@ struct GoalsCardView: View {
                          color: .blue)
                 goalRing(progress: progress.sleepMinutes,
                          label: "Sleep",
-                         current: formatDuration(lastNightSleepMin),
+                         // "—" (not "0m") when no night ended today, so an empty ring reads as
+                         // "no data yet", never "0 minutes slept" (#147).
+                         current: sleepCredited ? formatDuration(creditedLastNightMin) : "—",
                          goal: formatDuration(sleepGoalMin),
                          color: .purple)
             }

--- a/ios/OpenCircuit/SleepCardView.swift
+++ b/ios/OpenCircuit/SleepCardView.swift
@@ -38,6 +38,12 @@ struct SleepCardView: View {
     /// Freshly staged segments from the just-finished sync (empty when none / after disconnect).
     /// Preferred over the store so a completed sync updates the card immediately.
     var liveSegments: [SleepSegment]
+    /// Completion time of the most recent successful sync/drain (from `ObservabilityStore`), used to
+    /// tell "last night hasn't drained yet" from "you didn't sleep" (#148). A drain that lands AFTER
+    /// this morning's wake yet stages no night ending today is a genuine miss; before that, the
+    /// missing-night banner is suppressed in favour of a soft "not synced yet" note. nil ⇒ never
+    /// synced. Uses the SYNC time, not a sample timestamp (device timestamps can be 60+ min stale).
+    var lastSyncAt: Date?
     /// Sleep-vitals samples (HR / HRV / SpO₂) over the last few days — narrowed in memory to the
     /// resolved night window for the "overnight average" row under the stage breakdown. Bounded
     /// (value-positive + windowed) so it never scans all history (#32), mirroring
@@ -50,8 +56,9 @@ struct SleepCardView: View {
     /// Trailing nights queried for the baseline + temp chart (#69). 35 ≥ the 30-night baseline.
     private static let historyNights = 35
 
-    init(liveSegments: [SleepSegment] = []) {
+    init(liveSegments: [SleepSegment] = [], lastSyncAt: Date? = nil) {
         self.liveSegments = liveSegments
+        self.lastSyncAt = lastSyncAt
         var d = FetchDescriptor<StoredSleepSummary>(sortBy: [SortDescriptor(\.night, order: .reverse)])
         d.fetchLimit = Self.historyNights
         _storedSleep = Query(d)
@@ -141,18 +148,47 @@ struct SleepCardView: View {
         }
     }
 
-    /// True when we're past this morning's expected wake yet the night on screen did NOT end today —
-    /// i.e. last night wasn't captured and we're falling back to an older recorded night. Gated on
-    /// being past the scheduled wake so a mid-sleep glance (e.g. 3 a.m., the night still in progress)
-    /// never claims a miss. Uses the same manual/default schedule the rest of the night gating uses.
-    /// Drives `missedNightNotice` so a stale total never silently reads as last night (the
-    /// overnight-self-contention failure mode).
-    private var lastNightMissing: Bool {
-        guard let night, night.wakeKnown else { return false }
-        let now = Date()
-        let wakeRef = SleepWindow.interval(bedMinutes: bedMinutes, wakeMinutes: wakeMinutes,
-                                           nightEndingNear: now)?.end ?? now
-        return now > wakeRef && !Calendar.current.isDateInToday(night.when)
+    /// Recency of the night on screen, resolved by the shared kit predicate so this card and the
+    /// Daily-Goals Sleep ring (`GoalsCardView`) can never disagree about what counts as last night.
+    /// `.missing` (orange banner) requires: past THIS MORNING'S wake (fixed all day, so it doesn't
+    /// vanish in the evening — #148 Bug 2), the shown night did NOT end today, AND a sync completed
+    /// after wake yet staged no today night. Before such a sync it's `.notSyncedYet` (soft note, not
+    /// an alarming false negative — #148 Bug 1). A legacy rollup with no clock time is never judged.
+    private var recencyStatus: MissedNight.Status {
+        guard let night else { return .ok }
+        return MissedNight.status(now: Date(), bedMinutes: bedMinutes, wakeMinutes: wakeMinutes,
+                                  nightWake: night.wakeKnown ? night.when : nil,
+                                  wakeKnown: night.wakeKnown, lastSyncAt: lastSyncAt)
+    }
+
+    /// True when last night is a genuine miss (drives the orange banner + the Goals-ring agreement
+    /// invariant: whenever this is true the Goals Sleep ring is empty).
+    private var lastNightMissing: Bool { recencyStatus == .missing }
+
+    /// The recency note to show above the stage details, if any: the orange miss banner, the soft
+    /// "not synced yet" note, or nothing.
+    @ViewBuilder
+    private var recencyNotice: some View {
+        switch recencyStatus {
+        case .missing:      missedNightNotice
+        case .notSyncedYet: notSyncedYetNotice
+        case .ok:           EmptyView()
+        }
+    }
+
+    /// Soft, NON-alarming note for the pre-morning-sync gap: last night simply hasn't drained off
+    /// the ring yet (the app stays quiet during sleep and drains are ~hourly), so we don't yet know
+    /// if it was missed. Deliberately not orange — a normal wake-and-open morning must not be told
+    /// "No sleep recorded" (#148 Bug 1).
+    private var notSyncedYetNotice: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "arrow.triangle.2.circlepath").font(.caption2).foregroundStyle(.secondary)
+            Text("Last night hasn’t synced yet. Open OpenCircuit near the ring to pull it in — showing your most recent recorded night until then.")
+                .font(.caption2).foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 6).padding(.horizontal, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.10)))
     }
 
     /// Honest fallback banner shown above the stage details when `lastNightMissing`: last night didn't
@@ -181,7 +217,7 @@ struct SleepCardView: View {
                 }
             }
             if let night {
-                if lastNightMissing { missedNightNotice }
+                recencyNotice
                 content(night)
             } else {
                 emptyState

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/MissedNight.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/MissedNight.swift
@@ -1,0 +1,122 @@
+// Pure, platform-agnostic "is last night actually last night?" date math.
+//
+// Two surfaces used to answer this question independently and could disagree:
+//   • the Daily-Goals Sleep ring (GoalsCardView) credited the newest stored night as "today"
+//     with NO recency guard, so a days-old night filled the ring (#147); and
+//   • the Sleep card's missed-night banner (SleepCardView) fired every morning before the
+//     first sync (false positive) and vanished every evening (the wake reference flipped to
+//     tomorrow's wake) (#148).
+//
+// Both are the SAME underlying "recency" bug, so the decision lives here — one place, unit
+// tested with `swift test`, no SwiftUI/SwiftData — and both cards call it so they can never
+// disagree about what counts as last night or when it is genuinely missing.
+//
+// Invariant that ties the two together: whenever the banner reads `.missing`, the credit is
+// withheld (empty ring). `.missing` requires the shown night did NOT end today, and the credit
+// is granted ONLY when the shown night ended today, so the two are mutually exclusive by
+// construction.
+
+import Foundation
+
+public enum MissedNight {
+
+    /// What the UI should say about the currently-shown night's recency.
+    public enum Status: Equatable {
+        /// Nothing to flag: the shown night ended today, or it's too early / legacy to judge
+        /// (mid-sleep before this morning's wake, or a rollup with no clock time).
+        case ok
+        /// Past this morning's wake with no night ending today, but no sync has completed since
+        /// wake — last night may simply not have drained off the ring yet. Show a soft, neutral
+        /// "not synced yet" note, NOT the alarming miss banner (#148 Bug 1).
+        case notSyncedYet
+        /// Past this morning's wake, a sync DID complete after wake, and still no night ending
+        /// today — the night was genuinely missed. Show the honest orange banner (#148).
+        case missing
+    }
+
+    // MARK: This morning's wake anchor
+
+    /// This morning's wake instant — the wake of the sleep window we are currently in or have
+    /// most recently passed, held FIXED at today's wake for the whole waking day.
+    ///
+    /// `SleepWindow.interval(nightEndingNear:)` returns the wake *nearest* `now`, which after the
+    /// midpoint of the day (≈ wake + 12 h) flips to *tomorrow's* wake — that made the missed-night
+    /// banner disappear every evening (#148 Bug 2). We instead anchor to the window whose bedtime
+    /// we are already at/past: when `now` is before the nearest window's bedtime (evening, or a
+    /// glance before tonight's bed) that nearest window is still in the FUTURE, so we step back a
+    /// day to this morning's (already-past) wake. When `now` is at/after that bedtime — either
+    /// mid-sleep (wake still ahead → `now <= wake`, no miss claimed) or during the day after the
+    /// window ended — the nearest window's wake is the right reference.
+    ///
+    /// - Returns: `nil` only for a degenerate zero-length schedule (`bed == wake`).
+    public static func morningWake(now: Date, bedMinutes: Int, wakeMinutes: Int,
+                                   calendar: Calendar = .current) -> Date? {
+        guard let near = SleepWindow.interval(bedMinutes: bedMinutes, wakeMinutes: wakeMinutes,
+                                              nightEndingNear: now, calendar: calendar)
+        else { return nil }
+        // At/after the nearest window's bedtime → that window's wake is this morning's (it's
+        // ahead only when we're mid-sleep, which the caller's `now > wake` gate handles).
+        if now >= near.start { return near.end }
+        // Before the nearest window's bedtime → it's a future night; step back one day so the
+        // reference stays pinned to the wake we already passed this morning.
+        return SleepWindow.interval(bedMinutes: bedMinutes, wakeMinutes: wakeMinutes,
+                                    nightEndingNear: now.addingTimeInterval(-86_400),
+                                    calendar: calendar)?.end
+    }
+
+    // MARK: Credit recency (#147 — Goals Sleep ring)
+
+    /// The night's wake reference: its real wake time (`inBedEnd`) when known, else the
+    /// start-of-day `night` key. A legacy rollup (`inBedEnd` == `.distantPast`) falls back to the
+    /// key so it can't be credited on a later day.
+    public static func nightWakeReference(inBedEnd: Date?, nightKey: Date) -> Date {
+        inBedEnd ?? nightKey
+    }
+
+    /// Whether the shown night should count as "last night" for crediting — i.e. its wake ended
+    /// today. This is the SAME "ended today" test the miss banner uses (via `nightWake`), so the
+    /// two cards agree: a night ending today is credited AND never flagged missing; a night that
+    /// did not end today is neither credited nor (when a post-wake sync landed) shown as recorded.
+    public static func endedToday(inBedEnd: Date?, nightKey: Date,
+                                  now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        calendar.isDate(nightWakeReference(inBedEnd: inBedEnd, nightKey: nightKey),
+                        inSameDayAs: now)
+    }
+
+    // MARK: Missed-night status (#148 — Sleep card banner)
+
+    /// Classify the shown night's recency for the Sleep card.
+    ///
+    /// - Parameters:
+    ///   - nightWake: the shown night's actual wake (`inBedEnd`); `nil`/`wakeKnown == false` for a
+    ///     legacy rollup with no clock time (never judged).
+    ///   - wakeKnown: whether `nightWake` is a real wake instant.
+    ///   - lastSyncAt: completion time of the most recent successful sync/drain (NOT a sample
+    ///     timestamp — device timestamps can be 60+ min stale). `nil` when none is recorded.
+    public static func status(now: Date, bedMinutes: Int, wakeMinutes: Int,
+                              nightWake: Date?, wakeKnown: Bool,
+                              lastSyncAt: Date?, calendar: Calendar = .current) -> Status {
+        // Legacy rollup with no clock time — can't reason about it (mirror the app's guard).
+        guard wakeKnown, let nightWake else { return .ok }
+        guard let wake = morningWake(now: now, bedMinutes: bedMinutes,
+                                     wakeMinutes: wakeMinutes, calendar: calendar) else { return .ok }
+        // Not yet past this morning's wake (mid-sleep / early) — never claim a miss.
+        guard now > wake else { return .ok }
+        // The shown night already ended today → it IS last night; nothing to flag.
+        guard !calendar.isDate(nightWake, inSameDayAs: now) else { return .ok }
+        // Past wake with a stale night on screen. Only call it a genuine miss once a sync has
+        // actually completed AFTER this morning's wake and still produced no night ending today;
+        // otherwise last night may simply not have drained yet.
+        if let lastSyncAt, lastSyncAt > wake { return .missing }
+        return .notSyncedYet
+    }
+
+    /// Convenience: the honest orange "no sleep recorded" banner should show iff this is `true`.
+    public static func isMissing(now: Date, bedMinutes: Int, wakeMinutes: Int,
+                                 nightWake: Date?, wakeKnown: Bool,
+                                 lastSyncAt: Date?, calendar: Calendar = .current) -> Bool {
+        status(now: now, bedMinutes: bedMinutes, wakeMinutes: wakeMinutes,
+               nightWake: nightWake, wakeKnown: wakeKnown,
+               lastSyncAt: lastSyncAt, calendar: calendar) == .missing
+    }
+}

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/MissedNightTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/MissedNightTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import OpenCircuitKit
+
+// Recency math shared by the Goals Sleep ring credit (#147) and the Sleep-card missed-night
+// banner (#148). Pure date math on a fixed UTC calendar so "local midnight" is deterministic
+// in CI. Schedule under test: bed 22:30 → wake 06:30 (an 8 h window crossing midnight).
+final class MissedNightTests: XCTestCase {
+
+    private var utc: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+
+    private func date(_ iso: String) -> Date {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: iso)!
+    }
+
+    private let bed = 22 * 60 + 30    // 22:30
+    private let wake = 6 * 60 + 30    // 06:30
+
+    // MARK: morningWake — stays pinned to THIS morning's wake all waking day (#148 Bug 2)
+
+    func testMorningWakeMorning() {
+        let w = MissedNight.morningWake(now: date("2026-06-15T08:00:00Z"),
+                                        bedMinutes: bed, wakeMinutes: wake, calendar: utc)
+        XCTAssertEqual(w, date("2026-06-15T06:30:00Z"))
+    }
+
+    func testMorningWakeEveningStillTodaysWake() {
+        // 20:00 — the NEAREST wake is tomorrow 06:30; morningWake must step back to today's 06:30
+        // so the banner doesn't vanish in the evening.
+        let w = MissedNight.morningWake(now: date("2026-06-15T20:00:00Z"),
+                                        bedMinutes: bed, wakeMinutes: wake, calendar: utc)
+        XCTAssertEqual(w, date("2026-06-15T06:30:00Z"))
+    }
+
+    func testMorningWakeLateEveningBeforeBed() {
+        // 22:00, just before tonight's bed — still today's wake.
+        let w = MissedNight.morningWake(now: date("2026-06-15T22:00:00Z"),
+                                        bedMinutes: bed, wakeMinutes: wake, calendar: utc)
+        XCTAssertEqual(w, date("2026-06-15T06:30:00Z"))
+    }
+
+    func testMorningWakeMidSleepIsAheadOfNow() {
+        // 03:00, mid-sleep — this morning's wake (today 06:30) is still AHEAD of now, so the
+        // `now > wake` gate keeps a 3 a.m. glance from ever claiming a miss.
+        let w = MissedNight.morningWake(now: date("2026-06-15T03:00:00Z"),
+                                        bedMinutes: bed, wakeMinutes: wake, calendar: utc)
+        XCTAssertEqual(w, date("2026-06-15T06:30:00Z"))
+        XCTAssertGreaterThan(w!, date("2026-06-15T03:00:00Z"))   // future ⇒ gate false
+    }
+
+    func testMorningWakeDegenerateScheduleNil() {
+        XCTAssertNil(MissedNight.morningWake(now: date("2026-06-15T08:00:00Z"),
+                                             bedMinutes: 390, wakeMinutes: 390, calendar: utc))
+    }
+
+    // MARK: endedToday — the credit gate (#147)
+
+    func testEndedTodayNightEndedToday() {
+        // Night ended this morning (00:24 today) → credited.
+        XCTAssertTrue(MissedNight.endedToday(
+            inBedEnd: date("2026-06-15T06:24:00Z"),
+            nightKey: date("2026-06-14T00:00:00Z"),
+            now: date("2026-06-15T09:00:00Z"), calendar: utc))
+    }
+
+    func testEndedTwoDaysAgoNotCredited() {
+        // A 2-day-old night still has positive minutes but must NOT be credited.
+        XCTAssertFalse(MissedNight.endedToday(
+            inBedEnd: date("2026-06-13T06:30:00Z"),
+            nightKey: date("2026-06-12T00:00:00Z"),
+            now: date("2026-06-15T09:00:00Z"), calendar: utc))
+    }
+
+    func testLegacyDistantPastEndUsesNightKeyNotCredited() {
+        // Legacy rollup: inBedEnd unknown (nil) → falls back to the start-of-day key, which on a
+        // later day is not today → not credited.
+        XCTAssertFalse(MissedNight.endedToday(
+            inBedEnd: nil,
+            nightKey: date("2026-06-13T00:00:00Z"),
+            now: date("2026-06-15T09:00:00Z"), calendar: utc))
+    }
+
+    func testLegacyNightKeyIsTodayIsCredited() {
+        // A legacy rollup whose start-of-day key IS today → credited (best available signal).
+        XCTAssertTrue(MissedNight.endedToday(
+            inBedEnd: nil,
+            nightKey: date("2026-06-15T00:00:00Z"),
+            now: date("2026-06-15T09:00:00Z"), calendar: utc))
+    }
+
+    // MARK: status / isMissing — the banner (#148)
+
+    private func status(now: String, nightWake: Date?, wakeKnown: Bool = true,
+                        lastSyncAt: Date?) -> MissedNight.Status {
+        MissedNight.status(now: date(now), bedMinutes: bed, wakeMinutes: wake,
+                           nightWake: nightWake, wakeKnown: wakeKnown,
+                           lastSyncAt: lastSyncAt, calendar: utc)
+    }
+
+    // The core acceptance case: a STALE stored night (ended 2 days ago) with a post-wake sync.
+    private let staleNight = "2026-06-13T06:30:00Z"
+
+    func testMissingInMorningAfterPostWakeSync() {
+        // 08:00, sync completed at 07:30 (after this morning's 06:30 wake), stale night → missing.
+        XCTAssertEqual(status(now: "2026-06-15T08:00:00Z",
+                              nightWake: date(staleNight),
+                              lastSyncAt: date("2026-06-15T07:30:00Z")), .missing)
+    }
+
+    func testStillMissingInEvening() {
+        // 20:00 same day, same post-wake sync — must STILL be missing (Bug 2 fix).
+        XCTAssertEqual(status(now: "2026-06-15T20:00:00Z",
+                              nightWake: date(staleNight),
+                              lastSyncAt: date("2026-06-15T07:30:00Z")), .missing)
+    }
+
+    func testNotSyncedYetBeforeAnyPostWakeSync() {
+        // 08:00 but the last sync was YESTERDAY (before this morning's wake) → not synced yet,
+        // NOT an alarming miss (Bug 1 fix).
+        XCTAssertEqual(status(now: "2026-06-15T08:00:00Z",
+                              nightWake: date(staleNight),
+                              lastSyncAt: date("2026-06-14T18:00:00Z")), .notSyncedYet)
+    }
+
+    func testNotSyncedYetWhenNoSyncEverRecorded() {
+        XCTAssertEqual(status(now: "2026-06-15T08:00:00Z",
+                              nightWake: date(staleNight),
+                              lastSyncAt: nil), .notSyncedYet)
+    }
+
+    func testNotMissingWhenNightEndedToday() {
+        // Night ended today → ok even long after wake and after a sync.
+        XCTAssertEqual(status(now: "2026-06-15T20:00:00Z",
+                              nightWake: date("2026-06-15T06:24:00Z"),
+                              lastSyncAt: date("2026-06-15T07:30:00Z")), .ok)
+    }
+
+    func testNotMissingMidSleep() {
+        // 03:00 mid-sleep, stale stored night, a sync landed yesterday — must NOT flag a miss
+        // before this morning's wake.
+        XCTAssertEqual(status(now: "2026-06-15T03:00:00Z",
+                              nightWake: date(staleNight),
+                              lastSyncAt: date("2026-06-14T18:00:00Z")), .ok)
+    }
+
+    func testLegacyWakeUnknownNeverMissing() {
+        XCTAssertEqual(status(now: "2026-06-15T08:00:00Z",
+                              nightWake: nil, wakeKnown: false,
+                              lastSyncAt: date("2026-06-15T07:30:00Z")), .ok)
+    }
+
+    // The exact acceptance assertions spelled out in #148.
+    func testAcceptanceIsMissingMatrix() {
+        func missing(_ now: String, _ sync: Date?) -> Bool {
+            MissedNight.isMissing(now: date(now), bedMinutes: bed, wakeMinutes: wake,
+                                  nightWake: date(staleNight), wakeKnown: true,
+                                  lastSyncAt: sync, calendar: utc)
+        }
+        XCTAssertTrue(missing("2026-06-15T08:00:00Z", date("2026-06-15T07:30:00Z")))   // post-wake sync
+        XCTAssertTrue(missing("2026-06-15T20:00:00Z", date("2026-06-15T07:30:00Z")))   // evening, same
+        XCTAssertFalse(missing("2026-06-15T08:00:00Z", date("2026-06-14T18:00:00Z")))  // no post-wake sync
+    }
+
+    // MARK: cross-check the invariant that ties #147 and #148 together
+
+    func testMissingImpliesCreditWithheld() {
+        // For every hour of the day, whenever the banner says `.missing`, the credit gate must be
+        // false (empty ring) — the two surfaces can never contradict.
+        for hour in 0..<24 {
+            let now = date(String(format: "2026-06-15T%02d:00:00Z", hour))
+            let st = MissedNight.status(now: now, bedMinutes: bed, wakeMinutes: wake,
+                                        nightWake: date(staleNight), wakeKnown: true,
+                                        lastSyncAt: date("2026-06-15T07:30:00Z"), calendar: utc)
+            if st == .missing {
+                XCTAssertFalse(MissedNight.endedToday(inBedEnd: date(staleNight),
+                                                      nightKey: date("2026-06-12T00:00:00Z"),
+                                                      now: now, calendar: utc),
+                               "credit must be withheld while banner is .missing @\(hour)h")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two sleep-recency trust fixes from the 2026-07-04 UX sweep — a stale night must not read as "last night."

Closes #147, closes #148.

## What changed
A new pure, unit-tested `OpenCircuitKit/MissedNight.swift` recency predicate is the single source of truth used by **both** surfaces, so the credit and the banner agree by construction.

**#147 — the Daily Goals sleep ring no longer credits a days-old night as today.** When no night actually ended today it shows 0% / "—" instead of replaying the last recorded night's minutes.

**#148 — the missed-night banner is now sync-aware.** Before the morning sync it shows a soft "not synced yet" note (no false "you didn't sleep"); the real orange miss banner appears only once a sync *after* wake confirms there's still no night; and it stays through the evening instead of vanishing every night.

## Review & verification
Adversarially reviewed — **SOUND** (with only low/by-design nits):
- The `morningWake` date-math was deliberately corrected vs the issue's literal "step back a day" spec, which would fire a **false miss during a 3 a.m. glance**. Verified across all 24h for a typical schedule plus exotic ones (wake==bed, after-midnight, non-midnight-crossing).
- A mutation test (reverting `morningWake` to the naive version) produces 4 real failures — the guard is load-bearing, not vacuous.
- The `.missing` state is gated on `lastSyncAt > morningWake` using the existing `lastSuccessfulSync` watermark (no new persistence), closing the pre-sync false-positive without permanently suppressing a genuine miss.
- `swift test` **650 tests, 0 failures** (18 new); app **BUILD SUCCEEDED**.

## Note for reviewers
The two surfaces agree by shared *predicate*; right after a fresh sync the Sleep card may briefly show today's night (from live segments) while the Goals ring still reads "—" until its `@Query` publishes — transient and in the safe (under-credit) direction.

cc @bluna-ai for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
