### PR TITLE
fix(ios): escalate provisional→full notification auth on alert opt-in + denied-notifs banner (#133 #136)

### DIFF
--- a/ios/OpenCircuit/HealthNotificationCenter.swift
+++ b/ios/OpenCircuit/HealthNotificationCenter.swift
@@ -1,6 +1,7 @@
 import Foundation
 import OpenCircuitKit
 import UserNotifications
+import UIKit
 
 // THE shared local-notification service for health alerts (#73) and skin-temp/fever
 // notifications (#85). There is exactly ONE of these engines: a single quiet-hours/DND window,
@@ -378,8 +379,9 @@ struct HealthNotificationCenter {
 
     /// UserDefaults flag: we've already attempted the one-time provisional→full upgrade prompt for
     /// the opted-in body-vital alerts (#133). iOS only ever presents that upgrade prompt once, so
-    /// this stops us re-attempting on every toggle/alert fire and makes a decline stick (delivery
-    /// then falls back to the quiet provisional grant). Shared by the engine's `ensureAuthorized()`
+    /// this stops us re-attempting on every toggle/alert fire and makes the user's choice stick —
+    /// "Keep Delivering Quietly" stays provisional (silent), "Turn Off" → `.denied` (the #136 banner
+    /// then surfaces so they can re-enable). Shared by the engine's `ensureAuthorized()`
     /// and the Settings opt-in path (`requestFullAuthorizationIfNeeded`).
     static let fullAuthRequestedKey = "alerts.health.fullAuthRequested"
 
@@ -415,8 +417,9 @@ struct HealthNotificationCenter {
     /// loudly instead of silently.
     ///
     /// Idempotent + flag-guarded (`fullAuthRequestedKey`): attempts the upgrade at most once, since
-    /// iOS shows the provisional→explicit prompt only a single time. A prior decline is respected
-    /// (we don't nag; delivery falls back to provisional). Already-authorized/ephemeral is a no-op.
+    /// iOS shows the provisional→explicit prompt only a single time. A prior choice is respected
+    /// (we don't nag): "Keep Delivering Quietly" stays provisional, "Turn Off" → `.denied`.
+    /// Already-authorized/ephemeral is a no-op.
     /// Deliberately leaves the morning-summary (`RingSession`) / observability (`ObservabilityStore`)
     /// request sites untouched — those are SUPPOSED to stay provisional.
     func requestFullAuthorizationIfNeeded() async {
@@ -424,6 +427,14 @@ struct HealthNotificationCenter {
         guard !defaults.bool(forKey: Self.fullAuthRequestedKey) else { return }
         switch await center.notificationSettings().authorizationStatus {
         case .notDetermined, .provisional:
+            // iOS can only present the permission prompt while the app is FOREGROUND-ACTIVE. If we
+            // requested here in the background — e.g. an opted-in alert firing during an hourly
+            // wake-drain, and these alerts are ON BY DEFAULT — no prompt would appear, yet the
+            // one-shot flag below would still be burned, permanently stranding a provisional user
+            // (#133). So gate on `.active`: a background provisional fire still DELIVERS (the caller
+            // `ensureAuthorized()` returns true for `.provisional`), and the flag stays unburned so
+            // the next foreground eval or the Settings toggle presents the real upgrade prompt.
+            guard UIApplication.shared.applicationState == .active else { return }
             // Foreground: iOS presents the standard opt-in prompt (or the provisional→explicit
             // upgrade prompt). Mark attempted regardless of the result — the prompt is one-shot.
             _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])

--- a/ios/OpenCircuit/HealthNotificationCenter.swift
+++ b/ios/OpenCircuit/HealthNotificationCenter.swift
@@ -376,18 +376,65 @@ struct HealthNotificationCenter {
         store.markFired(fire)
     }
 
+    /// UserDefaults flag: we've already attempted the one-time provisional→full upgrade prompt for
+    /// the opted-in body-vital alerts (#133). iOS only ever presents that upgrade prompt once, so
+    /// this stops us re-attempting on every toggle/alert fire and makes a decline stick (delivery
+    /// then falls back to the quiet provisional grant). Shared by the engine's `ensureAuthorized()`
+    /// and the Settings opt-in path (`requestFullAuthorizationIfNeeded`).
+    static let fullAuthRequestedKey = "alerts.health.fullAuthRequested"
+
     /// Request notification authorization LAZILY — only the first time there's actually something
     /// to post, so a user who never crosses a threshold is never prompted. These are alerts the
     /// user opted into in Settings, so we request a standard (visible) authorization.
     private func ensureAuthorized() async -> Bool {
         let settings = await center.notificationSettings()
         switch settings.authorizationStatus {
-        case .authorized, .provisional, .ephemeral:
+        case .authorized, .ephemeral:
+            return true
+        case .provisional:
+            // A provisional-only grant (won first by the nightly morning-summary / observability
+            // paths, #133) delivers EVERY notification silently — including the high-HR / low-SpO2 /
+            // fever alerts the user opted into. Attempt the one-time upgrade to full alert+sound+badge
+            // so those surface with a banner + sound, then deliver regardless of the outcome:
+            // provisional delivery still beats dropping the alert. This does NOT touch the provisional
+            // REQUEST sites in RingSession / ObservabilityStore — those stay quiet by design.
+            await requestFullAuthorizationIfNeeded()
             return true
         case .notDetermined:
             return (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
         default:
             return false
+        }
+    }
+
+    /// Escalate a provisional (or not-yet-determined) grant to FULL alert+sound+badge notification
+    /// authorization for the opted-in body-vital alerts (#133). Call from a FOREGROUND consent
+    /// moment — the Settings ▸ Health-alerts opt-in toggles — where iOS can actually present the
+    /// prompt (a background wake-drain cannot). This pre-empts the provisional grant that the
+    /// morning-summary / observability paths would otherwise win first, so an enabled alert delivers
+    /// loudly instead of silently.
+    ///
+    /// Idempotent + flag-guarded (`fullAuthRequestedKey`): attempts the upgrade at most once, since
+    /// iOS shows the provisional→explicit prompt only a single time. A prior decline is respected
+    /// (we don't nag; delivery falls back to provisional). Already-authorized/ephemeral is a no-op.
+    /// Deliberately leaves the morning-summary (`RingSession`) / observability (`ObservabilityStore`)
+    /// request sites untouched — those are SUPPOSED to stay provisional.
+    func requestFullAuthorizationIfNeeded() async {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: Self.fullAuthRequestedKey) else { return }
+        switch await center.notificationSettings().authorizationStatus {
+        case .notDetermined, .provisional:
+            // Foreground: iOS presents the standard opt-in prompt (or the provisional→explicit
+            // upgrade prompt). Mark attempted regardless of the result — the prompt is one-shot.
+            _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
+            defaults.set(true, forKey: Self.fullAuthRequestedKey)
+        case .authorized, .ephemeral:
+            // Already delivering visibly — record so we skip the probe next time.
+            defaults.set(true, forKey: Self.fullAuthRequestedKey)
+        default:
+            // .denied: respect it (the Settings banner, #136, is where the user re-enables). Leave
+            // the flag unset so a later re-enable can still upgrade to full when it next fires.
+            break
         }
     }
 

--- a/ios/OpenCircuit/UserProfile.swift
+++ b/ios/OpenCircuit/UserProfile.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import UIKit
+import UserNotifications
 import OpenCircuitKit
 
 @MainActor
@@ -96,6 +98,13 @@ struct UserProfileSettingsView: View {
     @AppStorage(HealthAlertDefaults.quietEnabled) private var quietEnabled = false
     @AppStorage(HealthAlertDefaults.quietStartMinutes) private var quietStart = HealthAlertDefaults.defaultQuietStart
     @AppStorage(HealthAlertDefaults.quietEndMinutes) private var quietEnd = HealthAlertDefaults.defaultQuietEnd
+
+    /// System notification-authorization status, surfaced so the alert / quiet-hours / reminder
+    /// settings warn when delivery is off (#136). Refreshed on appear + on scene-active (the user
+    /// may flip it in iOS Settings while away). `.provisional`/`.ephemeral` still deliver (quietly),
+    /// so they are treated as OK — no banner. Read-only here: opening Settings never itself requests
+    /// authorization (the lazy-prompt design is preserved).
+    @State private var notifStatus: UNAuthorizationStatus = .notDetermined
 
     var body: some View {
         Form {
@@ -285,19 +294,23 @@ struct UserProfileSettingsView: View {
             }
 
             Section("Health alerts") {
+                notifAuthBanner
                 Toggle("High heart rate", isOn: $highHREnabled)
+                    .onChange(of: highHREnabled) { _, on in escalateNotifAuth(enabled: on) }
                 if highHREnabled {
                     Stepper(value: $highHRBpm, in: 80...200, step: 5) {
                         LabeledContent("Notify above", value: "\(highHRBpm) bpm")
                     }
                 }
                 Toggle("Low blood oxygen", isOn: $lowSpO2Enabled)
+                    .onChange(of: lowSpO2Enabled) { _, on in escalateNotifAuth(enabled: on) }
                 if lowSpO2Enabled {
                     Stepper(value: $lowSpO2Percent, in: 80...99) {
                         LabeledContent("Notify below", value: "\(lowSpO2Percent)%")
                     }
                 }
                 Toggle("Elevated HR while inactive", isOn: $elevatedHREnabled)
+                    .onChange(of: elevatedHREnabled) { _, on in escalateNotifAuth(enabled: on) }
                 if elevatedHREnabled {
                     Stepper(value: $elevatedHRBpm, in: 80...160, step: 5) {
                         LabeledContent("Sustained above", value: "\(elevatedHRBpm) bpm")
@@ -307,10 +320,17 @@ struct UserProfileSettingsView: View {
                         .font(.caption).foregroundStyle(.secondary)
                 }
                 Toggle("Skin-temp & fever alerts", isOn: $tempFeverEnabled)
+                    .onChange(of: tempFeverEnabled) { _, on in escalateNotifAuth(enabled: on) }
                 Text("Note: OpenCircuit is not a medical device. These reminders are based on ring "
                      + "sensor data only and are not a diagnosis. If you feel unwell, consult a "
                      + "qualified medical professional.")
                     .font(.caption2).foregroundStyle(.secondary)
+            }
+            .task { await refreshNotifAuthState() }
+            .onChange(of: scenePhase) { _, phase in
+                // Coming back from iOS Settings: reflect a freshly-flipped notification switch
+                // (enabled or disabled) in the banner without an app relaunch (#136).
+                if phase == .active { Task { await refreshNotifAuthState() } }
             }
 
             Section("Women's health") {
@@ -432,6 +452,56 @@ struct UserProfileSettingsView: View {
             // nil = status unknown (entitlement-stripped sideload): keep the Connect button so
             // its tap path can throw and surface the sideload notice, as before.
             healthPromptExhausted = (await health.authorizationPromptAvailable()) == false
+        }
+    }
+
+    // MARK: Notification-auth banner (#136) + full-auth escalation (#133)
+
+    /// Warns when notifications can't reach the user so the alert / quiet-hours / reminder controls
+    /// below don't read as "armed" when they're silently dropped (#136). Shown once at the top of the
+    /// "Health alerts" section — it visually covers Quiet hours and Reminders too, which share the
+    /// same app-wide authorization. `.authorized`/`.provisional`/`.ephemeral` all still deliver, so
+    /// no banner then. Mirrors the "dead button" precedent in the Apple Health section above.
+    @ViewBuilder private var notifAuthBanner: some View {
+        switch notifStatus {
+        case .denied:
+            Label {
+                Text("Notifications are turned off for OpenCircuit, so no alerts or reminders "
+                     + "can be delivered.")
+            } icon: {
+                Image(systemName: "bell.slash.fill").foregroundStyle(.orange)
+            }
+            Button {
+                if let url = URL(string: UIApplication.openSettingsURLString) { openURL(url) }
+            } label: {
+                Label("Turn On in Settings", systemImage: "arrow.up.forward.app")
+            }
+        case .notDetermined:
+            // Soft hint only — matches the lazy-authorization design (the engine prompts on the
+            // first real post, #133). Do NOT eagerly request auth from this screen.
+            Text("iOS will ask permission the first time an alert needs to fire.")
+                .font(.caption).foregroundStyle(.secondary)
+        default:
+            EmptyView()
+        }
+    }
+
+    /// Read (never request) the system notification-authorization status for the banner (#136).
+    private func refreshNotifAuthState() async {
+        notifStatus = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+    }
+
+    /// Opting into a body-vital alert is a foreground consent moment: escalate a provisional (or
+    /// not-yet-determined) grant to FULL alert+sound+badge auth so the alert the user JUST enabled
+    /// won't deliver silently under a provisional grant the morning-summary/observability paths won
+    /// first (#133). No-op when the toggle is turned OFF. The one-time flag guard + the actual
+    /// request live in `HealthNotificationCenter.requestFullAuthorizationIfNeeded()` so the engine
+    /// and the UI share one policy. Refreshes the banner afterward to reflect the new grant.
+    private func escalateNotifAuth(enabled: Bool) {
+        guard enabled else { return }
+        Task {
+            await HealthNotificationCenter().requestFullAuthorizationIfNeeded()
+            await refreshNotifAuthState()
         }
     }
 


### PR DESCRIPTION
Two notification-trust fixes from the 2026-07-04 UX sweep.

Closes #133, closes #136.

## What changed
**#133 (P1) — opting into a health alert now escalates provisional → FULL authorization.** A provisional notification grant (won early by the morning-summary / observability paths) delivers *everything silently* — including the high-HR / low-SpO₂ / fever alerts the user explicitly enabled. Now enabling an alert toggle (and the foreground alert-eval path) requests full alert+sound+badge authorization so those surface loudly. The provisional **request** sites in `RingSession` / `ObservabilityStore` are untouched — they stay quiet by design; only the alert opt-in escalates.

**#136 — the Alerts settings now warn when notifications are denied**, with a banner + a working deep link to the app's Settings page, so a silently-dropped alert/reminder is discoverable.

## Review & verification
Adversarially reviewed — it caught a **P1 blocker**, now fixed:
- The one-shot escalation flag could be **burned by a background alert fire** (alerts are on by default → an hourly wake-drain fires one) via a `requestAuthorization` that iOS never presents while backgrounded — stranding the exact provisional user #133 targets, permanently silent. Fixed by gating the request + flag-set on `applicationState == .active`: a background provisional fire still delivers (quietly), the flag stays unburned, and the next foreground eval or Settings toggle presents the real upgrade prompt.
- Verified: provisional request sites unchanged; `ensureAuthorized` delivery semantics + de-dupe ordering preserved; #136 banner correct for denied and silent for authorized/provisional; no `requestAuthorization` fired merely on appearing.
- `xcodebuild` (generic/iOS, Debug) **BUILD SUCCEEDED**.

## Manual checks
As a provisional user, enable a health alert in Settings → the iOS upgrade prompt appears (foreground); deny notifications in iOS Settings → the in-app banner appears with a working "Open Settings" link that clears on return.

cc @bluna-ai for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
