### PR TITLE
fix(ios): final UX-sweep cleanup — metric profile entry, dev-tool gating, bounded epoch buffers (#151 #152 #157)

### DIFF
--- a/ios/OpenCircuit/BLE/RingSession.swift
+++ b/ios/OpenCircuit/BLE/RingSession.swift
@@ -2545,6 +2545,18 @@ extension RingSession: CBPeripheralDelegate {
                 // Sync-open ACK. At NOTICE so an ACCEPTED open (0x82 arrives) is distinguishable
                 // from a refused one (silence — cursor out of range); debug writes don't persist.
                 ringLog.notice("← 0x82 sync-open ACK: \(self.lastFrame ?? "", privacy: .public)")
+                // #157: the sync-open ACK marks the START of a fresh drain and always precedes this
+                // drain's first 0x47/0x4c page, so re-seed the (gated, #24) epoch-decode session here.
+                // Otherwise its raw page buffers accumulate for the whole life of the connection and
+                // every 0x50 re-parses ALL pages ever seen (O(n²) CPU, unbounded memory). Re-seeding at
+                // the open bounds the buffers to a single drain AND discards a previous drain's partial
+                // pages when it ended without a 0x50 (dropped link / watchdog-terminated sync). Safe:
+                // `syncSession` is a parallel decode SINK only — the drain's cursor/resume is driven by
+                // the ring's self-advancing resume pointer + the persisted SyncCursor, and real history
+                // records flow into the separate `bulkRecords` buffer (untouched here), so clearing this
+                // can neither drop drain data nor disturb a resume. The correct stream-high byte is
+                // recomputed from each drain's own 0x50 in `complete(with:)`, so a plain re-seed is fine.
+                self.syncSession = EpochSyncSession()
                 return
             case 0x50:
                 // End-of-history cursor report (§5.5) — NO XOR trailer, so it never

--- a/ios/OpenCircuit/ContentView.swift
+++ b/ios/OpenCircuit/ContentView.swift
@@ -152,7 +152,11 @@ struct ContentView: View {
                     // case the authorize button must deep-link to Health instead of no-opping.
                     healthPromptExhausted = (await health.authorizationPromptAvailable()) == false
                 }
+#if DEBUG
+                // #152: the BP estimate is served by the localhost desktop estimator (127.0.0.1:8765),
+                // so only poll it in DEBUG — a Release build makes no loopback request on launch.
                 await calibration.refreshLatestEstimateIfNeeded(minInterval: 0)
+#endif
             }
             // Foreground auto-refresh: reconnect to the last-known ring and pull fresh data
             // when the app becomes active, so opening it after a while shows updated vitals
@@ -162,7 +166,10 @@ struct ContentView: View {
                     handleForegroundActivation()
                     refreshObservability()        // pick up anything a background run wrote
                     evaluateForegroundAlerts()    // live battery + Health-auth check (#44)
+#if DEBUG
+                    // #152: dev-only localhost BP-estimate poll; never runs in Release.
                     Task { await calibration.refreshLatestEstimateIfNeeded() }
+#endif
                 } else if phase == .background {
                     // Don't leave a user-initiated foreground scan/picker running once we leave the
                     // foreground — a nil-filtered scan yields nothing in the background and just keeps
@@ -981,6 +988,12 @@ struct ContentView: View {
                       || session?.monitoring == true        // stop live before syncing
                       || session?.notStreaming == true)     // a not-streaming ring would sync nothing (#54)
 
+#if DEBUG
+            // #152: "One-time historic pull" and "Forensic sweep" are reverse-engineering capture
+            // tools — they dump the raw BLE exchange / probe unresolved channel selectors for Mac-side
+            // decoding, not something an end user can act on. Keep them out of Release. The legitimate
+            // "Sync from ring" button + freshness above and the sync-status/Health-mirror rows below
+            // stay visible. `.disabled(...)` guards preserved for the DEBUG build.
             Button {
                 session?.captureHistoricPull()
             } label: {
@@ -1009,10 +1022,17 @@ struct ContentView: View {
                       || session?.monitoring == true
                       || session?.probing == true
                       || session?.notStreaming == true)
+#endif
 
             if session?.monitoring == true {
                 Text("Stop live HR/SpO₂ before syncing.").font(.caption2).foregroundStyle(.secondary)
             }
+#if DEBUG
+            // #152: the calibration/BP block is a developer tool — it talks to the localhost desktop
+            // estimator (CalibrationSupport.defaultBaseURL = http://127.0.0.1:8765) and the BP number
+            // is produced by that server, not on-device. Keep it out of Release so production users
+            // never see a "Start calibration session" button they can't make work. (The shipping user
+            // rows above — freshness, Sync from ring, Health mirror — are untouched.)
             Divider()
             VStack(alignment: .leading, spacing: 10) {
                 HStack {
@@ -1066,9 +1086,13 @@ struct ContentView: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
+#endif
             if let status = session?.syncStatus, session?.syncing != true {
                 Text(status).font(.caption).foregroundStyle(.secondary)
             }
+#if DEBUG
+            // #152: status/log surfaces for the DEBUG-only RE capture tools above (historic pull +
+            // forensic sweep, incl. the raw-BLE-log share button). Gated so Release shows none of them.
             if let status = session?.historicPullStatus, session?.capturingHistoricPull != true {
                 Text(status).font(.caption).foregroundStyle(.secondary)
             }
@@ -1079,15 +1103,21 @@ struct ContentView: View {
                 Button("Share raw history capture") { shareProbeCapture(log) }
                     .font(.caption)
             }
+#endif
             Text("Use OpenCircuit as the sole sync app for this ring. Overnight sleep and heart-rate history are written after the morning history sync rather than as a live overnight stream on the home screen.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+#if DEBUG
+            // #152: these two captions describe the DEBUG-only RE capture tools ("raw BLE exchange" /
+            // "probes the unresolved channel selectors … for Mac-side reverse engineering"). Gated with
+            // the buttons they explain so Release never mentions them.
             Text("The one-time historic pull uses the same known two-channel drain as normal sync, but also records the raw BLE exchange so you can map exactly what was present on the ring at pull time.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
             Text("Forensic sweep goes further: it drains the known history channels first, then probes the unresolved channel selectors into the same raw log for Mac-side reverse engineering.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+#endif
 
             // Health mirror STATUS lives here once authorized (the first-run authorize prompt now
             // lives in the top-of-dashboard banner — #143 — so it isn't duplicated here). Show the

--- a/ios/OpenCircuit/UserProfile.swift
+++ b/ios/OpenCircuit/UserProfile.swift
@@ -3,6 +3,23 @@ import UIKit
 import UserNotifications
 import OpenCircuitKit
 
+/// Body-measurement ENTRY unit for the Profile section (#151). Storage stays canonical kg/cm
+/// (OpenCircuitKit's BMR math expects metric); this only picks which units the weight/height fields
+/// present and edit in. Defaults to the locale's measurement system so a metric-region user enters
+/// kg/cm out of the box. Kept local to this settings screen and mirrors the `DistanceUnit` shape in
+/// OpenCircuitKit's `UnitPreferences`.
+private enum BodyUnit: String, CaseIterable {
+    case metric   = "metric"    // kg / cm
+    case imperial = "imperial"  // lb + ft/in
+
+    static var localeDefault: BodyUnit {
+        if #available(iOS 16, *) {
+            return Locale.current.measurementSystem == .us ? .imperial : .metric
+        }
+        return Locale.current.regionCode == "US" ? .imperial : .metric
+    }
+}
+
 @MainActor
 struct UserProfileSettingsView: View {
     @AppStorage("userProfile.age") private var age = 35
@@ -74,6 +91,9 @@ struct UserProfileSettingsView: View {
     // Unit preferences (#83). Default to locale-appropriate units out of the box.
     @AppStorage("units.temperature") private var tempUnitRaw = TemperatureUnit.localeDefault.rawValue
     @AppStorage("units.distance")    private var distUnitRaw = DistanceUnit.localeDefault.rawValue
+    // Body-measurement entry unit (#151). Storage stays kg/cm; only the Profile weight/height
+    // fields switch between kg/cm and lb + ft/in. Defaults to the locale's measurement system.
+    @AppStorage("units.body")        private var bodyUnitRaw = BodyUnit.localeDefault.rawValue
 
     // Local calibration server + BP estimate Health writeback.
     @AppStorage(CalibrationDefaults.baseURLKey) private var calibrationBaseURL = CalibrationDefaults.defaultBaseURL
@@ -120,33 +140,58 @@ struct UserProfileSettingsView: View {
                 }
                 LabeledContent("Weight") {
                     HStack(spacing: 4) {
-                        TextField("lb", value: weightLb, format: .number.precision(.fractionLength(0)))
-                            .keyboardType(.decimalPad)
-                            .multilineTextAlignment(.trailing)
-                        Text("lb").foregroundStyle(.secondary)
+                        if bodyUnit == .metric {
+                            // Metric path (#151): bind straight to the canonical kg store, no conversion.
+                            TextField("kg", value: $weightKg, format: .number.precision(.fractionLength(1)))
+                                .keyboardType(.decimalPad)
+                                .multilineTextAlignment(.trailing)
+                            Text("kg").foregroundStyle(.secondary)
+                        } else {
+                            TextField("lb", value: weightLb, format: .number.precision(.fractionLength(0)))
+                                .keyboardType(.decimalPad)
+                                .multilineTextAlignment(.trailing)
+                            Text("lb").foregroundStyle(.secondary)
+                        }
                     }
                 }
                 LabeledContent("Height") {
                     HStack(spacing: 4) {
-                        TextField("ft", value: $heightFeetInput, format: .number)
-                            .keyboardType(.numberPad)
-                            .multilineTextAlignment(.trailing)
-                            .frame(maxWidth: 36)
-                            .onChange(of: heightFeetInput) { _, _ in commitHeight() }
-                        Text("ft").foregroundStyle(.secondary)
-                        TextField("in", value: $heightInchesInput, format: .number)
-                            .keyboardType(.numberPad)
-                            .multilineTextAlignment(.trailing)
-                            .frame(maxWidth: 36)
-                            .onChange(of: heightInchesInput) { _, newValue in
-                                // A typed value ≥12 (or negative) snaps back into 0...11.
-                                let clamped = min(max(newValue, 0), 11)
-                                if clamped != newValue { heightInchesInput = clamped }
-                                commitHeight()
-                            }
-                        Text("in").foregroundStyle(.secondary)
+                        if bodyUnit == .metric {
+                            // Metric path (#151): a single cm field bound to the canonical store. No
+                            // ft/in local buffers, so `commitHeight()` can't clobber a cm entry.
+                            TextField("cm", value: $heightCm, format: .number.precision(.fractionLength(0)))
+                                .keyboardType(.decimalPad)
+                                .multilineTextAlignment(.trailing)
+                                .frame(maxWidth: 64)
+                            Text("cm").foregroundStyle(.secondary)
+                        } else {
+                            TextField("ft", value: $heightFeetInput, format: .number)
+                                .keyboardType(.numberPad)
+                                .multilineTextAlignment(.trailing)
+                                .frame(maxWidth: 36)
+                                .onChange(of: heightFeetInput) { _, _ in commitHeight() }
+                            Text("ft").foregroundStyle(.secondary)
+                            TextField("in", value: $heightInchesInput, format: .number)
+                                .keyboardType(.numberPad)
+                                .multilineTextAlignment(.trailing)
+                                .frame(maxWidth: 36)
+                                .onChange(of: heightInchesInput) { _, newValue in
+                                    // A typed value ≥12 (or negative) snaps back into 0...11.
+                                    let clamped = min(max(newValue, 0), 11)
+                                    if clamped != newValue { heightInchesInput = clamped }
+                                    commitHeight()
+                                }
+                            Text("in").foregroundStyle(.secondary)
+                        }
                     }
-                    .onAppear { seedHeightInputs() }
+                    // Seed the ft/in buffers from the current `heightCm` when the imperial fields are
+                    // (or become) visible — on first appear AND when the user flips the unit picker to
+                    // imperial — so switching shows the converted value rather than a stale 0 ft 0 in
+                    // (which would immediately commit and wipe the stored height). No-op for metric.
+                    .onAppear { if bodyUnit == .imperial { seedHeightInputs() } }
+                    .onChange(of: bodyUnitRaw) { _, newRaw in
+                        if newRaw == BodyUnit.imperial.rawValue { seedHeightInputs() }
+                    }
                 }
                 Picker("Sex", selection: $sexRaw) {
                     ForEach(BiologicalSex.allCases, id: \.rawValue) { sex in
@@ -418,8 +463,12 @@ struct UserProfileSettingsView: View {
                     Text("km").tag(DistanceUnit.metric.rawValue)
                     Text("mi").tag(DistanceUnit.imperial.rawValue)
                 }
-                Text("Affects how temperature and distance values are shown throughout the app. "
-                     + "Values are always stored in metric internally.")
+                Picker("Body measurements", selection: $bodyUnitRaw) {
+                    Text("kg, cm").tag(BodyUnit.metric.rawValue)
+                    Text("lb, ft/in").tag(BodyUnit.imperial.rawValue)
+                }
+                Text("Affects how temperature, distance, and body measurements are shown throughout "
+                     + "the app. Values are always stored in metric internally.")
                     .font(.caption).foregroundStyle(.secondary)
             }
 
@@ -561,7 +610,11 @@ struct UserProfileSettingsView: View {
 
     // MARK: Imperial display over metric storage
     // Storage stays kg/cm (OpenCircuitKit's BMR math expects metric); these bindings present
-    // and edit it in lb / ft+in, converting on the way through.
+    // and edit it in lb / ft+in, converting on the way through. The imperial path is used only
+    // when `bodyUnit == .imperial` (#151); the metric path binds the kg/cm stores directly.
+
+    /// Resolved body-measurement entry unit (#151), defaulting to metric if the stored raw is unknown.
+    private var bodyUnit: BodyUnit { BodyUnit(rawValue: bodyUnitRaw) ?? .metric }
 
     private static let lbPerKg = 2.2046226218
     private static let cmPerIn = 2.54

--- a/ios/OpenCircuit/WorkoutView.swift
+++ b/ios/OpenCircuit/WorkoutView.swift
@@ -110,7 +110,7 @@ struct WorkoutView: View {
             // Best-effort HR note (#45)
             HStack(alignment: .top, spacing: 8) {
                 Image(systemName: "info.circle").foregroundStyle(.secondary)
-                Text("Live heart rate during workouts is best-effort (issue #45: on-demand polling, no background refresh). HR gaps will be shown honestly — data is never fabricated.")
+                Text("Live heart rate during workouts is best-effort (on-demand polling, no background refresh). HR gaps will be shown honestly — data is never fabricated.")
                     .font(.caption).foregroundStyle(.secondary)
             }
             .padding(10)
@@ -241,7 +241,7 @@ struct WorkoutView: View {
             }
 
             // #45 disclaimer
-            Text("Live HR is best-effort (polling, no background refresh — issue #45). Gaps are shown honestly.")
+            Text("Live HR is best-effort (polling, no background refresh). Gaps are shown honestly.")
                 .font(.caption2).foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
@@ -313,7 +313,7 @@ struct WorkoutView: View {
                             )
                         }
                     } else {
-                        Text("No HR zone data captured (insufficient readings — see issue #45).")
+                        Text("No HR zone data captured (insufficient readings).")
                             .font(.caption).foregroundStyle(.secondary)
                     }
                 }
@@ -323,7 +323,7 @@ struct WorkoutView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     if summary.hrSampleCount < 30 {
                         noteRow(icon: "exclamationmark.triangle", color: .orange,
-                                text: "Few HR readings captured (\(summary.hrSampleCount)). Live HR polling is best-effort — the ring may have missed updates (issue #45).")
+                                text: "Few HR readings captured (\(summary.hrSampleCount)). Live HR polling is best-effort — the ring may have missed updates.")
                     }
                     if summary.estimatedActiveKcal != nil {
                         // Label the ACTUAL source: HR-TRIMP when HR locked, else the GPS-distance


### PR DESCRIPTION
Closes out the build-18 UX sweep — the last four polish items, shipped together as build 20's UX refactor.

Closes #151, closes #152, closes #157.

## What changed
- **#151 — metric profile entry.** Weight/height entry was imperial-only (lb, ft/in). Added a "Body measurements" unit picker with a metric (kg/cm) path alongside imperial, defaulting by locale (`Locale.current.measurementSystem`). Underlying storage stays kg/cm, so BMR math is unaffected; switching units preserves the stored value (no zero-clobber).
- **#152 — dev/RE tooling out of the shipping dashboard.** The "History & sleep" card exposed the localhost BP-calibration workflow ("Start calibration session" / "Refresh BP estimate" / BP row), plus the "One-time historic pull" and "Forensic sweep" RE-capture tools — none of which work without a Mac-side `127.0.0.1:8765` server. All of it is now behind `#if DEBUG`, and both launch/foreground calibration polls are gated, so a Release build shows only the real user rows (Sync from ring, freshness, status, Health mirror) and issues no loopback traffic.
- **#157 — bounded epoch buffers.** `EpochSyncSession` page buffers accumulated for the life of the connection and every end-of-history frame re-parsed the whole accumulation (O(n²)). Now re-seeded per drain at the `0x82` open-ACK, bounding memory to a single drain. It's decoupled from the cursor/resume and `bulkRecords` history path, so clearing it cannot drop data or disturb a resume.
- **Copy** — stripped internal "(issue #45)" tracker IDs from 4 user-facing WorkoutView strings.

## Review & verification
Adversarially reviewed — **SOUND**, no defects:
- #157: `syncSession` confirmed decoupled from history/cursor; each drain gets a fresh session and `complete()` reparses only its own pages (recomputing the stream-high byte from that drain's `0x50`); an aborted drain's stale pages are discarded at the next open.
- #152: all five dev items compile out of Release (4 balanced `#if DEBUG` pairs), user rows stay, Release compiles with no reference to a gated-out symbol, no `127.0.0.1` poll.
- #151: unit-switch round-trip preserves `heightCm`/`weightKg` (no clobber), correct locale default.
- **Debug + Release both BUILD SUCCEEDED.**

cc @bluna-ai for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
