### PR TITLE
fix(ios): alert & reminder firing policy — activity-gated high-HR, quiet-hours bedtime, post-sync sedentary (#137 #144 #145)

### DIFF
--- a/ios/OpenCircuit/ContentView.swift
+++ b/ios/OpenCircuit/ContentView.swift
@@ -167,6 +167,11 @@ struct ContentView: View {
                     recordForegroundSync()
                     flushHealth()
                     evaluateHealthAlerts()   // #73/#85: a fresh sync may cross a threshold
+                    // #145: evaluate the sedentary reminder only now, against the freshly-synced
+                    // `lastActivityAt` — so it can't fire on stale pre-sync data right after a walk.
+                    // This runs whenever syncing flips to false (even if no new frames), so a
+                    // genuinely-inactive user still gets the nudge.
+                    evaluateReminders(includeSedentary: true)
                 }
             }
             .onChange(of: session?.monitoring) { _, monitoring in
@@ -366,13 +371,18 @@ struct ContentView: View {
         let battery = session?.batteryPercent
         Task { await LocalAlertCenter().evaluate(batteryPercent: battery, healthAuthorized: authorized) }
         evaluateHealthAlerts()
-        evaluateReminders()
+        // Pre-sync pass: wear + bedtime only. The sedentary rule is deferred to the post-sync
+        // handler so it never fires on a stale `lastActivityAt` right after activity (#145).
+        evaluateReminders(includeSedentary: false)
     }
 
-    /// Evaluate the three app-side reminders (#84: sedentary / wear / bedtime) against the
-    /// current session and persisted UserDefaults state, routing survivors through the shared
-    /// notification engine (quiet hours + anti-spam backoff).
-    private func evaluateReminders() {
+    /// Evaluate the app-side reminders (#84: sedentary / wear / bedtime) against the current
+    /// session and persisted UserDefaults state, routing survivors through the shared notification
+    /// engine (quiet hours + anti-spam backoff). `includeSedentary` is `false` on the pre-sync
+    /// scene-active pass so the move reminder never fires on a stale `lastActivityAt` (#145); it is
+    /// evaluated with `true` only after a foreground sync lands fresh step data. Wear + bedtime run
+    /// on every pass since they don't depend on fresh steps.
+    private func evaluateReminders(includeSedentary: Bool) {
         let d = UserDefaults.standard
         SleepScheduleDefaults.register(d)
         let bedMinutes  = d.integer(forKey: SleepScheduleDefaults.bedMinutes)
@@ -384,7 +394,8 @@ struct ContentView: View {
                 session: s,
                 sleepBedMinutes: bedMinutes,
                 sleepWakeMinutes: wakeMinutes,
-                sleepEnabled: sleepEnabled)
+                sleepEnabled: sleepEnabled,
+                includeSedentary: includeSedentary)
         }
     }
 

--- a/ios/OpenCircuit/HealthNotificationCenter.swift
+++ b/ios/OpenCircuit/HealthNotificationCenter.swift
@@ -213,9 +213,30 @@ struct HealthNotificationCenter {
                 .map { SpO2Reading(percent: Int(($0.value * 100).rounded()), time: $0.start) }
         }
 
-        // The sustained-while-inactive rule reads the same HR series over the same wide window; its
-        // own `lastFired` filter inside the evaluator gives it once-per-event de-dupe.
-        for hit in HealthAlertEvaluator.evaluate(hr: hr, spo2: spo2, inactiveHR: hr,
+        // --- #144: activity gate for the HR rules ------------------------------------------------
+        // Exercise HR routinely crosses 120 bpm, so the raw high-HR / elevated-while-inactive rules
+        // would fire a false "high heart rate" alarm after every workout. Gate them on concurrent
+        // step activity. Steps live ONLY in `StoredStepSample` (persisted by `addDailySteps`), NOT in
+        // the `StoredSample` table that `recentSamples`/`historySamples` read — those carry only
+        // HR/HRV/SpO2/RR/temp — so the windows MUST come from `stepSamples(from:to:)`. By the time we
+        // evaluate (post-sync in the foreground, post-drain in the background) the sync has already
+        // committed the same-window step rows, so this reads the freshly-synced activity.
+        //
+        // `activeStepIntervals` drops zero-delta windows AND the day-wide `[startOfDay, sampleDate]`
+        // fallback window that a fresh-baseline / rollover reading records (that guard is
+        // safety-critical — a multi-hour window would suppress a genuine resting crossing). Steps and
+        // HR share device timestamps, so they line up by device time. SpO2 is NOT gated. With no
+        // step windows the series is returned unchanged, so a real resting crossing still alerts.
+        let stepWindows = ((try? localStore.stepSamples(from: instantSince, to: now)) ?? [])
+            .map { StepWindow(start: $0.start, end: $0.end, delta: $0.delta) }
+        let stepIntervals = HealthAlertEvaluator.activeStepIntervals(stepWindows)
+        let nonExercisingHR = HealthAlertEvaluator.nonExercising(hr, activeIntervals: stepIntervals)
+
+        // Both the instantaneous high-HR and the sustained-while-inactive rule read the non-exercising
+        // series over the same wide window; the evaluator's own `lastFired` filter gives once-per-event
+        // de-dupe. SpO2 (`spo2`) is passed unfiltered — its rule is unaffected by the activity gate.
+        for hit in HealthAlertEvaluator.evaluate(hr: nonExercisingHR, spo2: spo2,
+                                                 inactiveHR: nonExercisingHR,
                                                  thresholds: thresholds,
                                                  lastFired: lastFired) {
             candidates.append(hit.notification)
@@ -306,15 +327,24 @@ struct HealthNotificationCenter {
     /// call liberally — a no-op when nothing crosses a threshold or everything is held by
     /// the gate. Pass `sleepEnabled = true` and the configured bed/wake minutes to enable
     /// the bedtime reminder; pass `sleepEnabled = false` to skip it.
+    ///
+    /// `includeSedentary` (#145): the sedentary rule reads the persisted `lastActivityAt`, which is
+    /// STALE before a foreground sync lands the walk's step delta — so evaluating it pre-sync fires a
+    /// false "time to move!" right after activity (and the 2h backoff then suppresses the real one).
+    /// The caller passes `false` on the plain scene-active pass (wear + bedtime still evaluate there,
+    /// since they don't need fresh step data) and `true` only after a sync completes, so the rule
+    /// runs against fresh data.
     func evaluateReminders(session: RingSession?,
                            sleepBedMinutes: Int, sleepWakeMinutes: Int, sleepEnabled: Bool,
+                           includeSedentary: Bool = true,
                            now: Date = Date()) async {
         ReminderDefaults.register()
         let d = UserDefaults.standard
         var candidates: [HealthNotification] = []
 
-        // Sedentary / move reminder
-        if d.bool(forKey: ReminderDefaults.sedentaryEnabled) {
+        // Sedentary / move reminder — only when `includeSedentary` (post-sync), so it never fires on
+        // a stale pre-sync `lastActivityAt` reading (#145).
+        if includeSedentary, d.bool(forKey: ReminderDefaults.sedentaryEnabled) {
             let interval = TimeInterval(d.integer(forKey: ReminderDefaults.sedentaryIntervalMin)) * 60
             let r = SedentaryReminder(interval: max(interval, 10 * 60))
             let lastActivityEpoch = d.double(forKey: ReminderDefaults.lastActivityAt)
@@ -356,7 +386,18 @@ struct HealthNotificationCenter {
 
         guard !candidates.isEmpty else { return }
         let quiet = HealthAlertDefaults.quietHours()
-        let fire = gate.filter(candidates, now: now, lastFired: store.lastFired(), quietHours: quiet)
+        let lastFired = store.lastFired()
+        // #137: the bedtime reminder is a user-SCHEDULED wind-down self-reminder, not a body-vital
+        // alert the user is trying to mute overnight. Its only firing window is
+        // [bed − minutesBefore, bed), which for a typical post-22:00 bedtime falls entirely inside the
+        // default 22:00–07:00 quiet window — so routing it through the shared quiet gate would suppress
+        // it every single night. Split it out: bedtime bypasses the quiet-hours mute but STILL gets the
+        // anti-spam backoff (via `lastFired`), so it fires at most once per night. Every OTHER reminder
+        // (wear / sedentary) stays under the quiet gate unchanged — no regression to the overnight mute.
+        let bedtime = candidates.filter { $0 == .bedtimeReminder }
+        let others  = candidates.filter { $0 != .bedtimeReminder }
+        var fire = gate.filter(others, now: now, lastFired: lastFired, quietHours: quiet)
+        fire += gate.filter(bedtime, now: now, lastFired: lastFired, quietHours: QuietHours(enabled: false))
         guard !fire.isEmpty, await ensureAuthorized() else { return }
         for n in fire { await post(n, hit: nil) }
         store.markFired(fire, at: now)

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/HealthAlerts.swift
@@ -140,6 +140,19 @@ public struct HealthAlertThresholds: Equatable, Sendable {
     }
 }
 
+/// One step-count snapshot's observation window + delta, carrying the device's own timestamps.
+/// A pure value type so the #144 activity-gate math is testable off the app's SwiftData
+/// `StoredStepSample` model (which is app-target-only). The app maps each `StoredStepSample` to one
+/// of these before handing them to `activeStepIntervals`.
+public struct StepWindow: Equatable, Sendable {
+    public let start: Date
+    public let end: Date
+    public let delta: Int
+    public init(start: Date, end: Date, delta: Int) {
+        self.start = start; self.end = end; self.delta = delta
+    }
+}
+
 /// One fired alert with the reading that triggered it (for the "… detected at [time]" copy).
 public struct HealthAlertHit: Equatable, Sendable {
     public let notification: HealthNotification
@@ -191,6 +204,55 @@ public enum HealthAlertEvaluator {
             if let rs = runStart, s.start.timeIntervalSince(rs) >= minDuration { return s }
         }
         return nil
+    }
+
+    /// Default cap on a step snapshot's window width still treated as a discrete activity burst
+    /// (#144). Normal per-reading step windows are the gap between two step readings — seconds on the
+    /// live poll, up to a few minutes across a background drain — comfortably under this. A window
+    /// WIDER than this is the day-wide `[startOfDay, sampleDate]` FALLBACK that `StoredStepSample`
+    /// records on a fresh baseline / day rollover (no prior same-day reading to anchor to); those run
+    /// to multiple hours and must be excluded from the gate (see `activeStepIntervals`). Chosen short
+    /// on purpose: it cleanly excludes every hours-long fallback, and erring short only risks
+    /// under-gating (an occasional post-workout false alarm) — never the catastrophic direction of
+    /// suppressing a real cardiac crossing.
+    public static let maxActivityWindow: TimeInterval = 30 * 60
+
+    /// Build the concurrent-activity intervals for the HR gate (#144) from step snapshots, dropping:
+    ///  - zero/negative-`delta` windows (no actual movement), and
+    ///  - windows WIDER than `maxActivityWindow` — the day-wide `[startOfDay, sampleDate]` FALLBACK
+    ///    `StoredStepSample` records on a fresh baseline / day rollover. This exclusion is
+    ///    SAFETY-CRITICAL: feeding a multi-hour fallback window into `nonExercising` would suppress
+    ///    EVERY HR crossing since midnight — including a genuine resting tachycardia — a health-safety
+    ///    false negative, the worst outcome. Excluding it costs at most an occasional missed gate (a
+    ///    post-workout false alarm), which is the far safer failure direction.
+    public static func activeStepIntervals(_ steps: [StepWindow],
+                                           maxActivityWindow: TimeInterval = maxActivityWindow)
+    -> [(Date, Date)] {
+        steps.filter { $0.delta > 0 && $0.end.timeIntervalSince($0.start) <= maxActivityWindow }
+             .map { ($0.start, $0.end) }
+    }
+
+    /// Drop HR samples that overlap concurrent step activity (or its `pad`-long recovery tail), so
+    /// exercise heart rate can't trip the resting high-HR / elevated-while-inactive alarms (#144).
+    /// A sample is EXCLUDED when its device timestamp `start` lies inside any `activeIntervals`
+    /// window `[from, to]` — or within `pad` after `to`, covering the post-exercise HR recovery
+    /// tail. Match is by the DEVICE timestamps carried on BOTH series (never wall-clock arrival):
+    /// all-day HR and steps ride in on the same ~hourly background drains with timestamps 30–60+
+    /// min old, so only their device times line up.
+    ///
+    /// KEY SAFETY PROPERTY: this only ever SUPPRESSES on positive evidence of concurrent activity.
+    /// An empty `activeIntervals` (no step data synced for the window) returns the series unchanged,
+    /// so a genuine resting tachycardia with no steps still fires and missing step data can never
+    /// silence a real alert. It never narrows the lookback window — it filters by activity overlap,
+    /// not recency.
+    public static func nonExercising(_ hr: [HRSample], activeIntervals: [(Date, Date)],
+                                     pad: TimeInterval = 10 * 60) -> [HRSample] {
+        guard !activeIntervals.isEmpty else { return hr }
+        return hr.filter { sample in
+            !activeIntervals.contains { interval in
+                sample.start >= interval.0 && sample.start <= interval.1.addingTimeInterval(pad)
+            }
+        }
     }
 
     /// Evaluate all three #73 rules and return the hits (disabled rules are skipped). `inactiveHR`

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HealthAlertsTests.swift
@@ -158,6 +158,124 @@ final class HealthAlertsTests: XCTestCase {
         XCTAssertTrue(hits.isEmpty, "already-fired crossings must not replay on the next drain")
     }
 
+    // MARK: #144 activity gate (nonExercising)
+
+    func testNonExercisingDropsHROverlappingSteps() {
+        // A high HR concurrent with a stepping window is dropped; a high HR in a still window survives.
+        let stepping = (at(10, 0), at(10, 20))          // 20-min walk
+        let series = [hr(165, 10, 10),                  // during the walk → excluded
+                      hr(122, 14, 0)]                   // still period → kept
+        let filtered = HealthAlertEvaluator.nonExercising(series, activeIntervals: [stepping], pad: 10 * 60)
+        XCTAssertEqual(filtered.map(\.bpm), [122])
+    }
+
+    func testNonExercisingExcludesRecoveryTail() {
+        // A crossing within the `pad` recovery tail AFTER the walk ends is still excluded…
+        let stepping = (at(10, 0), at(10, 20))
+        let inTail = [hr(150, 10, 25)]                  // 5 min after the walk, inside the 10-min pad
+        XCTAssertTrue(HealthAlertEvaluator.nonExercising(inTail, activeIntervals: [stepping], pad: 10 * 60).isEmpty)
+        // …but beyond the pad it survives (recovery is over).
+        let afterTail = [hr(150, 10, 35)]               // 15 min after → outside the 10-min pad
+        XCTAssertEqual(HealthAlertEvaluator.nonExercising(afterTail, activeIntervals: [stepping], pad: 10 * 60).count, 1)
+    }
+
+    func testNonExercisingNoStepDataSuppressesNothing() {
+        // Missing step data must NEVER silence a real crossing — empty intervals returns the series as-is.
+        let series = [hr(165, 10, 10), hr(122, 14, 0)]
+        XCTAssertEqual(HealthAlertEvaluator.nonExercising(series, activeIntervals: [], pad: 10 * 60), series)
+    }
+
+    func testNonExercisingGatedEvaluateOnlyAlertsStillCrossing() {
+        // End-to-end: gate a mixed series then evaluate. The exercising 165 bpm is suppressed while the
+        // still-period resting crossing (128 bpm, no concurrent steps) still fires exactly once (#144).
+        let thresholds = HealthAlertThresholds(highHRBpm: 120, lowSpO2Enabled: false, elevatedHREnabled: false)
+        let stepping = (at(10, 0), at(10, 20))
+        let mixed = [hr(165, 10, 10),                   // exercising → suppressed
+                     hr(128, 14, 0)]                    // resting crossing → alerts
+        let gated = HealthAlertEvaluator.nonExercising(mixed, activeIntervals: [stepping])
+        let hits = HealthAlertEvaluator.evaluate(hr: gated, spo2: [], inactiveHR: gated, thresholds: thresholds)
+        XCTAssertEqual(hits.map(\.notification), [.highHR])
+        XCTAssertEqual(hits.first?.value, 128)
+    }
+
+    // MARK: #144 activeStepIntervals — the production step-source path + day-wide fallback guard
+
+    func testActiveStepIntervalsKeepsNarrowNonzeroWindows() {
+        // A normal per-reading window (a few minutes, nonzero delta) becomes a gate interval.
+        let w = [StepWindow(start: at(10, 0), end: at(10, 3), delta: 40)]
+        let intervals = HealthAlertEvaluator.activeStepIntervals(w)
+        XCTAssertEqual(intervals.count, 1)
+        XCTAssertEqual(intervals.first?.0, at(10, 0))
+        XCTAssertEqual(intervals.first?.1, at(10, 3))
+    }
+
+    func testActiveStepIntervalsDropsZeroDeltaWindow() {
+        let w = [StepWindow(start: at(10, 0), end: at(10, 3), delta: 0)]
+        XCTAssertTrue(HealthAlertEvaluator.activeStepIntervals(w).isEmpty)
+    }
+
+    func testActiveStepIntervalsExcludesDayWideFallbackWindow() {
+        // SAFETY GUARD: a fresh-baseline / rollover reading records a day-wide [startOfDay, sampleDate]
+        // window. It MUST NOT become a gate interval — otherwise it blankets the whole day.
+        let dayWide = [StepWindow(start: at(0, 0), end: at(10, 15), delta: 900)]   // 10h15m fallback
+        XCTAssertTrue(HealthAlertEvaluator.activeStepIntervals(dayWide).isEmpty,
+                      "day-wide fallback window must not become a gate interval")
+        // The boundary: a window exactly at the cap is kept; just over it is dropped.
+        let atCap  = [StepWindow(start: at(10, 0), end: at(10, 30), delta: 5)]     // == 30 min
+        let overCap = [StepWindow(start: at(10, 0), end: at(10, 31), delta: 5)]    // 31 min
+        XCTAssertEqual(HealthAlertEvaluator.activeStepIntervals(atCap).count, 1)
+        XCTAssertTrue(HealthAlertEvaluator.activeStepIntervals(overCap).isEmpty)
+    }
+
+    func testDayWideFallbackWindowCannotSuppressGenuineCrossing() {
+        // End-to-end safety: a resting crossing at 08:30 (no narrow activity) must STILL fire even
+        // when a day-wide fallback step window [00:00, 10:15] is present — the guard drops that window
+        // so it can't blanket-suppress the morning (the catastrophic false-negative this guards).
+        let thresholds = HealthAlertThresholds(highHRBpm: 120, lowSpO2Enabled: false, elevatedHREnabled: false)
+        let steps = [StepWindow(start: at(0, 0), end: at(10, 15), delta: 900)]     // day-wide fallback only
+        let intervals = HealthAlertEvaluator.activeStepIntervals(steps)
+        let crossing = [hr(150, 8, 30)]                                            // resting, no concurrent steps
+        let gated = HealthAlertEvaluator.nonExercising(crossing, activeIntervals: intervals)
+        let hits = HealthAlertEvaluator.evaluate(hr: gated, spo2: [], inactiveHR: gated, thresholds: thresholds)
+        XCTAssertEqual(hits.map(\.notification), [.highHR],
+                       "a day-wide fallback window must never silence a real crossing")
+    }
+
+    func testNarrowWindowGateEngagesOnRealStepData() {
+        // The gate DOES engage on real narrow windows (proving it's not a no-op): 165 bpm concurrent
+        // with a 3-min stepping window is suppressed, while a resting 128 bpm in a still period fires.
+        let thresholds = HealthAlertThresholds(highHRBpm: 120, lowSpO2Enabled: false, elevatedHREnabled: false)
+        let steps = [StepWindow(start: at(10, 0), end: at(10, 3), delta: 60)]
+        let intervals = HealthAlertEvaluator.activeStepIntervals(steps)
+        let mixed = [hr(165, 10, 1),   // exercising → suppressed
+                     hr(128, 14, 0)]   // resting crossing → alerts
+        let gated = HealthAlertEvaluator.nonExercising(mixed, activeIntervals: intervals)
+        let hits = HealthAlertEvaluator.evaluate(hr: gated, spo2: [], inactiveHR: gated, thresholds: thresholds)
+        XCTAssertEqual(hits.map(\.notification), [.highHR])
+        XCTAssertEqual(hits.first?.value, 128)
+    }
+
+    // MARK: #137 bedtime reminder bypasses the quiet-hours gate (caller-side split)
+
+    func testBedtimeReminderBypassesQuietHoursWhileVitalsStayMuted() {
+        // Reproduces the `evaluateReminders` split: `now` is 22:45 — inside BOTH the default
+        // 22:00–07:00 quiet window AND a typical [22:30, 23:00) bedtime window. A body-vital alert
+        // stays muted (no regression), while the bedtime reminder — gated with quiet DISABLED —
+        // survives, and the anti-spam backoff still de-dupes it so it fires at most once per night.
+        let gate = NotificationGate()
+        let quiet = QuietHours(enabled: true, startMinutes: 22 * 60, endMinutes: 7 * 60)
+        let now = at(22, 45)
+        // Body-vital alert: still suppressed during quiet hours.
+        XCTAssertTrue(gate.filter([.highHR], now: now, lastFired: [:], quietHours: quiet).isEmpty)
+        // Bedtime reminder: gated with quiet disabled → fires even though `now` is inside quiet hours.
+        XCTAssertEqual(gate.filter([.bedtimeReminder], now: now, lastFired: [:],
+                                   quietHours: QuietHours(enabled: false)), [.bedtimeReminder])
+        // Backoff still applies: a second eval later in the same window is suppressed (fires once/night).
+        XCTAssertTrue(gate.filter([.bedtimeReminder], now: at(22, 50),
+                                  lastFired: [.bedtimeReminder: now],
+                                  quietHours: QuietHours(enabled: false)).isEmpty)
+    }
+
     // MARK: #85 flag routing
 
     func testTempFeverRouting() {

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/ReminderEngineTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/ReminderEngineTests.swift
@@ -51,6 +51,15 @@ final class ReminderEngineTests: XCTestCase {
         XCTAssertFalse(r.shouldFire(lastActivityAt: nil, now: now1000, calendar: cal))
     }
 
+    func testSedentaryDoesNotFireWithFreshActivityWithinInterval() {
+        // #145: once a foreground sync lands a fresh step delta, the gap is < interval → no nudge.
+        // The bug was evaluating this rule PRE-sync against a stale `lastActivityAt` (gap ≥ interval);
+        // the app-layer fix defers the evaluation to post-sync so `lastActivityAt` is fresh like this.
+        let r = SedentaryReminder(interval: 50 * 60, activeStartMinutes: 8 * 60, activeEndMinutes: 21 * 60)
+        let fresh = now1000.addingTimeInterval(-(5 * 60))   // moved 5 min ago
+        XCTAssertFalse(r.shouldFire(lastActivityAt: fresh, now: now1000, calendar: cal))
+    }
+
     // MARK: - WearReminder
 
     func testWearFiresAfterInterval() {


### PR DESCRIPTION
Three alert/reminder firing-policy fixes from the 2026-07-04 UX sweep.

Closes #137, closes #144, closes #145.

## What changed
**#144 — the high-HR alert now has an activity gate.** It used to fire at the default 120 bpm after every workout. HR samples concurrent with recent step activity are now filtered out before the high-HR / elevated-HR-inactive rules run, via a pure `nonExercising` gate.

**#137 — the bedtime reminder now fires under Quiet Hours.** With a typical post-22:00 bedtime it was suppressed by the quiet-hours gate. Bedtime is now split out of that gate — only bedtime bypasses quiet hours; every other reminder still honors it, and bedtime still fires at most once per night.

**#145 — the sedentary reminder no longer fires on stale data.** It was evaluated pre-sync against a stale `lastActivityAt` ("time to move!" right after activity). It's now evaluated only post-sync with fresh data.

## Review & verification
Adversarially reviewed — it caught a **blocker**, now fixed:
- The #144 gate originally read steps from `StoredSample`, where **steps are never written** (they live in `StoredStepSample`), so the gate was a silent no-op — the workout false-alarm still fired while green tests gave false confidence. Fixed to read from `stepSamples()`, factored into a pure, unit-tested `activeStepIntervals` helper.
- **Health-safety guard:** the day-wide `[startOfDay, sampleDate]` fallback step windows (fresh baseline / day rollover) are excluded via a 30-min cap (erring short), so they can't blanket-suppress a genuine resting tachycardia. A dedicated end-to-end test asserts a resting 150 bpm crossing still fires with a `[00:00,10:15]` fallback window present, and another proves the gate genuinely engages on real narrow windows.
- #137 and #145 reviewed **SOUND** (bedtime split doesn't un-gate other quiet-suppressed reminders; sedentary still evaluates post-sync, wear/bedtime unaffected).
- `swift test` **643 tests, 0 failures** (+5); app **BUILD SUCCEEDED**.

cc @bluna-ai for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
