### PR TITLE
Fix workout rearming and short-gap sleep windows

### DIFF
--- a/ios/OpenCircuit/BLE/RingSession.swift
+++ b/ios/OpenCircuit/BLE/RingSession.swift
@@ -247,6 +247,11 @@ final class RingSession: NSObject {
     /// Fires once after the notify subscription is confirmed: if no DATA frame has arrived within
     /// `firstFrameTimeout`, flips `notStreaming` (ring not activated/bonded). #54.
     private var streamWatchdogTask: Task<Void, Never>?
+    /// Re-applies the user's persisted automatic-workout preference once per authenticated
+    /// connection. The ring-side setting is not queryable, so a remembered local `true` must not
+    /// be treated as proof that firmware is still armed after a reboot/reconnect.
+    private var automaticWorkoutReassertTask: Task<Void, Never>?
+    private var automaticWorkoutDetectionAppliedThisConnection = false
     /// Seconds after a confirmed subscription to wait for the ring's first DATA frame. The keepalive
     /// starts writing status/fetch immediately on `ready`, so an activated ring answers well within
     /// this; only an un-activated ring stays silent past it.
@@ -767,6 +772,7 @@ final class RingSession: NSObject {
         autoMeasureTask?.cancel(); autoMeasureTask = nil
         postSyncStatusTask?.cancel(); postSyncStatusTask = nil
         streamWatchdogTask?.cancel(); streamWatchdogTask = nil
+        automaticWorkoutReassertTask?.cancel(); automaticWorkoutReassertTask = nil
         syncTask?.cancel(); syncTask = nil
         rssiPollTask?.cancel(); rssiPollTask = nil   // Find My Ring RSSI poll (#96)
         // #reconnect (review HIGH): tear down SPORT too. Without this the sport-enter task — its `06 03`
@@ -2226,17 +2232,53 @@ final class RingSession: NSObject {
         return true
     }
 
-    /// Change the ring's persistent automatic-workout detector (#179). `05 23 01 00` / `00 00` is
+    /// Change the ring's automatic-workout detector (#179). `05 23 01 00` / `00 00` is
     /// captured ground truth from the official app. The local flag gates the extra foreground sport
-    /// history drain and is written only when the command can actually be sent.
+    /// history drain and records the user's desired state; enabled state is re-asserted once per
+    /// authenticated connection because firmware state cannot currently be queried.
     @discardableResult
     func setAutomaticWorkoutDetection(enabled: Bool) -> Bool {
         guard ready, syncTask == nil, !monitoring, !workoutHolding else { return false }
         write(Command.automaticSportRecognition(enabled: enabled))
         automaticWorkoutDetectionEnabled = enabled
         UserDefaults.standard.set(enabled, forKey: automaticWorkoutDetectionKey)
+        automaticWorkoutDetectionAppliedThisConnection = true
+        automaticWorkoutReassertTask?.cancel()
+        automaticWorkoutReassertTask = nil
         ringLog.notice("automatic workout detection: \(enabled ? "ENABLED (05 23 01 00)" : "disabled (05 23 00 00)", privacy: .public)")
         return true
+    }
+
+    /// A persisted toggle is desired state, not an observation of firmware state. Wait until the
+    /// link has delivered authenticated data and the single-writer BLE path is idle, then arm the
+    /// detector again. This runs once per RingSession (therefore once per reconnect) and never
+    /// interrupts history, live measurement, calibration, or a manual workout.
+    private func reassertAutomaticWorkoutDetectionIfNeeded() {
+        guard automaticWorkoutDetectionEnabled,
+              !automaticWorkoutDetectionAppliedThisConnection,
+              automaticWorkoutReassertTask == nil else { return }
+        automaticWorkoutReassertTask = Task { [weak self] in
+            guard let self else { return }
+            defer { self.automaticWorkoutReassertTask = nil }
+            while !Task.isCancelled {
+                if self.ready,
+                   self.notifySubscribed,
+                   self.gotDataFrame,
+                   self.syncTask == nil,
+                   !self.syncing,
+                   !self.monitoring,
+                   !self.livePreparing,
+                   !self.workoutHolding,
+                   !self.calibrationCapturing {
+                    self.write(Command.automaticSportRecognition(enabled: true))
+                    self.automaticWorkoutDetectionAppliedThisConnection = true
+                    ringLog.notice("automatic workout detection: RE-ASSERTED after reconnect (05 23 01 00)")
+                    print("[OC] automatic workout detection RE-ASSERTED after reconnect")
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+        }
     }
 
     /// Merge retransmitted sport pages, retain the official app's two-day review window, rebuild
@@ -3269,6 +3311,7 @@ extension RingSession: CBPeripheralDelegate {
             if self.ready {
                 self.startKeepalive()      // continuous descriptor polling (temp/steps/battery)
                 self.startAutoMeasure()    // periodic HR/SpO₂ reads so those refresh on their own
+                self.reassertAutomaticWorkoutDetectionIfNeeded()
             }
         }
     }
@@ -3757,7 +3800,10 @@ extension RingSession: CBPeripheralDelegate {
             }
             self.notifySubscribed = characteristic.isNotifying
             ringLog.notice("notify subscribed=\(characteristic.isNotifying)")
-            if characteristic.isNotifying { self.startStreamWatchdog() }
+            if characteristic.isNotifying {
+                self.startStreamWatchdog()
+                self.reassertAutomaticWorkoutDetectionIfNeeded()
+            }
         }
     }
 

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
@@ -214,6 +214,11 @@ public enum SleepStaging {
         /// night — including the 100 %-efficiency ones — stages byte-identically to the pre-widen
         /// model (the regression escape hatch, mirroring `motionAwakeVitalsHalfWindow = 0`). ~24 ≈ 1 h.
         public var preOnsetBedtimeReachEpochs: Int
+        /// Largest short sensor/history gap (in 150-second epoch intervals) that the bedtime widen
+        /// may cross. A few missing epochs are common while the ring changes measurement state; a
+        /// much longer awake-bordered hole remains ambiguous and must not be called time in bed.
+        /// ~5 ≈ 12.5 min, covering the device-observed 2026-07-18 11-minute dropout.
+        public var preOnsetBedtimeMaxGapEpochs: Int
 
         public init(awakeMotion: Int = 15,
                     deepHRPercentile: Double = 0.42,
@@ -240,7 +245,8 @@ public enum SleepStaging {
                     onsetSearchEpochs: Int = 48,
                     minConsolidatedSleepEpochs: Int = 16,
                     deepBaselineMarginBPM: Double = 18,
-                    preOnsetBedtimeReachEpochs: Int = 24) {
+                    preOnsetBedtimeReachEpochs: Int = 24,
+                    preOnsetBedtimeMaxGapEpochs: Int = 5) {
             self.awakeMotion = awakeMotion
             self.deepHRPercentile = deepHRPercentile
             self.remHRPercentile = remHRPercentile
@@ -267,6 +273,7 @@ public enum SleepStaging {
             self.minConsolidatedSleepEpochs = minConsolidatedSleepEpochs
             self.deepBaselineMarginBPM = deepBaselineMarginBPM
             self.preOnsetBedtimeReachEpochs = preOnsetBedtimeReachEpochs
+            self.preOnsetBedtimeMaxGapEpochs = preOnsetBedtimeMaxGapEpochs
         }
 
         public static let `default` = Tuning()
@@ -425,9 +432,11 @@ public enum SleepStaging {
             let t = r.date(epoch: epoch)
             let hr = Double(r.heartRate!)
             let gap = prevTime.timeIntervalSince(t)
-            // Tolerate a single dropped epoch (real 0x4c streams drop one now and then) so an awake
-            // lead-in with a lone gap isn't cut short; larger gaps still need the asleep-bridge.
-            let contiguous = gap <= interval * 2.5
+            // Tolerate a SHORT dropout (real 0x4c streams can miss several epochs while changing
+            // measurement state) so measured awake lead-in is not discarded. Longer gaps still
+            // require sleep-level HR on both sides and therefore retain the anti-fabrication guard.
+            let maxShortGap = interval * Double(max(1, tuning.preOnsetBedtimeMaxGapEpochs))
+            let contiguous = gap <= maxShortGap
             let asleepBridge = hr <= wakeThreshold && prevHR <= wakeThreshold
             guard contiguous || asleepBridge else { break }
             bedStart = t

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/BedtimeWidenTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/BedtimeWidenTests.swift
@@ -177,4 +177,22 @@ final class BedtimeWidenTests: XCTestCase {
         let on = SleepStaging.classify(from: recs, tuning: tuning(reach: 48))
         XCTAssertEqual(inBedStart(on), onset(on), "an awake-bordered gap is not bridged (no widen)")
     }
+
+    func testShortAwakeBorderedDropoutStillWidens() {
+        // Device regression 2026-07-18: a measured elevated-HR lead-in ended about 11 minutes
+        // before the flat sleep block. Treat that as a routine sensor/history dropout, not enough
+        // ambiguity to throw away the whole measured bedtime lead-in. The 30-minute guard above
+        // remains a no-op, bounding how much unknown time the envelope can absorb.
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 100_000
+        for _ in 0..<12 { recs.append(mrec(c, hr: 78)); c += step }
+        c += step * 3                                                // 10 min separation
+        for _ in 0..<120 { recs.append(srec(c, hr: 52)); c += step }
+
+        let on = SleepStaging.classify(from: recs, tuning: tuning(reach: 48))
+        guard let bed = inBedStart(on), let sleep = onset(on) else { return XCTFail("no segments") }
+        XCTAssertLessThan(bed, sleep, "a short dropout must not erase measured awake-in-bed lead-in")
+        XCTAssertGreaterThan(SleepStaging.summary(on).awake, 0)
+        XCTAssertLessThan(SleepStaging.summary(on).efficiency, 1.0)
+    }
 }


### PR DESCRIPTION
## What changed

- Re-assert automatic workout recognition once per authenticated, idle ring connection when the saved preference is enabled.
- Treat the saved workout toggle as desired state instead of proof of current firmware state.
- Allow bedtime widening to cross short sensor/history dropouts up to 12.5 minutes while preserving the existing long-gap anti-fabrication guard.
- Add a regression test for the device-observed 11-minute pre-sleep dropout.

## Why

A 30-minute workout produced movement data but no sport-history records after reconnect because OpenCircuit remembered the enabled toggle without reapplying the ring-side command. Separately, an 11-minute pre-sleep history gap caused measured awake-in-bed epochs to be discarded, collapsing time in bed onto time asleep at 100% efficiency.

## Impact

Workout detection is re-armed reliably after reconnects. Sleep summaries retain measured bedtime lead-in across brief dropouts without shifting sleep onset or inflating time asleep.

## Validation

- `swift test`: 792 tests passed.
- Device-targeted Xcode build succeeded.
- Physical-device log confirmed workout recognition was re-asserted after reconnect.
- Physical-device archive replay corrected the affected night from 0 awake minutes / 100% efficiency to 29 awake minutes / 94.7% efficiency while preserving 510 asleep minutes.