### PR TITLE
fix(ios): honest Apple Health mirroring — partial-grant handling + write-failure surfacing + auth routing (#132 #135 #143)

### DIFF
--- a/ios/OpenCircuit/ContentView.swift
+++ b/ios/OpenCircuit/ContentView.swift
@@ -16,6 +16,14 @@ struct ContentView: View {
     /// `requestAuthorization` would silently no-op, so the authorize button must route to the
     /// Health app instead. Re-probed at launch, on foreground return, and after a live decline.
     @State private var healthPromptExhausted = false
+    /// Tri-state Health share status (#132): distinguishes a full grant from a PARTIAL one (heart
+    /// rate granted, another type — SpO₂/temp/sleep — denied), so the card can warn honestly instead
+    /// of a blanket "Auto-syncing" that silently drops the denied metrics. Recomputed alongside
+    /// `healthAuthorized` (launch / foreground / post-authorize / post-flush).
+    @State private var healthShareState: HealthKitWriter.ShareState = .unauthorized
+    /// Persisted per-metric Health write failures (#135) — a metric whose `save` actually threw
+    /// (e.g. a category toggled off in Settings ▸ Health). Surfaced as an amber "hasn't synced" line.
+    @State private var healthWriteFailures: [MetricKind] = []
     @Environment(\.openURL) private var openURL
     @State private var lastWrite: String?
     /// Drives the "Bluetooth is off" explainer alert from the connect card's Turn-on-Bluetooth
@@ -82,6 +90,13 @@ struct ContentView: View {
             List {
                 Group {
                     connectionCard
+                    // First-run Health authorization banner (#143): routes a new user to authorize
+                    // Health right under the connection card, instead of burying the only authorize
+                    // button beneath the RE tooling at the bottom of the last card. Disappears the
+                    // moment auth succeeds (`healthAuthorized` is refreshed in `.task`/on foreground).
+                    if !healthAuthorized, HealthKitWriter.isAvailable {
+                        healthAuthBanner
+                    }
                     ForEach(visibleSections) { section in
                         sectionView(section)
                     }
@@ -128,6 +143,7 @@ struct ContentView: View {
                 // read there once blocked the launch render into a black screen. #14
                 healthAuthorized = health.isShareAuthorized
                 if healthAuthorized { observability.markHealthEverAuthorized() }
+                refreshHealthShareState()   // partial-grant (#132) + persisted write failures (#135)
                 refreshObservability()
                 if healthAuthorized {
                     flushHealth()
@@ -353,6 +369,7 @@ struct ContentView: View {
         let wasAuthorized = healthAuthorized
         let authorized = health.isShareAuthorized
         healthAuthorized = authorized
+        refreshHealthShareState()   // a partial grant or a toggle flipped in Health while away (#132/#135)
         if authorized {
             observability.markHealthEverAuthorized()
             healthPromptExhausted = false
@@ -1061,84 +1078,157 @@ struct ContentView: View {
                 .font(.caption2)
                 .foregroundStyle(.secondary)
 
-            // The Health mirror controls. Show the Authorize button whenever Health isn't yet
-            // authorized — regardless of whether the current sync had records — so a first-time
-            // user (or one whose syncs all return empty) can still enable Health mirroring.
-            // Once authorized, only show the "auto-syncing" line when there are recent records
-            // (avoids a persistent green banner while the ring is empty).
-            if !healthAuthorized || session?.historySamples.isEmpty == false {
+            // Health mirror STATUS lives here once authorized (the first-run authorize prompt now
+            // lives in the top-of-dashboard banner — #143 — so it isn't duplicated here). Show the
+            // status line when there are recent records OR something needs attention (a partial
+            // grant — #132 — or a persisted write failure — #135), so the honest amber warning
+            // surfaces even on an empty-ring day; stay silent otherwise (no persistent green banner).
+            if healthAuthorized, session?.historySamples.isEmpty == false || healthNeedsAttention {
                 Divider()
                 healthRow
             }
         }
     }
 
+    /// The authorized-state Health status line + the last-write detail. The unauthorized authorize
+    /// prompt is `healthAuthPrompt`, rendered by the top-of-dashboard banner (#143), not here.
     private var healthRow: some View {
         VStack(spacing: 8) {
-            if !healthAuthorized, healthPromptExhausted {
-                // iOS shows the Health permission sheet once, ever — after a decline,
-                // requestAuthorization is a silent no-op (the "dead button" bug). Route to the
-                // Health app's own toggles instead; foreground return re-probes and backfills.
-                Button {
-                    openURL(HealthKitWriter.healthAppURL)
-                } label: {
-                    Label("Turn On Access in Health", systemImage: "heart.text.square")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                Text("Health access was declined earlier, and iOS only shows that prompt once. "
-                     + "In Health: profile picture ▸ Privacy ▸ Apps ▸ OpenCircuit — switch on "
-                     + "what you'd like to share, then come back. Syncing resumes automatically.")
-                    .font(.caption).foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            } else if !healthAuthorized {
-                Button {
-                    Task {
-                        do {
-                            try await health.requestAuthorization()
-                        } catch {
-                            // The request throws when the HealthKit entitlement is absent — the
-                            // signature of a free-Apple-ID sideload (the entitlement is paid-account
-                            // only and gets stripped on re-sign). Surface it instead of failing
-                            // silently; the app still works as a local dashboard. (#104)
-                            healthUnavailable = true
-                        }
-                        healthAuthorized = health.isShareAuthorized
-                        if healthAuthorized {
-                            healthUnavailable = false
-                            observability.markHealthEverAuthorized()
-                        } else {
-                            // A decline just now uses up the one-time sheet — flip the button
-                            // to the Health-app route immediately, not on the next launch.
-                            healthPromptExhausted =
-                                (await health.authorizationPromptAvailable()) == false
-                        }
-                        flushHealth()   // backfill everything already in the store
-                    }
-                } label: {
-                    Label("Authorize Apple Health", systemImage: "heart.text.square")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .disabled(!HealthKitWriter.isAvailable)
-                if healthUnavailable {
-                    Text("This build can't write to Apple Health — that needs the TestFlight build. "
-                         + "(Free side-loaded builds can't use HealthKit.) OpenCircuit still works "
-                         + "as a local dashboard.")
-                        .font(.caption).foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-            } else {
-                // Mirroring is automatic after every sync; this is just a reassurance line
-                // plus a manual nudge for the impatient.
-                Label("Auto-syncing to Apple Health", systemImage: "checkmark.seal.fill")
-                    .font(.caption).foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .center)
-            }
+            healthStatusLine
             if let lastWrite {
                 Text(lastWrite).font(.caption).foregroundStyle(.secondary)
             }
         }
+    }
+
+    /// Authorized-state status: the honest amber warning when a metric is denied (#132) or its
+    /// write is failing (#135), otherwise the green "auto-syncing" reassurance. Tapping the warning
+    /// deep-links into the Health app so the user can flip the missing type back on.
+    @ViewBuilder private var healthStatusLine: some View {
+        let attention = healthAttentionNames
+        if attention.isEmpty {
+            // Mirroring is automatic after every sync; this is just a reassurance line.
+            Label("Auto-syncing to Apple Health", systemImage: "checkmark.seal.fill")
+                .font(.caption).foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+        } else {
+            Button {
+                openURL(HealthKitWriter.healthAppURL)
+            } label: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Label("Some metrics aren't reaching Apple Health",
+                          systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption).foregroundStyle(.orange)
+                    Text("\(attention.joined(separator: ", ")) — tap to turn them on in Health.")
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    /// The state-driven Health authorize control (#143 extraction): the deep-link when the one-time
+    /// iOS sheet is exhausted, the normal request path otherwise, and the sideload "unavailable"
+    /// note. Reused by both the top-of-dashboard banner and (historically) the sync card, so the
+    /// request/probe logic lives in exactly one place. Callers gate it on `!healthAuthorized`.
+    @ViewBuilder private var healthAuthPrompt: some View {
+        if healthPromptExhausted {
+            // iOS shows the Health permission sheet once, ever — after a decline,
+            // requestAuthorization is a silent no-op (the "dead button" bug). Route to the
+            // Health app's own toggles instead; foreground return re-probes and backfills.
+            Button {
+                openURL(HealthKitWriter.healthAppURL)
+            } label: {
+                Label("Turn On Access in Health", systemImage: "heart.text.square")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            Text("Health access was declined earlier, and iOS only shows that prompt once. "
+                 + "In Health: profile picture ▸ Privacy ▸ Apps ▸ OpenCircuit — switch on "
+                 + "what you'd like to share, then come back. Syncing resumes automatically.")
+                .font(.caption).foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            Button {
+                Task {
+                    do {
+                        try await health.requestAuthorization()
+                    } catch {
+                        // The request throws when the HealthKit entitlement is absent — the
+                        // signature of a free-Apple-ID sideload (the entitlement is paid-account
+                        // only and gets stripped on re-sign). Surface it instead of failing
+                        // silently; the app still works as a local dashboard. (#104)
+                        healthUnavailable = true
+                    }
+                    healthAuthorized = health.isShareAuthorized
+                    if healthAuthorized {
+                        healthUnavailable = false
+                        observability.markHealthEverAuthorized()
+                    } else {
+                        // A decline just now uses up the one-time sheet — flip the button
+                        // to the Health-app route immediately, not on the next launch.
+                        healthPromptExhausted =
+                            (await health.authorizationPromptAvailable()) == false
+                    }
+                    refreshHealthShareState()   // reflect a partial grant / cleared failures (#132/#135)
+                    flushHealth()   // backfill everything already in the store
+                }
+            } label: {
+                Label("Authorize Apple Health", systemImage: "heart.text.square")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .disabled(!HealthKitWriter.isAvailable)
+            if healthUnavailable {
+                Text("This build can't write to Apple Health — that needs the TestFlight build. "
+                     + "(Free side-loaded builds can't use HealthKit.) OpenCircuit still works "
+                     + "as a local dashboard.")
+                    .font(.caption).foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    /// First-run Health authorization banner (#143). Directly under the connection card so a new
+    /// user is routed to authorize Health — the app's entire purpose — WITHOUT scrolling past the
+    /// Sync / historic-pull / forensic-sweep / calibration tooling to the buried authorize button.
+    /// Gated on `!healthAuthorized` at the call site, so it vanishes the moment auth succeeds.
+    private var healthAuthBanner: some View {
+        card {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Connect Apple Health", systemImage: "heart.text.square")
+                    .font(.headline)
+                Text("Turn on Apple Health to start saving your ring's data.")
+                    .font(.caption).foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                healthAuthPrompt
+            }
+        }
+    }
+
+    /// True when Health is authorized but a metric is either DENIED (partial grant, #132) or has a
+    /// persisted write FAILURE (#135) — drives the amber warning instead of the green line.
+    private var healthNeedsAttention: Bool { !healthAttentionNames.isEmpty }
+
+    /// Friendly names of the metrics not reaching Health: the partial-grant denied types (#132)
+    /// unioned with the persisted per-metric write failures (#135), de-duplicated and sorted.
+    private var healthAttentionNames: [String] {
+        var names = Set<String>()
+        if case .partial(let denied) = healthShareState {
+            names.formUnion(HealthKitWriter.friendlyNames(for: denied))
+        }
+        names.formUnion(healthWriteFailures.map(\.displayName))
+        return names.sorted()
+    }
+
+    /// Recompute the honest Health status surfaces (#132/#135): the partial-grant tri-state and the
+    /// persisted per-metric write failures. Cheap; called wherever `healthAuthorized` is refreshed
+    /// (launch, foreground return, post-authorize, post-flush), since the user can toggle types in
+    /// the Health app while away.
+    private func refreshHealthShareState() {
+        healthShareState = health.shareState
+        healthWriteFailures = HealthKitWriter.healthWriteFailures().keys.sorted { $0.rawValue < $1.rawValue }
     }
 
     // MARK: Device Info (#79)
@@ -1280,6 +1370,9 @@ struct ContentView: View {
         }
         Task {
             let r = await health.flushToHealth(store: store, sleepSegments: segments)
+            // Reflect any per-metric write failure (or its clearing) this flush just persisted, so
+            // the sync card's amber warning is accurate without waiting for a foreground return (#135).
+            refreshHealthShareState()
             if r.sleepSegments > 0 {
                 // Clear the persisted segments now that they're confirmed written to HealthKit.
                 scanner.clearLastCommittedSleepSegments()

--- a/ios/OpenCircuit/Health/HealthKitWriter.swift
+++ b/ios/OpenCircuit/Health/HealthKitWriter.swift
@@ -321,9 +321,14 @@ final class HealthKitWriter {
         // Distance is netted/credited per CALENDAR DAY (the GPS-credit ledger in UserDefaults is
         // day-keyed), so snapshots are grouped by day rather than assuming one day's worth.
         if let pending = try? store.pendingStepSamples(), !pending.isEmpty {
-            var toWrite: [QuantitySample] = pending.map {
+            let stepSamples: [QuantitySample] = pending.map {
                 QuantitySample(kind: .steps, start: $0.start, end: $0.end, value: Double($0.delta))
             }
+            // Derive the per-day distance samples (and their GPS-credit reductions) up front, but do
+            // NOT fold them into the step write — see the coupling note below. `netDistanceEstimate`
+            // only COMPUTES the net (reading the day-keyed GPS ledger); the ledger is mutated solely
+            // by `commitDistanceGPSCredit`, which we defer until distance actually writes.
+            var distanceSamples: [QuantitySample] = []
             var gpsCommits: [(reduction: Double, day: Date)] = []
             let byDay = Dictionary(grouping: pending) { Calendar.current.startOfDay(for: $0.end) }
             for (day, rows) in byDay {
@@ -332,39 +337,49 @@ final class HealthKitWriter {
                 let (netDistanceM, gpsReduction) = Self.netDistanceEstimate(rawDistanceM, day: day)
                 if netDistanceM > 0 {
                     let dayEnd = rows.map(\.end).max() ?? day
-                    toWrite.append(QuantitySample(kind: .distance, start: day, end: dayEnd, value: netDistanceM))
+                    distanceSamples.append(QuantitySample(kind: .distance, start: day, end: dayEnd, value: netDistanceM))
                 }
                 gpsCommits.append((gpsReduction, day))
             }
-            // Scalar KINDS split independently (#132), but steps and the DERIVED distance stay
-            // COUPLED: distance has no watermark of its own — it's re-derived from the same
-            // `StoredStepSample` rows every flush and rides their `healthWritten` flag (advanced only
-            // by `markStepSamplesWritten`). So distance may only be written/committed when the step
-            // rows are being marked written THIS pass (i.e. steps saved). Otherwise a granted-distance
-            // sample would re-derive + re-write on every subsequent flush while the rows stay pending,
-            // and HealthKit SUMS it → the day's distance inflates ~N×. If steps failed, skip distance
-            // entirely (no write, no GPS credit) so it's deferred, not duplicated.
-            let outcome = await write(toWrite)
-            if !outcome.failed.contains(.steps) {
+            // Scalar KINDS split independently (#132), but steps and the DERIVED distance stay COUPLED:
+            // distance has no watermark of its own — it's re-derived from the same `StoredStepSample`
+            // rows every flush and rides their `healthWritten` flag (advanced only by
+            // `markStepSamplesWritten`). So distance is written in a SEPARATE pass that runs ONLY after
+            // the step rows are marked written this flush. Folding distance into the step batch would
+            // let a granted-distance sample LAND even when the steps save fails (the per-kind split
+            // saves each kind independently) — and, with the rows still pending, re-derive + re-write
+            // every subsequent flush → HealthKit SUMS it → the day's distance inflates ~N×. Writing
+            // distance only after a successful step save defers it instead of duplicating it.
+            let stepsOutcome = await write(stepSamples)
+            if !stepsOutcome.failed.contains(.steps) {
                 try? store.markStepSamplesWritten(pending)
                 result.steps = pending.reduce(0) { $0 + $1.delta }
                 writtenKinds.insert(.steps)
-                // Steps landed → the rows won't be re-derived, so it's safe to write/commit distance.
-                if Self.distanceMayWrite(stepsFailed: false, distanceFailed: outcome.failed.contains(.distance)) {
-                    for commit in gpsCommits { Self.commitDistanceGPSCredit(commit.reduction, day: commit.day) }
-                    let distanceWritten = outcome.written.filter { $0.kind == .distance }.reduce(0) { $0 + $1.value }
-                    result.distanceM = distanceWritten
-                    if distanceWritten > 0 { writtenKinds.insert(.distance) }
-                } else {
-                    pendingFlushFailures.insert(.distance)
+                // Steps landed and the rows are now marked written → safe to write/commit distance.
+                if !distanceSamples.isEmpty {
+                    let distanceOutcome = await write(distanceSamples)
+                    if Self.distanceMayWrite(stepsFailed: false,
+                                             distanceFailed: distanceOutcome.failed.contains(.distance)) {
+                        for commit in gpsCommits { Self.commitDistanceGPSCredit(commit.reduction, day: commit.day) }
+                        let distanceWritten = distanceOutcome.written
+                            .filter { $0.kind == .distance }.reduce(0) { $0 + $1.value }
+                        result.distanceM = distanceWritten
+                        if distanceWritten > 0 { writtenKinds.insert(.distance) }
+                    } else {
+                        // TRADEOFF (accepted): steps granted + distance denied → this window's distance
+                        // estimate is skipped and won't backfill if the user later enables Distance,
+                        // because the step rows are already marked written. Distance is a DERIVED
+                        // estimate (steps × stride), not measured data; a separate `distanceWritten`
+                        // flag + migration to make it independently backfillable is out of scope. The
+                        // GPS credit is NOT committed here, so it isn't consumed against a write that
+                        // didn't happen.
+                        pendingFlushFailures.insert(.distance)
+                    }
                 }
             }
-            // TRADEOFF (accepted): steps granted + distance denied → that window's distance estimate
-            // is skipped and won't backfill if the user later enables Distance, because the step rows
-            // are already marked written. Distance is a DERIVED estimate (steps × stride), not measured
-            // data; a separate `distanceWritten` flag + migration to make it independently backfillable
-            // is out of scope. If steps FAILED, distance failure isn't recorded — it's simply deferred.
-            pendingFlushFailures.formUnion(outcome.failed.subtracting([.distance]))
+            // If steps FAILED, distance was never written (deferred with the rows), so no distance
+            // failure is recorded here.
+            pendingFlushFailures.formUnion(stepsOutcome.failed.subtracting([.distance]))
         }
         // Derived daily resting HR — one sample per finalized day (#18, #37). Idempotency is a
         // UserDefaults day-watermark, NOT the store cursor: RHR isn't a stored sample, and the

--- a/ios/OpenCircuit/Health/HealthKitWriter.swift
+++ b/ios/OpenCircuit/Health/HealthKitWriter.swift
@@ -112,6 +112,70 @@ final class HealthKitWriter {
             && store.authorizationStatus(for: HKQuantityType(.heartRate)) == .sharingAuthorized
     }
 
+    /// The shareable, AUTHORIZABLE types the user has explicitly DENIED (turned off in the iOS
+    /// permission sheet or later in Settings ▸ Health ▸ Data Access). SHARE status is reportable
+    /// per-type (unlike READ status), so this is a trustworthy signal. `allTypes` already excludes
+    /// the non-authorizable `bloodPressureType` HKCorrelationType (querying it throws an uncatchable
+    /// Obj-C exception), so this never touches it. Includes `.sleepAnalysis` and `.menstrualFlow`.
+    func deniedShareTypes() -> [HKSampleType] {
+        guard Self.isAvailable else { return [] }
+        return allTypes.filter { store.authorizationStatus(for: $0) == .sharingDenied }
+    }
+
+    /// Tri-state Health share status so the UI can tell "never granted" from "some granted, some
+    /// denied" — the partial case is the trap #132 fixes: `isShareAuthorized` (heart rate) is `true`
+    /// yet other metrics silently never reach Health. `isShareAuthorized` stays as-is so the flush
+    /// keeps writing the metrics that ARE granted; this only drives the honest status copy.
+    enum ShareState: Equatable {
+        case unauthorized
+        case partial([HKSampleType])   // HR granted, but these types are denied
+        case authorized
+    }
+
+    var shareState: ShareState {
+        guard Self.isAvailable else { return .unauthorized }
+        return Self.resolveShareState(authorizableTypes: allTypes) {
+            store.authorizationStatus(for: $0)
+        }
+    }
+
+    /// Pure share-state resolution over an injected authorization-status lookup — testable without a
+    /// live `HKHealthStore` (the simulator reports every type `.notDetermined`). Heart rate is the
+    /// representative "did the user grant anything" gate, mirroring `isShareAuthorized`.
+    static func resolveShareState(authorizableTypes: Set<HKSampleType>,
+                                  status: (HKSampleType) -> HKAuthorizationStatus) -> ShareState {
+        guard status(HKQuantityType(.heartRate)) == .sharingAuthorized else { return .unauthorized }
+        let denied = authorizableTypes.filter { status($0) == .sharingDenied }
+        return denied.isEmpty ? .authorized : .partial(Array(denied))
+    }
+
+    /// User-facing name for a share type, for the partial-grant / failure warnings. Maps quantity
+    /// types back through `MetricKind` where possible; a small table covers the non-`MetricKind`
+    /// extras (sleep, energy, cycle tracking, blood pressure, workouts).
+    static func friendlyName(for type: HKSampleType) -> String {
+        for k in MetricKind.allCases {
+            if let qt = quantityType(for: k), qt.isEqual(type) { return k.displayName }
+        }
+        if type.isEqual(HKCategoryType(.sleepAnalysis)) { return "Sleep" }
+        if type.isEqual(HKQuantityType(.basalEnergyBurned)) { return "Resting Energy" }
+        if type.isEqual(HKCategoryType(.menstrualFlow)) { return "Cycle Tracking" }
+        if type.isEqual(systolicType) || type.isEqual(diastolicType) { return "Blood Pressure" }
+        if type.isEqual(HKQuantityType(.distanceCycling)) { return "Cycling Distance" }
+        if type is HKWorkoutType || type is HKSeriesType { return "Workouts" }
+        return type.identifier
+    }
+
+    /// De-duplicated, stably-sorted friendly names for a set of denied/failed types (both BP
+    /// constituents collapse to one "Blood Pressure", etc.).
+    static func friendlyNames(for types: [HKSampleType]) -> [String] {
+        var seen = Set<String>()
+        var out: [String] = []
+        for name in types.map({ friendlyName(for: $0) }).sorted() where seen.insert(name).inserted {
+            out.append(name)
+        }
+        return out
+    }
+
     /// Deep link into the Health app — the recovery path once the one-time permission sheet
     /// has been used up (see `authorizationPromptAvailable`). There is no per-app deep link to
     /// Health's privacy page; the app root is as close as iOS allows.
@@ -145,10 +209,47 @@ final class HealthKitWriter {
         var distanceM = 0.0         // estimated distance written (#81)
         var exerciseMinutes = 0.0   // estimated exercise minutes written (#82)
         var menstrualFlowEntries = 0  // user-logged period entries written (#78)
+        /// Metrics whose HealthKit `save` actually THREW this pass (#135) — distinct from "nothing
+        /// pending". Persisted per-metric so the UI can surface an honest "X hasn't synced" warning
+        /// instead of the blanket "Auto-syncing" line. Empty on a clean/idle flush.
+        var failures: Set<MetricKind> = []
         var wroteAnything: Bool {
             samples > 0 || sleepSegments > 0 || steps > 0
                 || restingDays > 0 || passiveHours > 0 || activeKcal > 0 || naps > 0
                 || distanceM > 0 || exerciseMinutes > 0 || menstrualFlowEntries > 0
+        }
+    }
+
+    /// Metrics whose HealthKit `save` threw during the CURRENT flush pass. Reset at the top of
+    /// `flushToHealth`; the inline blocks and per-helper flushes add to it on a caught save error.
+    /// Rolled into `FlushResult.failures` and persisted (below) so all three flush entry points
+    /// (foreground, RingSession, background task) surface a consistent failure state. (#135)
+    private var pendingFlushFailures: Set<MetricKind> = []
+
+    // MARK: Persisted per-metric write-failure map (#135)
+    //
+    // Flushes run from three entry points on SEPARATE `HealthKitWriter` instances, so the last
+    // failure per metric lives in UserDefaults (mirroring the `hk.*` watermark pattern) where all
+    // three can write it and the UI can read it. Set on a caught save error, CLEARED on the next
+    // successful write of that metric — so "nothing pending" and "writes failing" stay distinct.
+    private static let failureMapKey = "hk.failures.byMetric"   // [MetricKind.rawValue : since1970]
+
+    /// Merge one flush pass into the persisted failure map: stamp `failed` metrics with `now`, and
+    /// clear any `written` metric's flag (a later success wins, so a re-enabled type self-heals).
+    static func recordFlushOutcome(written: Set<MetricKind>, failed: Set<MetricKind>,
+                                   now: Date = Date(), _ defaults: UserDefaults = .standard) {
+        var map = (defaults.dictionary(forKey: failureMapKey) as? [String: Double]) ?? [:]
+        for m in failed { map[m.rawValue] = now.timeIntervalSince1970 }
+        for m in written { map.removeValue(forKey: m.rawValue) }
+        if map.isEmpty { defaults.removeObject(forKey: failureMapKey) }
+        else { defaults.set(map, forKey: failureMapKey) }
+    }
+
+    /// The persisted per-metric write failures (metric → last failure time), for the UI warning.
+    static func healthWriteFailures(_ defaults: UserDefaults = .standard) -> [MetricKind: Date] {
+        guard let map = defaults.dictionary(forKey: failureMapKey) as? [String: Double] else { return [:] }
+        return map.reduce(into: [:]) { acc, kv in
+            if let kind = MetricKind(rawValue: kv.key) { acc[kind] = Date(timeIntervalSince1970: kv.value) }
         }
     }
 
@@ -164,10 +265,20 @@ final class HealthKitWriter {
         Self.isFlushing = true
         defer { Self.isFlushing = false }
 
-        // Scalars: write, THEN advance the watermark, so a failed save backfills next time.
+        pendingFlushFailures = []            // per-pass failure accumulator (#135)
+        var writtenKinds: Set<MetricKind> = []  // metrics that landed at least one sample this pass
+
+        // Scalars: write, THEN advance the watermark, so a failed save backfills next time. The
+        // write is SPLIT per metric (#132): a single denied type (e.g. SpO₂) no longer sinks the
+        // whole batch — the granted metrics still land and only the denied one is left pending.
         if let pending = try? store.pendingHealthSamples(), !pending.isEmpty {
-            do { try await write(pending); try store.markHealthWritten(pending); result.samples = pending.count }
-            catch { /* leave the watermark; retry next flush */ }
+            let outcome = await write(pending)
+            if !outcome.written.isEmpty {
+                try? store.markHealthWritten(outcome.written)   // advance ONLY for what actually saved
+                result.samples = outcome.written.count
+                writtenKinds.formUnion(outcome.written.map(\.kind))
+            }
+            pendingFlushFailures.formUnion(outcome.failed)
         }
         // Sleep: same write-then-mark order (a failed save must not lose the night). Only mirror a
         // SETTLED night (SleepHealthGate): with periodic overnight draining the staged night grows
@@ -176,12 +287,20 @@ final class HealthKitWriter {
         // stopped advancing (sleeper is up), it writes once and the `.sleep` cursor blocks re-writes.
         if SleepHealthGate.isSettled(latestSegmentEnd: sleepSegments.map(\.end).max(), now: Date()),
            let pendingSleep = try? store.pendingHealthSleep(sleepSegments), !pendingSleep.isEmpty {
-            do { try await write(sleep: pendingSleep); try store.markSleepWritten(pendingSleep); result.sleepSegments = pendingSleep.count }
-            catch { /* leave the .sleep cursor; retry next flush */ }
+            do {
+                try await write(sleep: pendingSleep); try store.markSleepWritten(pendingSleep)
+                result.sleepSegments = pendingSleep.count
+                writtenKinds.insert(.sleep)
+            } catch {
+                // A denied .sleepAnalysis type throws here forever — surface it (#135) instead of
+                // silently retrying, so the card can say "Sleep hasn't synced". Cursor stays put.
+                pendingFlushFailures.insert(.sleep)
+            }
         }
         // Naps (#76): each carries its own `healthWritten` flag (NOT the night's `.sleep` cursor),
         // so a daytime nap and the overnight night write independently and never collide.
         result.naps = await flushNaps(store: store)
+        if result.naps > 0 { writtenKinds.insert(.sleep) }
 
         // Women's health (#78): write pending user-logged period flow entries to Health.
         // Gated by each entry's own `healthWritten` flag — independent of all other writes.
@@ -217,28 +336,57 @@ final class HealthKitWriter {
                 }
                 gpsCommits.append((gpsReduction, day))
             }
-            do {
-                try await write(toWrite)
-                try store.markStepSamplesWritten(pending)
-                for commit in gpsCommits { Self.commitDistanceGPSCredit(commit.reduction, day: commit.day) }
+            // Scalar KINDS split independently (#132), but steps and the DERIVED distance stay
+            // COUPLED: distance has no watermark of its own — it's re-derived from the same
+            // `StoredStepSample` rows every flush and rides their `healthWritten` flag (advanced only
+            // by `markStepSamplesWritten`). So distance may only be written/committed when the step
+            // rows are being marked written THIS pass (i.e. steps saved). Otherwise a granted-distance
+            // sample would re-derive + re-write on every subsequent flush while the rows stay pending,
+            // and HealthKit SUMS it → the day's distance inflates ~N×. If steps failed, skip distance
+            // entirely (no write, no GPS credit) so it's deferred, not duplicated.
+            let outcome = await write(toWrite)
+            if !outcome.failed.contains(.steps) {
+                try? store.markStepSamplesWritten(pending)
                 result.steps = pending.reduce(0) { $0 + $1.delta }
-                result.distanceM = toWrite.filter { $0.kind == .distance }.reduce(0) { $0 + $1.value }
-            } catch { /* leave the watermark; retry next flush */ }
+                writtenKinds.insert(.steps)
+                // Steps landed → the rows won't be re-derived, so it's safe to write/commit distance.
+                if Self.distanceMayWrite(stepsFailed: false, distanceFailed: outcome.failed.contains(.distance)) {
+                    for commit in gpsCommits { Self.commitDistanceGPSCredit(commit.reduction, day: commit.day) }
+                    let distanceWritten = outcome.written.filter { $0.kind == .distance }.reduce(0) { $0 + $1.value }
+                    result.distanceM = distanceWritten
+                    if distanceWritten > 0 { writtenKinds.insert(.distance) }
+                } else {
+                    pendingFlushFailures.insert(.distance)
+                }
+            }
+            // TRADEOFF (accepted): steps granted + distance denied → that window's distance estimate
+            // is skipped and won't backfill if the user later enables Distance, because the step rows
+            // are already marked written. Distance is a DERIVED estimate (steps × stride), not measured
+            // data; a separate `distanceWritten` flag + migration to make it independently backfillable
+            // is out of scope. If steps FAILED, distance failure isn't recorded — it's simply deferred.
+            pendingFlushFailures.formUnion(outcome.failed.subtracting([.distance]))
         }
         // Derived daily resting HR — one sample per finalized day (#18, #37). Idempotency is a
         // UserDefaults day-watermark, NOT the store cursor: RHR isn't a stored sample, and the
         // `hk:` cursor rows belong to the raw-sample mirror above.
         result.restingDays = await flushRestingHR(local: store, sleepSegments: sleepSegments)
+        if result.restingDays > 0 { writtenKinds.insert(.restingHeartRate) }
 
         // Energy: passive (hourly BMR) + active (HR-derived or steps-derived estimate).
         // Watermark-gated (#37) and labeled as derived estimates in HealthKit metadata.
         result.passiveHours = await flushPassiveCalories(profile: profile)
         result.activeKcal = await flushActiveCalories(local: store, profile: profile)
+        if result.activeKcal > 0 { writtenKinds.insert(.activeEnergy) }
 
         // Exercise minutes estimate (#82): elevated-HR minutes outside the sleep window.
         // ESTIMATE — basic 50% maxHR threshold. Full 4-level intensity follows #93 decode.
         result.exerciseMinutes = await flushExerciseMinutes(local: store, profile: profile)
 
+        // Roll the per-pass failures into the result and persist the per-metric failure map so all
+        // three flush entry points surface a consistent "X hasn't synced" state; a same-pass success
+        // clears a prior failure so a re-enabled type self-heals. (#135)
+        result.failures = pendingFlushFailures
+        Self.recordFlushOutcome(written: writtenKinds, failed: pendingFlushFailures)
         return result
     }
 
@@ -258,7 +406,7 @@ final class HealthKitWriter {
                 try await write(sleep: segs)
                 try store.markNapWritten(start: nap.start)
                 written += 1
-            } catch { break }   // stop on first failure; unwritten naps retry next flush
+            } catch { pendingFlushFailures.insert(.sleep); break }   // surface + stop; naps retry next flush
         }
         return written
     }
@@ -364,16 +512,47 @@ final class HealthKitWriter {
         }
     }
 
-    /// Write scalar samples. Caller filters with SyncCursor first.
-    func write(_ samples: [QuantitySample]) async throws {
-        let hkSamples: [HKQuantitySample] = samples.compactMap { s in
-            guard let type = Self.quantityType(for: s.kind) else { return nil }
-            let q = HKQuantity(unit: Self.unit(for: s.kind), doubleValue: s.value)
-            return HKQuantitySample(type: type, quantity: q, start: s.start, end: s.end,
-                                    metadata: Self.metadata(for: s.kind))
+    /// Outcome of a split scalar write (#132): which input samples actually LANDED (so the caller
+    /// advances only their watermark) and which metric KINDS threw (so they're surfaced + retried).
+    struct ScalarWriteOutcome {
+        var written: [QuantitySample] = []
+        var failed: Set<MetricKind> = []
+    }
+
+    /// Whether the derived distance estimate may be WRITTEN + GPS-credited this pass. Distance rides
+    /// the step rows' single `healthWritten` flag, so it may only land when steps saved (rows marked
+    /// written, so nothing re-derives) AND distance itself wasn't denied — else a granted distance
+    /// re-writes every flush while steps stay pending and HealthKit sums the duplicate (#132 fix).
+    static func distanceMayWrite(stepsFailed: Bool, distanceFailed: Bool) -> Bool {
+        !stepsFailed && !distanceFailed
+    }
+
+    /// Write scalar samples, SPLIT per metric kind. Caller filters with SyncCursor first.
+    ///
+    /// The batch is grouped by `MetricKind` and each group saved on its own, so a single DENIED
+    /// type (which makes `store.save` throw `errorAuthorizationDenied` for everything in one call)
+    /// no longer sinks the whole batch — the granted metrics still reach Health and only the denied
+    /// kind is reported as failed and left pending (#132). Non-throwing: failures are returned, not
+    /// raised, so the caller can advance watermarks per surviving kind.
+    func write(_ samples: [QuantitySample]) async -> ScalarWriteOutcome {
+        var outcome = ScalarWriteOutcome()
+        let byKind = Dictionary(grouping: samples, by: \.kind)
+        for (kind, group) in byKind {
+            let hk: [HKQuantitySample] = group.compactMap { s in
+                guard let type = Self.quantityType(for: s.kind) else { return nil }
+                let q = HKQuantity(unit: Self.unit(for: s.kind), doubleValue: s.value)
+                return HKQuantitySample(type: type, quantity: q, start: s.start, end: s.end,
+                                        metadata: Self.metadata(for: s.kind))
+            }
+            guard !hk.isEmpty else { continue }   // no writable HK type for this kind — nothing to save
+            do {
+                try await store.save(hk)
+                outcome.written.append(contentsOf: group)
+            } catch {
+                outcome.failed.insert(kind)   // this metric is denied/failing; others still land
+            }
         }
-        guard !hkSamples.isEmpty else { return }
-        try await store.save(hkSamples)
+        return outcome
     }
 
     /// Metadata key on HRV samples flagging which statistic the value actually is.
@@ -591,7 +770,7 @@ final class HealthKitWriter {
                 try await writeRestingHR(bpm: d.bpm, day: d.day)
                 written += 1
                 newWatermark = d.day
-            } catch { break }  // stop at the first failure; already-written days stay covered
+            } catch { pendingFlushFailures.insert(.restingHeartRate); break }  // surface; stop, already-written days stay covered
         }
         if newWatermark > lastWritten {
             defaults.set(newWatermark.timeIntervalSince1970, forKey: Self.rhrWatermarkKey)
@@ -671,7 +850,7 @@ final class HealthKitWriter {
             defaults.set(today.timeIntervalSince1970, forKey: Self.activeDayKey)
             defaults.set(total, forKey: Self.activeWrittenKey)
             return delta
-        } catch { return 0 }
+        } catch { pendingFlushFailures.insert(.activeEnergy); return 0 }
     }
 
     /// The user's body profile, read from the shared `@AppStorage` keys (the same keys

--- a/ios/OpenCircuit/UserProfile.swift
+++ b/ios/OpenCircuit/UserProfile.swift
@@ -25,6 +25,12 @@ struct UserProfileSettingsView: View {
     private let historyInspector = HealthKitHistoryInspector()
     @State private var healthAuthorized = false
     @State private var healthUnavailable = false
+    /// Tri-state Health share status (#132): a PARTIAL grant (heart rate on, another type off) must
+    /// not read as a plain "Connected" while those metrics silently never reach Health.
+    @State private var healthShareState: HealthKitWriter.ShareState = .unauthorized
+    /// Persisted per-metric Health write failures (#135), surfaced here alongside the partial-grant
+    /// state so Profile and the dashboard tell one consistent story.
+    @State private var healthWriteFailures: [MetricKind] = []
     /// The one-time iOS permission sheet was already used (declined) — `requestAuthorization`
     /// would silently no-op, so the button must route to the Health app instead. Re-probed on
     /// appear, on foreground return (the user may have just flipped the toggles), and after a
@@ -142,13 +148,31 @@ struct UserProfileSettingsView: View {
 
             Section("Apple Health") {
                 if healthAuthorized {
-                    LabeledContent("Status") {
-                        Label("Connected", systemImage: "checkmark.circle.fill")
-                            .labelStyle(.titleAndIcon)
-                            .foregroundStyle(.green)
+                    let missing = healthAttentionNames
+                    if missing.isEmpty {
+                        LabeledContent("Status") {
+                            Label("Connected", systemImage: "checkmark.circle.fill")
+                                .labelStyle(.titleAndIcon)
+                                .foregroundStyle(.green)
+                        }
+                        Text("OpenCircuit is writing your ring's metrics into Apple Health.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    } else {
+                        // A partial grant (#132) or a persisted write failure (#135): don't claim a
+                        // blanket "Connected" while these metrics silently never reach Health.
+                        LabeledContent("Status") {
+                            Label("Partial", systemImage: "exclamationmark.triangle.fill")
+                                .labelStyle(.titleAndIcon)
+                                .foregroundStyle(.orange)
+                        }
+                        Text("These aren't reaching Apple Health: \(missing.joined(separator: ", ")).")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Button {
+                            openURL(HealthKitWriter.healthAppURL)
+                        } label: {
+                            Label("Review in the Health App", systemImage: "heart.text.square")
+                        }
                     }
-                    Text("OpenCircuit is writing your ring's metrics into Apple Health.")
-                        .font(.caption).foregroundStyle(.secondary)
                 } else if HealthKitWriter.isAvailable {
                     if healthPromptExhausted {
                         // iOS shows the permission sheet once, ever — after a decline,
@@ -425,6 +449,10 @@ struct UserProfileSettingsView: View {
     /// the toggles in Health and returning flips it back to Connected.
     private func refreshHealthAuthState() async {
         healthAuthorized = health.isShareAuthorized
+        // Recompute the honest partial-grant (#132) + persisted write-failure (#135) surfaces at the
+        // same points, since the user can flip a type off in the Health app while away.
+        healthShareState = health.shareState
+        healthWriteFailures = HealthKitWriter.healthWriteFailures().keys.sorted { $0.rawValue < $1.rawValue }
         if healthAuthorized {
             healthUnavailable = false
             healthPromptExhausted = false
@@ -433,6 +461,17 @@ struct UserProfileSettingsView: View {
             // its tap path can throw and surface the sideload notice, as before.
             healthPromptExhausted = (await health.authorizationPromptAvailable()) == false
         }
+    }
+
+    /// Friendly names of metrics not reaching Health: partial-grant denied types (#132) unioned with
+    /// persisted per-metric write failures (#135), de-duplicated and sorted. Empty ⇒ fully connected.
+    private var healthAttentionNames: [String] {
+        var names = Set<String>()
+        if case .partial(let denied) = healthShareState {
+            names.formUnion(HealthKitWriter.friendlyNames(for: denied))
+        }
+        names.formUnion(healthWriteFailures.map(\.displayName))
+        return names.sorted()
     }
 
     private func formatGoalSleep(_ minutes: Int) -> String {

--- a/ios/OpenCircuitTests/HealthKitShareTypesTests.swift
+++ b/ios/OpenCircuitTests/HealthKitShareTypesTests.swift
@@ -63,6 +63,100 @@ final class HealthKitShareTypesTests: XCTestCase {
         XCTAssertEqual(defaults.double(forKey: HealthKitWriter.workoutActiveKcalKey), 30)
     }
 
+    // MARK: Partial-grant share state (#132)
+
+    /// A PARTIAL grant (heart rate on, other types off) must resolve to `.partial` with exactly the
+    /// denied set — not the blanket "authorized" that silently drops those metrics.
+    func testShareStatePartialListsDeniedTypes() {
+        let types = HealthKitWriter().allTypes
+        let spo2 = HKQuantityType(.oxygenSaturation)
+        let temp = HKQuantityType(.basalBodyTemperature)
+        let state = HealthKitWriter.resolveShareState(authorizableTypes: types) { type in
+            (type.isEqual(spo2) || type.isEqual(temp)) ? .sharingDenied : .sharingAuthorized
+        }
+        guard case .partial(let denied) = state else {
+            return XCTFail("expected .partial, got \(state)")
+        }
+        XCTAssertEqual(Set(denied), [spo2, temp])
+    }
+
+    func testShareStateAuthorizedWhenAllGranted() {
+        let types = HealthKitWriter().allTypes
+        let state = HealthKitWriter.resolveShareState(authorizableTypes: types) { _ in .sharingAuthorized }
+        XCTAssertEqual(state, .authorized)
+    }
+
+    /// Heart rate itself not granted ⇒ unauthorized regardless of the rest (mirrors isShareAuthorized).
+    func testShareStateUnauthorizedWhenHeartRateNotGranted() {
+        let types = HealthKitWriter().allTypes
+        let state = HealthKitWriter.resolveShareState(authorizableTypes: types) { type in
+            type.isEqual(HKQuantityType(.heartRate)) ? .notDetermined : .sharingAuthorized
+        }
+        XCTAssertEqual(state, .unauthorized)
+    }
+
+    /// Friendly names map through MetricKind, collapse both BP constituents to one label, and sort.
+    func testFriendlyNamesMapAndDedupe() {
+        let names = HealthKitWriter.friendlyNames(for: [
+            HKQuantityType(.oxygenSaturation),
+            HKQuantityType(.basalBodyTemperature),
+            HKQuantityType(.bloodPressureSystolic),
+            HKQuantityType(.bloodPressureDiastolic),   // collapses with systolic → one "Blood Pressure"
+            HKCategoryType(.sleepAnalysis),
+        ])
+        XCTAssertEqual(names, ["Blood Pressure", "Skin Temp", "Sleep", "SpO₂"])
+    }
+
+    // MARK: Persisted per-metric write-failure map (#135)
+
+    /// The failure map stamps failed metrics, clears a metric on its next successful write, and
+    /// keeps "nothing pending" (empty map) distinct from "writes failing".
+    func testWriteFailureMapPersistsAndClearsPerMetric() {
+        let suite = "HealthKitShareTypesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertTrue(HealthKitWriter.healthWriteFailures(defaults).isEmpty)
+
+        // SpO₂ + Sleep fail this pass; HR wrote fine.
+        HealthKitWriter.recordFlushOutcome(written: [.heartRate], failed: [.spo2, .sleep],
+                                           now: Date(timeIntervalSince1970: 1000), defaults)
+        XCTAssertEqual(Set(HealthKitWriter.healthWriteFailures(defaults).keys), [.spo2, .sleep])
+
+        // Next pass: SpO₂ recovers (a later success wins), Sleep still failing → only Sleep remains.
+        HealthKitWriter.recordFlushOutcome(written: [.spo2], failed: [.sleep],
+                                           now: Date(timeIntervalSince1970: 2000), defaults)
+        XCTAssertEqual(Set(HealthKitWriter.healthWriteFailures(defaults).keys), [.sleep])
+
+        // Sleep recovers → map empties (back to a clean "nothing failing" state).
+        HealthKitWriter.recordFlushOutcome(written: [.sleep], failed: [],
+                                           now: Date(timeIntervalSince1970: 3000), defaults)
+        XCTAssertTrue(HealthKitWriter.healthWriteFailures(defaults).isEmpty)
+    }
+
+    /// A FlushResult with a failure but no writes is still NOT "wrote anything" — the UI must be able
+    /// to tell an idle store (no failures) from a failing one.
+    func testFlushResultFailuresDefaultEmptyAndDoNotCountAsWrite() {
+        var r = HealthKitWriter.FlushResult()
+        XCTAssertTrue(r.failures.isEmpty)
+        XCTAssertFalse(r.wroteAnything)
+        r.failures = [.sleep]
+        XCTAssertFalse(r.wroteAnything)
+    }
+
+    /// Distance is DERIVED from step rows and rides their single watermark, so it must only write
+    /// when steps saved — else a granted distance re-derives + re-writes every flush while the rows
+    /// stay pending and HealthKit sums the duplicate (~N× inflation). Guards that regression.
+    func testDistanceOnlyWritesWhenStepsSucceeded() {
+        // Steps failed → distance must NOT write/commit, regardless of distance's own status.
+        XCTAssertFalse(HealthKitWriter.distanceMayWrite(stepsFailed: true, distanceFailed: false))
+        XCTAssertFalse(HealthKitWriter.distanceMayWrite(stepsFailed: true, distanceFailed: true))
+        // Steps ok + distance denied → skip distance (deferred with the rows).
+        XCTAssertFalse(HealthKitWriter.distanceMayWrite(stepsFailed: false, distanceFailed: true))
+        // Both ok → distance writes.
+        XCTAssertTrue(HealthKitWriter.distanceMayWrite(stepsFailed: false, distanceFailed: false))
+    }
+
     func testDailyActiveEnergyNetsWorkoutCaloriesFromChosenDailyEstimate() {
         // HR channel dominates → credit nets the HR-derived daily estimate.
         XCTAssertEqual(


### PR DESCRIPTION
The P1 "is my data actually reaching Health?" cluster from the 2026-07-04 UX sweep.

Closes #132, closes #135, closes #143.

## What changed
**#132 (P1) — a partial Apple Health grant no longer silently drops metrics, and the UI stops lying.** Previously one denied share type threw `errorAuthorizationDenied` for the *whole* scalar `save` batch — so denying SpO₂ also dropped HR, temperature, etc. — while the card still read "Connected / Auto-syncing." Now:
- the scalar write is **split per `MetricKind`** and saved independently, so a denied kind can't fail another kind's save;
- the sync watermark advances **only for kinds that actually wrote** — a denied/failed kind stays pending and retries next flush; it is **never** marked written, so no measured data is silently skipped;
- the UI reads an honest `shareState`: when a type is denied/failing it shows amber "Some metrics aren't reaching Apple Health: SpO₂, Temperature — tap to turn them on" with a deep link into Health, instead of the green line.

**#135 — Health write failures are surfaced**, not swallowed forever: a persisted per-metric failure map drives the same amber status and self-clears when the metric next writes.

**#143 — new users are routed to Health auth**: a dashboard banner + an extracted `healthAuthPrompt` replace the authorize button that was buried under RE tooling.

## Review & verification
Adversarially reviewed — the P1 scalar core is **SOUND** (a denied kind never sinks the batch; the watermark advances only for written kinds; no silent loss of measured data). The review caught one **Medium** defect, now fixed:
- Steps and the **derived distance estimate share one watermark** (distance is re-derived from `StoredStepSample` rows and rides their `healthWritten` flag). Splitting them let a partial grant either **inflate** distance (steps denied + distance granted → distance re-written every flush → HealthKit sums duplicates) or drop it. Fixed by writing distance in a **separate pass gated on the step save succeeding** — a steps-denied flush never writes distance (no inflation; deferred with the rows), and the GPS-credit ledger is only committed when distance actually lands.
- Accepted tradeoff (documented in code): steps granted + distance denied → that window's distance estimate is skipped and won't backfill on re-enable. Distance is a derived estimate, not measured data; an independent `distanceWritten` flag + migration was out of scope.

`xcodebuild` (generic/iOS, Debug) **BUILD SUCCEEDED**; `HealthKitShareTypesTests` pass on-sim (share-state tri-state, friendly-name dedupe, failure-map persist/clear, distance-coupling truth table).

## Shared-file coordination (for merge)
The `ContentView` change is **additive** — a banner inserted as a sibling between the connection card and the section list; **no List rows reordered**, `.onMove` untouched. `UserProfile` edits are confined to the "Apple Health" section.

## Manual check
Deny one Health type (e.g. SpO₂) in Settings → the other metrics still sync and the card shows "Partial" naming SpO₂ with a working Health deep link; re-enable it → it resumes without data loss.

cc @bluna-ai for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
