### PR TITLE
fix(sleep): locate final wake from the ring's SpO2 duty cycle, not from the last record (#190)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -428,6 +428,38 @@ time (no 12 h offset in this capture; bears on §5.6/§6.6). Reassemble + decode
   sleep-vitals = "not the idle template AND `[8]` ∉ {`0x12`,`0x13`}", so a sub-87 % desaturation
   still keeps its HR/HRV/SpO2 (the old value-gate dropped the whole epoch — see `BulkSleep.swift`).
 
+**The SpO2 DUTY CYCLE — the ring's own "I am measuring sleep" witness** 🟢 (2026-08-09, #190).
+While the ring runs its sleep-measurement program it takes an SpO2 reading every **300 s**. Epochs
+are 150 s, so consecutive `0x4c` records ALTERNATE sleep-vitals / activity **1:1**, and the
+alternation stops when the program exits — which is at, or just after, final wake. Measured over
+5650 unique records / 4 rings, re-derived independently from raw frames by a second decoder with
+**0 byte conflicts**:
+
+| observation | value |
+|---|---|
+| sleep-vitals inter-arrival, modal bin | **300 s** on every ring (AD 68.3 %, 9F 63.1 %, u3 83.6 %, u4 78.1 %) |
+| consecutive same-template pairs, ring AD | activity-activity 1305 vs sleepVitals-sleepVitals **24** — the ring essentially never emits two SpO2 reads in a row |
+| same-template ("violation") rate | **6.0 %** inside the staged sleep window vs **43.6 %** outside |
+| split at the user-reported wake | 3.9 % → 23.8 % (08-09); 1.6 % → 34.8 % (08-05) |
+| Mann-Whitney AUC vs wake | **0.819–1.000**, far above SpO2 (0.44/0.41), RR (0.61/0.59), HRV (0.79/0.50) or the confidence byte (0.42/0.27) |
+
+Confounds are REFUTED, not assumed: 20 sync, drain and BLE-reconnect events sit strictly INSIDE
+violation-free runs (including four successful drains inside one 5.7 h run, and a BLE
+teardown+reconnect inside a 191-epoch run), and the apparent 3.2× page-boundary enrichment goes to
+**0.0 %** under regime control (147 cross-page pairs inside the quiet regime, zero violations).
+
+⚠️ **Name it correctly.** This is a rule about **`[8]`, the SpO2 byte** — `BulkRecord.layout` is a
+discriminator *computed* from it (`0x12`/`0x13` ⇒ activity), not a device mode tag. Any change to
+that discriminator's fall-through silently moves this signal.
+
+⚠️ **Two caveats before building on it.** (1) It is **jitter- and gap-sensitive**: 91 of 3432 steps
+on ring AD are 151–221 s with no record missing, so an exact `dt == 150` test suppresses 57 genuine
+violations; and dropping ONE interior epoch makes its neighbours same-template in 90.5 % of
+positions by construction. Use `round(dt/150)` and bridge a single hole by parity. (2) It does **not**
+hold for a whole night on every ring: `9F`/Air fragments into 1.3–3.8 h pieces (two per night), and
+`u4` holds the cadence for a continuous **11.96 h**, which no timezone makes a night — most likely
+continuous SpO2 enabled. Consumed by `SleepStaging.cadenceSteps` / `markCadenceWakeOffset`.
+
 **Sleep-vitals fields — confirmed against the RingConn app's readout for the
 2026-06-13 night** (avg HR 68 / HRV 65 ms / SpO2 98 %, low 93 % ~02:30–03:00):
 - **`[4]` = heart rate (bpm)** 🟢. Sleep-window mean ~60, dips to 56–57 in deep-sleep

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
@@ -302,6 +302,73 @@ public enum SleepStaging {
         /// ~5 ≈ 12.5 min, covering the device-observed 2026-07-18 11-minute dropout.
         public var preOnsetBedtimeMaxGapEpochs: Int
 
+        // --- SpO2-CADENCE wake OFFSET (the "reported wake is when you synced" fix, #190) ---------
+        // Every pass above locates final wake from the SLEEPER (HR, motion, HRV density). When the
+        // primary motion channel is a flat placeholder and the morning HR rise is small, all of them
+        // miss, and the staged night then runs to the LAST RECORD — so the reported wake is
+        // `lastRecord + 120 s`, i.e. whenever the user last synced. 🟢 MEASURED on 2026-08-09
+        // (FR02.018, build 39): truncating the same capture in 49 five-minute steps moved reported
+        // sleep 367 → 625 min, one +5 per step, with no byte of physiology changed.
+        //
+        // This pass locates the wake from the RING instead. While the ring runs its sleep-measurement
+        // program it takes an SpO2 reading every 300 s, which makes consecutive 150-second epochs
+        // alternate sleep-vitals / activity 1:1 (`BulkRecord.layout`). That duty cycle EXITS near
+        // wake. 🟢 CONFIRMED over 5650 unique records / 4 rings, re-derived independently from raw
+        // frames by a second decoder with 0 byte conflicts:
+        //   • sleep-vitals inter-arrival is modal at 300 s on every ring (63–84 %);
+        //   • on the primary ring, activity-activity same-template pairs number 1305 against just 24
+        //     sleepVitals-sleepVitals — the ring essentially never emits two SpO2 reads in a row;
+        //   • the same-template ("violation") rate is 6.0 % inside the staged sleep window and 43.6 %
+        //     outside it; split at the user-reported wake it goes 3.9 %→23.8 % (08-09) and
+        //     1.6 %→34.8 % (08-05);
+        //   • Mann-Whitney AUC 0.819–1.000 on the two labelled nights, far above every vitals channel
+        //     (SpO2 0.44/0.41, RR 0.61/0.59, HRV 0.79/0.50, confidence byte 0.42/0.27).
+        // Sync/drain/BLE confounds are REFUTED: 20 sync, drain and reconnect events sit strictly
+        // INSIDE violation-free runs, including four successful drains inside one 5.7 h run and a BLE
+        // teardown+reconnect inside 08-09's 191-epoch run. Cross-page enrichment goes to 0.0 % under
+        // regime control (147 cross-page pairs inside the quiet regime, zero violations).
+        //
+        // ⚠️ NAME IT CORRECTLY. `raw[8]` is the SpO2 byte (PROTOCOL §5.3; APK `spo2` loc 0xb) with
+        // `0x12`/`0x13` as "no SpO2 here" sentinels. `layout` is a discriminator COMPUTED at
+        // `BulkSleep.layout`, not a device mode tag — this is an SpO2-CADENCE rule, and any change to
+        // that discriminator's fall-through silently moves it.
+
+        /// Minimum length, in epochs, of the unbroken sleep-vitals/activity ALTERNATION that the wake
+        /// locator will trust as "the ring was running its sleep-measurement program here". The wake
+        /// candidate is the epoch immediately after the LAST such run. **0 DISABLES the pass entirely
+        /// — byte-identical to the pre-cadence staging** (the regression escape hatch every other
+        /// pass in this file carries: `motionAwakeVitalsHalfWindow`, `hrWakeRescueCeilingBPM`,
+        /// `preOnsetBedtimeReachEpochs`, `offsetNoReturnSpreadFraction`).
+        ///
+        /// 🟢 The admissible band is MEASURED, not guessed. Sweeping K over the 16-night local corpus
+        /// gives, per night, the closed interval of K that yields the SAME committed cut:
+        /// 08-09 [12,191] · 08-05 [7,119] · 08-05(export) [6,119] · 08-04 [6,27] · 08-04(export)
+        /// [6,27] · 08-02 [2,40] · 06-27 [4,161] · 06-30 [2,137]. The binding constraints are
+        /// 08-09's 11-epoch post-wake quiet run (K must exceed it) and 08-04's 27-epoch final run
+        /// (K must not exceed it), so every night in the corpus agrees for K ∈ [12, 27]. 20 is the
+        /// value that MAXIMISES the worst-case headroom over that corpus (7 epochs ≈ 17 min either
+        /// side); 12 — the value a naive `minConsolidatedSleepEpochs` reuse would pick — sits on a
+        /// ONE-epoch margin worth 43 minutes on 08-09.
+        ///
+        /// 🟡 The corpus behind that band is 16 nights / 5 rings, but the two nights carrying WAKE
+        /// GROUND TRUTH are the same person on the same ring (08-09 → 09:06, 08-05 → 08:02). That is
+        /// below this project's own evidence bar; see `docs/RUNBOOK_SLEEP_GROUNDTRUTH.md` and
+        /// `SleepEditLabel` for the supervised labels that should re-fit it.
+        public var cadenceWakeQuietEpochs: Int
+
+        /// Upper bound, in epochs, on a quiet run the locator will trust. A run LONGER than this is
+        /// not a night's sleep-measurement program — it is a ring left in continuous SpO2 mode, and
+        /// its "end" carries no information about when anyone woke up.
+        ///
+        /// 🔴 This gate does NOT fire anywhere in the local corpus (the longest trusted run is 191
+        /// epochs ≈ 7.96 h, on 08-09). It exists because the corpus DID produce the failure it guards
+        /// against: ring `u4` holds the 300 s cadence for a continuous 11.96 h — timezone-independent,
+        /// no zone makes that a night. On that ring the run happens to reach the data edge, which the
+        /// locator already declines; this bound is what stops the same ring being cut at a stray
+        /// violation once more data drains in behind it. 240 ≈ 10 h, i.e. above every real night
+        /// measured here and below the u4 regime.
+        public var cadenceWakeMaxQuietEpochs: Int
+
         public init(awakeMotion: Int = 15,
                     deepHRPercentile: Double = 0.42,
                     remHRPercentile: Double = 0.86,
@@ -332,7 +399,9 @@ public enum SleepStaging {
                     minConsolidatedSleepEpochs: Int = 16,
                     deepBaselineMarginBPM: Double = 18,
                     preOnsetBedtimeReachEpochs: Int = 24,
-                    preOnsetBedtimeMaxGapEpochs: Int = 5) {
+                    preOnsetBedtimeMaxGapEpochs: Int = 5,
+                    cadenceWakeQuietEpochs: Int = 20,
+                    cadenceWakeMaxQuietEpochs: Int = 240) {
             self.awakeMotion = awakeMotion
             self.deepHRPercentile = deepHRPercentile
             self.remHRPercentile = remHRPercentile
@@ -364,6 +433,8 @@ public enum SleepStaging {
             self.deepBaselineMarginBPM = deepBaselineMarginBPM
             self.preOnsetBedtimeReachEpochs = preOnsetBedtimeReachEpochs
             self.preOnsetBedtimeMaxGapEpochs = preOnsetBedtimeMaxGapEpochs
+            self.cadenceWakeQuietEpochs = cadenceWakeQuietEpochs
+            self.cadenceWakeMaxQuietEpochs = cadenceWakeMaxQuietEpochs
         }
 
         public static let `default` = Tuning()
@@ -554,6 +625,10 @@ public enum SleepStaging {
         // (forward-filled for variability) because forward-fill would make every post-onset epoch read
         // as sleep-vitals.
         var rows: [(time: Date, hr: Int, hrv: Int?, motion: Int, spo2: Int?, rr: Double?, vitals: Bool)] = []
+        // Parallel to `rows`: the record TEMPLATE each row came from. Kept out of the tuple because it
+        // is not a physiological channel — it is the ring's own SpO2 duty cycle, read by
+        // `markCadenceWakeOffset` alone (#190).
+        var rowLayouts: [BulkRecord.Layout] = []
         // Per-epoch motion energy is measured ABOVE a LOCAL idle floor (same rolling estimate as
         // detection). Gen 2 idles at ~1, Gen 3 at ~15–16 and DRIFTS across the night with posture
         // (16→24→39, 🟢 FR05.008 capture 2026-06-23). The old `$1 == 1 ? 0 : …` hard-coded Gen 2's
@@ -576,6 +651,7 @@ public enum SleepStaging {
             guard let hr = lastHR else { continue }   // skip until the first HR reading
             let motion = max(0, Int(rawMotion[idx] - floor[idx]))
             rows.append((r.date(epoch: epoch), hr, lastHRV, motion, lastSpo2, lastRR, r.hrvRMSSD != nil))
+            rowLayouts.append(r.layout)
         }
         guard rows.count >= 2 else { return [] }
 
@@ -676,6 +752,20 @@ public enum SleepStaging {
                                   margin: resolvedOffsetMargin(hr: hr, floor: sleepFloor, tuning: tuning),
                                   vitals: rows.map(\.vitals),
                                   notBefore: notBefore, tuning: tuning)
+
+        // --- SpO2-CADENCE OFFSET: where the ring LEFT its sleep-measurement program -
+        // The LOCATOR the pass above lacks (#190). Everything before this point reads the sleeper;
+        // this reads the RING. Runs AFTER the HR pass, and like it only ever ADDS trailing awake, so
+        // whichever of the two cuts EARLIER wins and neither can undo an onset pass or a rescue. It
+        // is bound by `lastRescuedIndex` — but DELIBERATELY NOT by `lastVitalsSoftened`. See the
+        // "WHY NOT `notBefore`" note on `markCadenceWakeOffset`: gating this pass on the softening
+        // is what made the whole result oscillate with sync time (🟢 measured, three sign changes and
+        // a 47-minute swing on 08-05 from 25 minutes of extra data).
+        markCadenceWakeOffset(&awake,
+                              cadence: cadenceSteps(times: rows.map(\.time), layouts: rowLayouts),
+                              smHR: smHR, floor: sleepFloor,
+                              margin: resolvedOffsetMargin(hr: hr, floor: sleepFloor, tuning: tuning),
+                              notBefore: lastRescuedIndex, tuning: tuning)
 
         // --- ONSET / OFFSET: trim leading & trailing awake -------------------------
         // The kept window runs from the start of the first SUSTAINED asleep run to the
@@ -1043,6 +1133,13 @@ public enum SleepStaging {
     /// Test seam for the percentile helper (which is `private`).
     static func percentileForTesting(_ xs: [Double], _ q: Double) -> Double { percentile(xs.sorted(), q) }
 
+    /// Test seam for the consolidated-run helper (which is `private`), so a fixture can ASSERT it is
+    /// exercising the survival guard rather than tripping an earlier one — the mutation that survived
+    /// round 1's suite was exactly a survival guard whose test declined for a different reason.
+    static func sleepSpanForTesting(_ awake: [Bool], sustain: Int) -> (Int, Int)? {
+        sleepSpan(awake, sustain: sustain)
+    }
+
     static func resolvedOffsetMargin(hr: [Double], floor: Double, tuning: Tuning) -> Double {
         guard tuning.offsetNoReturnSpreadFraction > 0, !hr.isEmpty else { return 0 }
         let spread = max(0, percentile(hr.sorted(), 0.50) - floor)
@@ -1150,6 +1247,165 @@ public enum SleepStaging {
         // too weak a backstop for a pass that removes sleep — it would let an 8-hour night commit down
         // to a quarter of an hour. `minConsolidatedSleepEpochs` (16 ≈ 40 min) is the same bar
         // `markLeadInWakeOnset` uses to decide a real night happened.
+        guard sleepSpan(candidate, sustain: tuning.minConsolidatedSleepEpochs) != nil else { return }
+        awake = candidate
+    }
+
+    // MARK: - SpO2-cadence wake locator (#190)
+
+    /// What one epoch-to-epoch step says about the ring's SpO2 duty cycle.
+    ///
+    /// While the ring runs its sleep-measurement program it reads SpO2 every 300 s, so consecutive
+    /// 150-second epochs alternate `.sleepVitals` / `.activity` 1:1 (see `Tuning.cadenceWakeQuietEpochs`
+    /// for the evidence). `.violation` is the ring emitting the SAME template twice in a row — the duty
+    /// cycle broke. `.unknown` is a step that carries NO cadence information and must never be read as
+    /// either.
+    enum CadenceStep: Equatable {
+        /// The template flipped exactly as the duty cycle demands (allowing for one bridged hole).
+        case alternating
+        /// Two same-template epochs in a row: the duty cycle broke here.
+        case violation
+        /// No cadence information: an unworn/idle epoch on either side, or a hole of more than one
+        /// missing epoch. **Absence of evidence, never evidence of a wake.**
+        case unknown
+    }
+
+    /// Classify every epoch-to-epoch step of the row series against the ring's SpO2 duty cycle.
+    ///
+    /// ⚠️ GAP- AND JITTER-AWARENESS IS LOAD-BEARING, not politeness. The naive test
+    /// `dt == epochSeconds && layout[i] == layout[i-1]` fails in BOTH directions, and they are
+    /// complementary, so neither can be traded for the other:
+    ///   • DROPPING one interior epoch makes its neighbours same-template in 90.5 % of positions BY
+    ///     CONSTRUCTION. A gap-blind rule reads that as a violation storm and severs the night; a
+    ///     blind-bridging rule was measured joining 70 missing epochs into a 25-epoch phantom
+    ///     *daytime* run. So exactly ONE missing epoch is bridged — its template is inferred from
+    ///     PARITY (after an even number of steps the template returns to itself) — and anything
+    ///     longer becomes `.unknown`.
+    ///   • JITTER: 91 of 3432 steps on the primary ring are not exactly 150 s (151–221 s) with no
+    ///     record missing at all. An exact-equality test silently suppresses 57 genuine violations,
+    ///     so the step count is `round(dt / 150)`, not `dt == 150`.
+    /// 🟢 Monte-Carlo dropout on 08-09 measured the two definitions failing in opposite directions: a
+    /// page lost at 08:36 makes the gap-aware rule cut 29.6 min EARLY, one lost at 09:06 makes the
+    /// gap-blind rule cut 17.9 min LATE.
+    ///
+    /// `index 0` is always `.unknown` — there is no step INTO the first row.
+    static func cadenceSteps(times: [Date], layouts: [BulkRecord.Layout]) -> [CadenceStep] {
+        guard times.count == layouts.count, !times.isEmpty else { return [] }
+        var out = [CadenceStep](repeating: .unknown, count: times.count)
+        for i in 1 ..< times.count {
+            let previous = layouts[i - 1], current = layouts[i]
+            // An unworn epoch is outside the measurement program altogether; it is not a violation.
+            guard previous != .idle, current != .idle else { continue }
+            let dt = times[i].timeIntervalSince(times[i - 1])
+            let steps = max(1, Int((dt / Double(BulkRecord.epochSeconds)).rounded()))
+            guard steps <= 2 else { continue }   // more than one epoch missing → no information
+            // One flip per epoch step, so after an EVEN number of steps the template returns to itself.
+            let expectedSame = steps.isMultiple(of: 2)
+            out[i] = ((previous == current) == expectedSame) ? .alternating : .violation
+        }
+        return out
+    }
+
+    /// Mark final wake at the point the ring LEFT its sleep-measurement program (#190).
+    ///
+    /// The wake candidate is the epoch right after the END of the LAST unbroken alternating run of at
+    /// least `tuning.cadenceWakeQuietEpochs` epochs. Every other pass in this file infers wake from the
+    /// SLEEPER; when the primary motion channel is a flat placeholder and the morning HR rise is small,
+    /// all of them miss and the night silently runs to the last record — so the reported wake becomes
+    /// `lastRecord + 120 s`, a function of when the user synced rather than of when they woke.
+    ///
+    /// It is deliberately the LAST qualifying run, not the LONGEST. 🟢 MEASURED: "end of the longest
+    /// violation-free run" is catastrophic — 06-29 → 04:38 (−4 h 28 m), 08-04 → 07:25 (−1 h 29 m) — and
+    /// "last" is also what protects a ring left in continuous SpO2 mode, whose final long run always
+    /// reaches the data edge and is therefore declined.
+    ///
+    /// GUARDS, in order. Each one is a decline, never a weaker cut:
+    ///  1. `cadenceWakeQuietEpochs == 0` — the pass is off; byte-identical to pre-cadence staging.
+    ///  2. No run of at least K anywhere after onset — the cadence never held for a plausible night.
+    ///  3. The run ends at the DATA EDGE — the ring was still in the program when the capture stopped,
+    ///     so no wake has been observed. This is the guard that keeps the pass from re-manufacturing
+    ///     the very "wake == last record" artefact it exists to remove.
+    ///  4. The run ends at a `.unknown` step (a hole) rather than a `.violation` — absence of evidence.
+    ///  5. The run is longer than `cadenceWakeMaxQuietEpochs` — not a night, a ring in continuous SpO2.
+    ///  6. `s > earliest` — suffix-only by construction, never reaching onset, a rescued second bout
+    ///     (`notBefore`), or further back from the tail than `onsetSearchEpochs` (48 ≈ 2 h), which is
+    ///     what bounds the total damage this pass can do.
+    ///  7. The HR NO-RETURN confirmation: smoothed HR must stay above `floor + margin` for the WHOLE
+    ///     remainder of the night. 🟢 This is the guard doing the real adjudicating work — it is what
+    ///     declines the cadence cut on 06-29 (which would otherwise remove 75 minutes from an
+    ///     UNLABELLED night) and on 08-07.
+    ///  8. A consolidated asleep run must still survive, the same bar `markPointOfNoReturnOffset` uses.
+    ///
+    /// ⚠️ It does NOT carry `markPointOfNoReturnOffset`'s terminal-REM VITALS guard, and that omission
+    /// is deliberate and measured. That guard's premise — "the sleep-vitals stream thins at true wake" —
+    /// is 🔴 REFUTED on this hardware: measured FROM the user-reported wake, the suffix/body vitals
+    /// ratio is 1.00 on 08-09 and 0.53 on 08-05 against a 0.50 bar, so it declines a perfectly placed
+    /// cut on both labelled nights, and no setting of `hrWakeRescueVitalsFraction` can rescue it
+    /// (08-09 needs 0.481 ≤ 0.476). The guard was a PROXY for "is the ring still measuring sleep here";
+    /// the cadence is that question asked directly, which is exactly why this pass can afford to drop it.
+    ///
+    /// ⚠️ WHY NOT THE FULL `notBefore`. `markPointOfNoReturnOffset` is held back by BOTH the second-bout
+    /// rescue and the motion-awake VITALS SOFTENING (`motionAwakeStrict[i] && !motionAwake[i]`). This
+    /// pass is held back only by the FORMER, and that is a measured decision, not an oversight. The
+    /// softening's last index is UNSTABLE UNDER SYNC TIME — it is derived from `tailStart`, from a
+    /// night-wide HR floor, and from a rolling median whose window is truncated at the data edge — so on
+    /// 2026-08-05 it flickered nil → 241 → 245 → nil → 245 → nil across consecutive 5-minute truncation
+    /// cuts. Gating on it reintroduced exactly the defect this pass exists to remove: 🟢 MEASURED
+    /// end-to-end, the reported night went 478 · 473 · 473 · 497 · 502 · 507 · 512 · 517 · 485 — three
+    /// sign changes and a 47-minute swing produced by nothing but when the user synced. With the
+    /// softening out of the gate the located wake is IDENTICAL (08:10:14) on every one of those cuts.
+    /// The two mechanisms also answer the SAME question at different fidelity — the softening infers
+    /// "the ring was still measuring sleep" from HRV epochs within ±3 epochs, the cadence reads the
+    /// ring's duty cycle directly — so deferring the direct witness to the proxy is backwards. What
+    /// still protects the moving-but-asleep restless morning the softening was written for is guard 7:
+    /// a sleeper whose HR is still near the floor fails the HR no-return confirmation and is not cut.
+    ///
+    /// `internal` rather than `private`, for the same reason as `markPointOfNoReturnOffset`: a synthetic
+    /// record fixture carries a constant motion byte that de-floors to "still" everywhere, so an "awake"
+    /// fixture stages as sleep and the assertions go vacuous. Its tests drive it directly.
+    static func markCadenceWakeOffset(_ awake: inout [Bool], cadence: [CadenceStep], smHR: [Double],
+                                      floor: Double, margin: Double, notBefore: Int? = nil,
+                                      tuning: Tuning) {
+        guard tuning.cadenceWakeQuietEpochs > 0, margin > 0,
+              !awake.isEmpty, cadence.count == awake.count, smHR.count == awake.count,
+              let (lo, _) = sleepSpan(awake, sustain: tuning.onsetSustainEpochs) else { return }
+        let n = awake.count
+        guard lo + 1 <= n else { return }
+        // The scan may not begin at or before onset or a rescued second bout (`notBefore`), nor
+        // further back than the onset passes are allowed to reach from their own edge. It is NOT held
+        // back by the motion-awake vitals softening — see "WHY NOT THE FULL `notBefore`" above.
+        let searchFloor = n - min(tuning.onsetSearchEpochs, n)
+        let earliest = max(lo, notBefore ?? lo, searchFloor)
+
+        // The LAST maximal alternating run of >= K epochs, and WHY it ended. `i == n` is the virtual
+        // step past the end of the data — the "regime never exited" terminator.
+        var trusted: (end: Int, length: Int, terminator: CadenceStep?)?
+        var start = lo
+        for i in (lo + 1) ... n {
+            let terminator: CadenceStep? = i < n ? cadence[i] : nil
+            guard terminator != .alternating else { continue }
+            let end = i - 1
+            if end - start + 1 >= tuning.cadenceWakeQuietEpochs {
+                trusted = (end, end - start + 1, terminator)
+            }
+            start = i
+        }
+        guard let run = trusted else { return }              // the cadence never held for a night
+        guard run.terminator == .violation else { return }   // data edge or hole: no wake observed
+        guard run.length <= tuning.cadenceWakeMaxQuietEpochs else { return }   // not a night
+
+        let s = run.end + 1
+        // `> earliest`, not `>=`: the onset epoch (and the last rescued epoch) must remain asleep.
+        guard s < n, s > earliest else { return }
+        // HR NO-RETURN CONFIRMATION — the same test `markPointOfNoReturnOffset` scans for, used here
+        // as a second, INDEPENDENT witness on a cut the cadence has already located. The cadence says
+        // where the ring stopped measuring sleep; this says the body never settled back afterwards.
+        guard let suffixMin = smHR[s...].min(), suffixMin > floor + margin else { return }
+
+        var candidate = awake
+        for i in s ..< n { candidate[i] = true }
+        // Only commit if a CONSOLIDATED asleep run survives — a pass that REMOVES sleep must not be
+        // able to commit a night down to a token fragment.
         guard sleepSpan(candidate, sustain: tuning.minConsolidatedSleepEpochs) != nil else { return }
         awake = candidate
     }

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepStagingCadenceOffsetTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/SleepStagingCadenceOffsetTests.swift
@@ -1,0 +1,408 @@
+import XCTest
+@testable import OpenCircuitKit
+
+// Tests for the SpO2-CADENCE trailing-edge wake locator (#190) — `cadenceSteps` and
+// `markCadenceWakeOffset`.
+//
+// The defect: when the primary motion channel is a flat placeholder and the morning HR rise is small,
+// every sleeper-side pass misses the wake, the staged night runs to the last record, and the reported
+// wake becomes `lastRecord + 120 s` — a function of when the user SYNCED. 🟢 Truncating one real
+// capture in 49 five-minute steps moved reported sleep 367 → 625 min with no byte of physiology
+// changed.
+//
+// The unit cases drive the pass DIRECTLY, for the same reason `SleepStagingOffsetTests` does: a
+// synthetic record sequence carries a constant motion byte that de-floors to "still" everywhere, so a
+// fixture built to look "awake" silently stages as sleep and the assertion goes vacuous. The
+// `classify` cases at the bottom cover the WIRING, and are written to go red under mutation — the
+// adversarial review of round 1 caught a suite that stayed green when the call site was deleted.
+final class SleepStagingCadenceOffsetTests: XCTestCase {
+
+    private let floor: Double = 50
+    private func asleepMask(_ n: Int) -> [Bool] { [Bool](repeating: false, count: n) }
+
+    /// Flat sleeping HR with a sustained rise over the last `tail` epochs — a rise that never returns.
+    private func hrRisingAtEnd(n: Int, tail: Int, sleepHR: Double = 52, wakeHR: Double = 62) -> [Double] {
+        (0..<n).map { $0 >= n - tail ? wakeHR : sleepHR }
+    }
+
+    /// `alternating` for `[0, quietEnd]`, then `terminator` at `quietEnd + 1`, then `.violation` after.
+    private func cadence(n: Int, quietEnd: Int,
+                         terminator: SleepStaging.CadenceStep = .violation) -> [SleepStaging.CadenceStep] {
+        var out = [SleepStaging.CadenceStep](repeating: .violation, count: n)
+        out[0] = .unknown
+        for i in 1 ... quietEnd where i < n { out[i] = .alternating }
+        if quietEnd + 1 < n { out[quietEnd + 1] = terminator }
+        return out
+    }
+
+    // MARK: - `cadenceSteps`: reading the ring's SpO2 duty cycle off the wire
+
+    private func times(_ n: Int, step: Int = BulkRecord.epochSeconds) -> [Date] {
+        (0..<n).map { Date(timeIntervalSince1970: TimeInterval(1_000_000 + $0 * step)) }
+    }
+    private func alternatingLayouts(_ n: Int) -> [BulkRecord.Layout] {
+        (0..<n).map { $0.isMultiple(of: 2) ? .sleepVitals : .activity }
+    }
+
+    func testPerfectAlternationIsAllAlternating() {
+        let steps = SleepStaging.cadenceSteps(times: times(10), layouts: alternatingLayouts(10))
+        XCTAssertEqual(steps[0], .unknown, "there is no step INTO the first row")
+        XCTAssertTrue(steps.dropFirst().allSatisfy { $0 == .alternating })
+    }
+
+    func testSameTemplateTwiceIsAViolation() {
+        let layouts: [BulkRecord.Layout] = [.sleepVitals, .activity, .activity, .sleepVitals]
+        let steps = SleepStaging.cadenceSteps(times: times(4), layouts: layouts)
+        XCTAssertEqual(steps, [.unknown, .alternating, .violation, .alternating])
+    }
+
+    /// ONE missing epoch is bridged by PARITY: after an even number of steps the template returns to
+    /// itself, so `S … S` across 300 s is the alternation intact, not a break. Dropping one interior
+    /// epoch makes its neighbours same-template in 90.5 % of positions BY CONSTRUCTION — a gap-blind
+    /// rule reads that as a violation storm.
+    func testOneMissingEpochIsBridgedByParity() {
+        let t = [0, 150, 450].map { Date(timeIntervalSince1970: TimeInterval(1_000_000 + $0)) }
+        let steps = SleepStaging.cadenceSteps(times: t, layouts: [.activity, .sleepVitals, .sleepVitals])
+        XCTAssertEqual(steps[2], .alternating, "S→(A dropped)→S is the cadence holding, not breaking")
+    }
+
+    func testOneMissingEpochWithTheWrongParityIsStillAViolation() {
+        let t = [0, 150, 450].map { Date(timeIntervalSince1970: TimeInterval(1_000_000 + $0)) }
+        let steps = SleepStaging.cadenceSteps(times: t, layouts: [.activity, .sleepVitals, .activity])
+        XCTAssertEqual(steps[2], .violation, "two steps must return to the SAME template")
+    }
+
+    /// More than one missing epoch carries NO information. 🟢 A blind-bridging rule was measured
+    /// joining 70 missing epochs into a 25-epoch phantom *daytime* quiet run.
+    func testTwoMissingEpochsCarryNoInformation() {
+        let t = [0, 150, 600].map { Date(timeIntervalSince1970: TimeInterval(1_000_000 + $0)) }
+        let steps = SleepStaging.cadenceSteps(times: t, layouts: [.activity, .sleepVitals, .sleepVitals])
+        XCTAssertEqual(steps[2], .unknown)
+    }
+
+    /// JITTER, not a hole: 91 of 3432 steps on the primary ring are 151–221 s with no record missing.
+    /// An exact `dt == 150` test silently suppresses 57 genuine violations.
+    func testJitteredStepUnderOneAndAHalfEpochsIsStillOneEpoch() {
+        let t = [0, 221].map { Date(timeIntervalSince1970: TimeInterval(1_000_000 + $0)) }
+        XCTAssertEqual(SleepStaging.cadenceSteps(times: t, layouts: [.sleepVitals, .sleepVitals])[1],
+                       .violation, "a 221 s step is ONE epoch — the violation must survive the jitter")
+        XCTAssertEqual(SleepStaging.cadenceSteps(times: t, layouts: [.sleepVitals, .activity])[1],
+                       .alternating)
+    }
+
+    /// An unworn epoch is outside the measurement program altogether — absence of evidence.
+    func testIdleEpochCarriesNoInformation() {
+        let steps = SleepStaging.cadenceSteps(times: times(3), layouts: [.sleepVitals, .idle, .sleepVitals])
+        XCTAssertEqual(steps, [.unknown, .unknown, .unknown])
+    }
+
+    func testMismatchedInputsProduceNothing() {
+        XCTAssertTrue(SleepStaging.cadenceSteps(times: times(3), layouts: alternatingLayouts(2)).isEmpty)
+        XCTAssertTrue(SleepStaging.cadenceSteps(times: [], layouts: []).isEmpty)
+    }
+
+    // MARK: - `markCadenceWakeOffset`: what the locator does
+
+    func testCutsAtTheEndOfTheLastQuietRun() {
+        var awake = asleepMask(120)
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cadence(n: 120, quietEnd: 99),
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake.firstIndex(of: true), 100,
+                       "wake is the epoch AFTER the last epoch of the trusted quiet run")
+        XCTAssertTrue(awake[100...].allSatisfy { $0 })
+    }
+
+    /// Suffix-only by construction — the pass may never punch a hole in the middle of a night.
+    func testMarkedRegionIsAlwaysASuffix() {
+        var awake = asleepMask(120)
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cadence(n: 120, quietEnd: 99),
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 4, tuning: .default)
+        guard let first = awake.firstIndex(of: true) else { return XCTFail("expected a cut") }
+        XCTAssertTrue(awake[first...].allSatisfy { $0 })
+        XCTAssertFalse(awake[..<first].contains(true))
+    }
+
+    /// THE KILL SWITCH. 0 must be a total no-op, so a regression can always be turned off in one line.
+    func testZeroQuietEpochsIsANoOp() {
+        var awake = asleepMask(120)
+        let before = awake
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cadence(n: 120, quietEnd: 99),
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20), floor: floor, margin: 4,
+                                           tuning: SleepStaging.Tuning(cadenceWakeQuietEpochs: 0))
+        XCTAssertEqual(awake, before)
+    }
+
+    func testNonPositiveMarginIsANoOp() {
+        var awake = asleepMask(120)
+        let before = awake
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cadence(n: 120, quietEnd: 99),
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 0, tuning: .default)
+        XCTAssertEqual(awake, before)
+    }
+
+    /// THE GUARD THAT STOPS THE PASS RE-MANUFACTURING THE VERY ARTEFACT IT EXISTS TO REMOVE. A quiet
+    /// run that is still going when the capture stops has not been observed to END — cutting there
+    /// would put the wake back at the data edge.
+    func testDeclinesWhenTheQuietRunReachesTheDataEdge() {
+        var awake = asleepMask(120)
+        let before = awake
+        var cad = [SleepStaging.CadenceStep](repeating: .alternating, count: 120)
+        cad[0] = .unknown
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cad,
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake, before, "an unterminated quiet run is not evidence of a wake")
+    }
+
+    /// A hole is absence of evidence, not evidence of a wake. This is what keeps a dropped page from
+    /// being read as "the ring left its sleep program here".
+    func testDeclinesWhenTheRunEndsAtAHoleRatherThanAViolation() {
+        var awake = asleepMask(120)
+        let before = awake
+        SleepStaging.markCadenceWakeOffset(&awake,
+                                           cadence: cadence(n: 120, quietEnd: 99, terminator: .unknown),
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake, before)
+    }
+
+    func testDeclinesWhenNoRunReachesTheQuietBar() {
+        var awake = asleepMask(120)
+        let before = awake
+        // Alternation that never holds for more than 5 epochs anywhere.
+        var cad = [SleepStaging.CadenceStep](repeating: .alternating, count: 120)
+        for i in stride(from: 0, to: 120, by: 6) { cad[i] = .violation }
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cad,
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake, before, "the cadence never held for a plausible night")
+    }
+
+    /// LAST, not LONGEST. 🟢 "End of the longest violation-free run" was measured catastrophic:
+    /// 06-29 → −4 h 28 m, 08-04 → −1 h 29 m.
+    func testTakesTheLastQualifyingRunNotTheLongest() {
+        var awake = asleepMask(120)
+        var cad = [SleepStaging.CadenceStep](repeating: .alternating, count: 120)
+        cad[0] = .unknown
+        cad[80] = .violation                              // long run  [0, 79]  (80 epochs)
+        for i in 100..<120 { cad[i] = .violation }        // short run [80, 99] (20) — the LAST at/above K,
+                                                          // and nothing qualifies after it
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cad,
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake.firstIndex(of: true), 100,
+                       "the LONGEST run ends at 79; taking it would delete two more hours of sleep")
+    }
+
+    /// The independent second witness. The cadence says where the ring stopped measuring sleep; this
+    /// says the body never settled back. 🟢 It is what declines the cut on 06-29, which would
+    /// otherwise remove 75 min from an UNLABELLED night.
+    func testDeclinesWhenHRSettlesBackToTheFloorAfterTheCut() {
+        var awake = asleepMask(120)
+        let before = awake
+        var hr = hrRisingAtEnd(n: 120, tail: 20)
+        hr[110] = 51                                    // one dip back to the floor after the cut
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cadence(n: 120, quietEnd: 99),
+                                           smHR: hr, floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake, before, "a suffix that returns to the sleeping floor is not final wake")
+    }
+
+    /// A pass that REMOVES sleep must not be able to commit a night down to a token fragment. The
+    /// fixture is a heavily fragmented night: every asleep run is 10 epochs — long enough for
+    /// `onsetSustainEpochs` (6) to find a span, too short for `minConsolidatedSleepEpochs` (16) — so
+    /// cutting the tail would leave no consolidated sleep at all.
+    func testDeclinesWhenNoConsolidatedSleepWouldSurvive() {
+        var awake = asleepMask(120)
+        for i in 0..<120 where (i % 12) >= 10 { awake[i] = true }   // 10 asleep, 2 awake, repeating
+        let seeded = awake
+        XCTAssertNotNil(SleepStaging.sleepSpanForTesting(seeded, sustain: 6),
+                        "fixture sanity: the pass must get past its own onset-span guard")
+        XCTAssertNil(SleepStaging.sleepSpanForTesting(seeded, sustain: 16),
+                     "fixture sanity: no consolidated run exists to survive with")
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cadence(n: 120, quietEnd: 99),
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake, seeded, "the cut must be reverted, not committed to a fragment")
+    }
+
+    /// `notBefore` — a rescued second bout must not be overturned by this pass.
+    func testCannotCutAtOrBeforeNotBefore() {
+        var awake = asleepMask(120)
+        let before = awake
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cadence(n: 120, quietEnd: 99),
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 4, notBefore: 105, tuning: .default)
+        XCTAssertEqual(awake, before)
+    }
+
+    /// The magnitude bound: the scan may not reach further back from the tail than the onset passes
+    /// may from theirs (`onsetSearchEpochs`, 48 ≈ 2 h). This is what caps the damage this pass can do.
+    func testCannotReachFurtherBackThanTheOnsetSearchBound() {
+        var awake = asleepMask(200)
+        let before = awake
+        // The quiet run ends at 99 — 100 epochs from the end, well outside the 48-epoch reach.
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cadence(n: 200, quietEnd: 99),
+                                           smHR: hrRisingAtEnd(n: 200, tail: 100),
+                                           floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake, before)
+    }
+
+    /// REGIME PLAUSIBILITY. 🔴 Does not fire anywhere in the local corpus (longest trusted run 191
+    /// epochs ≈ 7.96 h) — it exists because ring `u4` was measured holding the 300 s cadence for a
+    /// continuous 11.96 h, which no timezone makes a night.
+    func testDeclinesWhenTheQuietRunIsTooLongToBeANight() {
+        var awake = asleepMask(300)
+        let before = awake
+        let cad = cadence(n: 300, quietEnd: 259)          // 260 epochs ≈ 10.8 h
+        let hr = hrRisingAtEnd(n: 300, tail: 40)
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cad, smHR: hr,
+                                           floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake, before, "10.8 h of unbroken cadence is a ring in continuous SpO2 mode")
+
+        var relaxed = asleepMask(300)
+        SleepStaging.markCadenceWakeOffset(&relaxed, cadence: cad, smHR: hr, floor: floor, margin: 4,
+                                           tuning: SleepStaging.Tuning(cadenceWakeMaxQuietEpochs: 300))
+        XCTAssertEqual(relaxed.firstIndex(of: true), 260,
+                       "sanity: only the plausibility bound was stopping it")
+    }
+
+    func testMismatchedArrayLengthsAreANoOp() {
+        var awake = asleepMask(120)
+        let before = awake
+        SleepStaging.markCadenceWakeOffset(&awake, cadence: cadence(n: 100, quietEnd: 80),
+                                           smHR: hrRisingAtEnd(n: 120, tail: 20),
+                                           floor: floor, margin: 4, tuning: .default)
+        XCTAssertEqual(awake, before)
+    }
+
+    // MARK: - Fixtures
+
+    /// A still, sleep-vitals-bearing epoch (`.sleepVitals`).
+    private func vrec(_ counter: UInt32, hr: UInt8, hrv: UInt8 = 55) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: 23)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xFF)
+        b[2] = UInt8((counter >> 8) & 0xFF); b[3] = UInt8(counter & 0xFF)
+        b[4] = hr; b[5] = hrv; b[8] = 0x62
+        for k in 0..<5 { b[10 + k] = 1 }
+        return BulkRecord(b)!
+    }
+    /// A STILL epoch on the `.activity` template — the other half of the ring's SpO2 duty cycle.
+    /// ⚠️ Motion is the baseline `1`, NOT the `0x14` the offset suite's `arec` uses: this record means
+    /// "no SpO2 reading in this epoch", not "the wearer moved". Expressing sleep-vs-wake through motion
+    /// in a fixture is the flat-motion trap — a constant motion value de-floors to STILL and the
+    /// assertions go vacuous. Here wake is expressed as ELEVATED HR only.
+    private func qrec(_ counter: UInt32, hr: UInt8) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: 23)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xFF)
+        b[2] = UInt8((counter >> 8) & 0xFF); b[3] = UInt8(counter & 0xFF)
+        b[4] = hr; b[8] = 0x12
+        for k in 0..<5 { b[10 + k] = 1 }
+        return BulkRecord(b)!
+    }
+
+    /// THE 2026-08-09 SHAPE, in miniature. The ring alternates its SpO2 duty cycle 1:1 through the
+    /// night, then the duty cycle EXITS and the morning is same-template throughout. The wearer is
+    /// still (placeholder motion all night), the morning HR rise is far too small to clear
+    /// `wakeHRMarginBPM` (+18), and the ring keeps emitting sleep-vitals ACROSS the wake — so the
+    /// terminal-REM vitals guard on `markPointOfNoReturnOffset` declines and the cadence is the only
+    /// witness left. Without this pass the night runs to the last record.
+    private func cadenceExitNight(epochs: Int = 160, riseAt: Int = 120,
+                                  sleepHR: UInt8 = 54, wakeHR: UInt8 = 64) -> [BulkRecord] {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 1_000_000
+        for i in 0..<epochs {
+            if i >= riseAt {
+                recs.append(vrec(c, hr: wakeHR, hrv: 55))          // same template, every epoch
+            } else {
+                recs.append(i.isMultiple(of: 2) ? vrec(c, hr: sleepHR, hrv: 55) : qrec(c, hr: sleepHR))
+            }
+            c += UInt32(BulkRecord.epochSeconds)
+        }
+        return recs
+    }
+
+    // MARK: - Integration through `classify` (these go red if the call site is deleted)
+
+    /// PINS THE CALL SITE. The default is ENABLED, so this compares default against `0`.
+    func testEnabledByDefaultMovesTheStagedWakeVersusDisabled() {
+        let recs = cadenceExitNight()
+        let off = SleepStaging.classify(from: recs,
+                                        tuning: SleepStaging.Tuning(cadenceWakeQuietEpochs: 0))
+        let on = SleepStaging.classify(from: recs)          // default = enabled
+        guard let offWake = SleepStaging.sleepWindow(off)?.wake,
+              let onWake = SleepStaging.sleepWindow(on)?.wake else {
+            return XCTFail("both configurations must still stage a night")
+        }
+        XCTAssertLessThan(onWake, offWake,
+                          "the DEFAULT must pull final wake earlier than the disabled config — if this "
+                          + "fails the pass is not wired in, or the default was reverted to off")
+        XCTAssertGreaterThan(offWake.timeIntervalSince(onWake), 60 * 60,
+                            "the whole same-template morning must come off, not a token epoch")
+        XCTAssertEqual(SleepStaging.sleepWindow(on)?.onset, SleepStaging.sleepWindow(off)?.onset,
+                       "a trailing-edge pass must not disturb the onset")
+    }
+
+    /// The defect in one assertion: with the pass off, the reported wake IS the data edge, wherever the
+    /// data happens to end. `BulkSleep` expands each 150 s epoch into five 30 s sub-samples, so the
+    /// block — and the wake with it — lands on `lastRecord + 120 s`.
+    func testWithThePassDisabledTheWakeIsMerelyTheLastRecord() {
+        let recs = cadenceExitNight()
+        let off = SleepStaging.classify(from: recs, tuning: SleepStaging.Tuning(cadenceWakeQuietEpochs: 0))
+        guard let wake = SleepStaging.sleepWindow(off)?.wake, let last = recs.last?.date() else {
+            return XCTFail("expected a staged night")
+        }
+        XCTAssertEqual(wake.timeIntervalSince(last), 120, accuracy: 1)
+    }
+
+    /// SYNC-TIME INVARIANCE — the property the whole issue is about. Staging the SAME night after
+    /// truncating the capture at successively later points must not keep pushing the wake later once
+    /// the wake itself is in the data. 🟢 On the real 2026-08-09 capture master moved +5 min per
+    /// 5-minute step across all 49 steps (367 → 625 min); with this pass the located wake is identical
+    /// on every cut from the true wake onward.
+    func testWakeStopsMovingOnceItIsInTheData() {
+        let recs = cadenceExitNight()
+        var wakes: [Date] = []
+        for extra in stride(from: 4, through: 40, by: 4) {
+            let truncated = Array(recs.prefix(120 + extra))
+            guard let w = SleepStaging.sleepWindow(SleepStaging.classify(from: truncated))?.wake else {
+                return XCTFail("every truncation must still stage a night (cut at +\(extra))")
+            }
+            wakes.append(w)
+        }
+        XCTAssertEqual(Set(wakes).count, 1,
+                       "the wake moved with the truncation point: \(wakes.map(\.timeIntervalSince1970))")
+    }
+
+    func testDefaultIsEnabled() {
+        XCTAssertGreaterThan(SleepStaging.Tuning.default.cadenceWakeQuietEpochs, 0,
+                             "the cadence locator ships ON; disabling it is a deliberate act")
+    }
+
+    /// The measured admissible band for K over the local corpus is [12, 27] — bounded below by
+    /// 08-09's 11-epoch post-wake quiet run and above by 08-04's 27-epoch final run. A default outside
+    /// it changes a real night's answer by tens of minutes.
+    func testDefaultQuietBarSitsInsideTheMeasuredAdmissibleBand() {
+        let k = SleepStaging.Tuning.default.cadenceWakeQuietEpochs
+        XCTAssertGreaterThanOrEqual(k, 12, "below 12 the 11-epoch post-wake run on 08-09 wins (+43 min)")
+        XCTAssertLessThanOrEqual(k, 27, "above 27 the 08-04 night jumps back an extra 70 min")
+    }
+
+    /// A night the ring alternated through to the very last record must be left ALONE — this is the
+    /// end-to-end form of the data-edge guard, and the case that would otherwise re-create the bug.
+    func testNightStillInCadenceAtTheDataEdgeIsUntouched() {
+        var recs: [BulkRecord] = []
+        var c: UInt32 = 1_000_000
+        for i in 0..<160 {
+            recs.append(i.isMultiple(of: 2) ? vrec(c, hr: 54) : qrec(c, hr: 54))
+            c += UInt32(BulkRecord.epochSeconds)
+        }
+        let off = SleepStaging.totalAsleep(
+            SleepStaging.classify(from: recs, tuning: SleepStaging.Tuning(cadenceWakeQuietEpochs: 0)))
+        let on = SleepStaging.totalAsleep(SleepStaging.classify(from: recs))
+        XCTAssertEqual(on, off, accuracy: 1)
+        XCTAssertGreaterThan(off, 0, "fixture sanity: the night really does stage")
+    }
+}


### PR DESCRIPTION
Closes #190.

## The defect

When the primary motion channel is a flat placeholder and the morning HR rise never clears `floor + wakeHRMarginBPM`, every sleeper-side pass misses the wake, the staged night runs to the last record, and the reported wake becomes **`lastRecord + 120 s`** — whenever the user synced. 🟢 Truncating the 2026-08-09 capture in 49 five-minute steps moved reported sleep **367 → 625 min**, one +5 per step, with no byte of physiology changed.

## The fix

`SleepStaging.markCadenceWakeOffset` asks the **ring** instead of the sleeper. While the ring runs its sleep-measurement program it reads SpO2 every 300 s, so 150-second epochs alternate `sleepVitals`/`activity` 1:1; the duty cycle exits at wake. Wake is the epoch after the **last** unbroken alternating run of at least `cadenceWakeQuietEpochs`.

The protocol fact is now in `docs/PROTOCOL.md` §5.3 — 5650 records / 4 rings / 0 byte conflicts, violation rate 6.0 % inside the staged sleep window vs 43.6 % outside, AUC 0.819–1.000, with the sync/drain/BLE/page-boundary confounds re-tested under regime control.

### Both labelled nights

```
08-09  625m 09:58:21 → 575m 09:08:51    error +52.4 → +2.9 min   (truth 09:06)
08-05  528m 08:52:44 → 485m 08:10:14    error +50.7 → +8.2 min   (truth 08:02)
```

## Answering the five blockers in the issue

**1. It oscillated on 08-05 end-to-end.** Root-caused, and it was never the locator. The locator returned `end=232@08:07:44 → cut 08:10:14` on *every* truncation cut; what flickered was **`lastVitalsSoftened`** in `notBefore` (nil → 241 → 245 → nil → 245 → nil), which is derived from `tailStart`, a night-wide HR floor, and a rolling median truncated at the data edge. Gating on it produced `478 · 473 · 473 · 497 · 502 · 507 · 512 · 517 · 485` — three sign changes, 47-minute swing. The pass is therefore gated on the second-bout rescue only. The moving-but-asleep restless morning that the softening exists for is still protected, by the HR no-return confirmation (a sleeper at the floor is never cut) — and the 24 existing tests in that family stay green.

**2. Gap- and jitter-blindness.** `round(dt/150)`, one missing epoch bridged by **parity**, anything longer is `.unknown` and can never terminate a trusted run. Dropout Monte-Carlo, 100 trials each:

| night | 1 % | 3 % | 5 % |
|---|---|---|---|
| 08-09 | **100/100** wake identical | 95/100 (4× +2.5 min, 1× declines to master) | 88/100 |
| 08-05 | 96/100 | 94/100 | 83/100 |

Every failure mode is ≤ 10 min or a clean decline back to master. The gap-blind K=12 rule this replaces was −57 / −75 / −135 min at 1/3/5 %.

**3. K sat on a one-epoch margin.** Sweeping K per night gives the closed interval that yields the same cut: 08-09 [12,191] · 08-05 [7,119] · 08-04 [6,27] · 08-02 [2,40] · 06-27 [4,161] · 06-30 [2,137]. **Every night agrees for K ∈ [12, 27]**, bounded below by 08-09's 11-epoch post-wake run and above by 08-04's 27-epoch final run. **K = 20** maximises the worst-case headroom (7 epochs ≈ 17 min either side). A test pins the default inside the measured band.

**4. Regime plausibility gate.** Three declines: no run ≥ K anywhere; a run that reaches the **data edge** (which is what makes a ring left in continuous SpO2 mode a no-op — and is what stops the pass re-manufacturing the artefact it removes); and `cadenceWakeMaxQuietEpochs` (240 ≈ 10 h) for the u4-class 11.96 h regime. 🔴 The last one does not fire anywhere in the corpus (longest trusted run 191 epochs ≈ 7.96 h) and is synthetic-tested only.

**5. The −75 min on 06-29.** It never happens: the **HR no-return confirmation declines it**, and 06-29 comes out byte-identical. Same for 08-07.

## Acceptance

- **Kill switch:** `cadenceWakeQuietEpochs = 0` is **byte-identical to master, 18/18**, verified against a regenerated `CorpusBaseline` (md5 `6663c44ec8234c25a56c364357868d18`, reproduced before use).
- **Truncation sweep, 5-min steps, end-to-end.** 08-09: **0 sign changes**, and the wake locks at 09:08:51 for all 11 cuts past the true wake while master keeps adding +5 min per step. 08-05: the wake is identical on every cut from 08:12 on. ⚠️ 08-05's *asleep total* still carries one −5 min step at 08:17:44 — that is master's night-wide HR floor (p12 over rows that include the post-wake tail) drifting as data arrives, not the locator; master shows the same class of step at 05:32:44 with the pass **off**. Called out rather than papered over.
- **Corpus, per-ring, correct timezones:** 11 of 18 byte-identical. Changed: 08-09 −50, 08-05@13-03 −43, 08-05 export −17, 08-04@12-58 −17, 08-04 export −17, 06-27 −5, 08-02 −2. **The in-bed envelope and the onset are unchanged on every night** — this is a pure trailing-edge pass.
- **Tests:** 1278 / 0 failures (1250 baseline + 28 new). **All 12 mutations of the new code are caught**, including deleting the call site, taking the longest run, dropping the data-edge guard, exact-`dt` equality, removing parity bridging, and reverting the default.
- iOS app target builds.

## ⚠️ What this ships on

**Ground truth is n = 2, the same person on the same ring.** That is below this project's own evidence bar and is why `cadenceWakeQuietEpochs` is a one-line kill switch. The corpus (18 nights / 5 rings / 4+ people) constrains *stability* and *byte-identity*, not accuracy. Logging alarm/wake for a week — `SleepEditLabel` already turns sleep edits into supervised labels — is still the thing that would move this furthest.

Not device-validated yet.

## Not in scope (each deserves its own issue)

The issue's "adjacent defects" list is untouched: bedtime is still "came off the charger", the 32-min in-bed fragment is still discarded, the #41 wear gate is still inert on the staged path, `constantFiller` is still dead code, `StepAccumulator`'s header comment is still wrong, and the `layout` fall-through wart is unchanged. Master's trailing-edge band drift (the −5 min above) is a new one found on the way.