### PR TITLE
fix(sleep): make the intensity-tail light/active seam ABSOLUTE, not a rank over whatever synced (#197)

### DIFF
--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
@@ -665,9 +665,11 @@ public enum BulkSleep {
 
     /// One magnitude per epoch using the same run-level signal selection as `motionTimeline`.
     /// The staging model subtracts its rolling local floor afterward, exactly as on primary motion.
-    static func motionMagnitudes(from records: [BulkRecord]) -> [Float] {
+    static func motionMagnitudes(from records: [BulkRecord],
+                                 absoluteActiveCut: Int = motionIntensityActiveCut) -> [Float] {
         if case .intensityTail(let degenerate) = motionSource(records) {
-            return motionIntensityFallbackMagnitudes(records, degenerate: degenerate)
+            return motionIntensityFallbackMagnitudes(records, degenerate: degenerate,
+                                                     absoluteActiveCut: absoluteActiveCut)
         }
         return records.map { record in
             Float(record.motion.reduce(0) { $0 + Int($1) })
@@ -676,12 +678,15 @@ public enum BulkSleep {
 
     /// Convert the secondary intensity distribution into the scale shared by coarse detection and
     /// staging. Any non-zero tail remains visible as LIGHT movement in `SleepDetailMetrics`, but only
-    /// the night's upper intensity quintile becomes motion-awake here. This keeps ordinary sleeping
+    /// a tail above `motionIntensityActiveCut` becomes motion-awake here. This keeps ordinary sleeping
     /// position shifts from becoming wake while retaining substantial, sustained movement as an
     /// awakening cue. Values deliberately straddle the existing thresholds: `1` is still/light for
     /// detection and staging, `16` is active (`motionStillThreshold == 2`, `awakeMotion == 15`).
     ///
-    /// `degenerate:` selects WHERE the light/active seam is drawn, and nothing else:
+    /// ⚠️ SINCE #197 the seam is the ABSOLUTE `motionIntensityActiveCut`, and `degenerate:` only
+    /// selects between the two LEGACY per-set ranks, which are reachable solely by passing
+    /// `absoluteActiveCut: 0`. Both descriptions below are therefore history — kept because they
+    /// record WHY the two branches once differed, and because `0` still reproduces them exactly:
     ///   • `false` — the constant-filler branch keeps the fixed 0.80 quantile, byte for byte.
     ///   • `true` — the non-expressive-primary branch (#184) uses an Otsu two-class seam over the
     ///     same positive pool. WHY: the quantile presumes the run is ~80 % sleep. On the FR04.009
@@ -713,14 +718,48 @@ public enum BulkSleep {
         return best
     }
 
+    /// The ABSOLUTE light/active seam for the intensity tail, in raw `[15:20]` byte-sum units.
+    /// **`0` restores the legacy per-set rank** (p80 / Otsu) byte-for-byte — the one-line revert.
+    ///
+    /// WHY AN ABSOLUTE NUMBER AT ALL (#197). Both legacy seams — the 0.80 quantile and the Otsu
+    /// two-class split — are computed over `positive`, i.e. over **whatever has drained so far**. The
+    /// threshold was therefore a function of sync timing, not of the wearer, and 🟢 MEASURED on
+    /// 2026-08-05 (AD/Gen2) it moved 249 → 247 → 247 → 249 across consecutive 5-minute truncation
+    /// cuts while two interior epochs sat exactly on it, flipping them between magnitude 1 (still)
+    /// and 16 (awake) and swinging the reported night 478 · 473 · 473 · 478. A rank also FORCES a
+    /// fixed share of positive epochs to be "movement" on every night — a night barely stirred and a
+    /// night of thrashing both got their top 20 % called awake, which is a rank artefact, not a
+    /// measurement.
+    ///
+    /// WHY 345, AND WHAT IT IS NOT. It is **the fixed value the per-night rank was already choosing,
+    /// on average** — the median per-night legacy cut over the 16 corpus sources that stage a night
+    /// is 344.5, and the primary user's own ring (AD/Gen2, n = 11) has median 343, so the number is
+    /// not driven by one ring. Choosing it this way deliberately PRESERVES the operating point, which
+    /// is what keeps the three calibrations fitted to this population valid
+    /// (`degenerateMaxQuietStillFraction` 0.50, `degenerateMinSlotOrderFraction` 0.75,
+    /// `hrvPoolingNoiseFloorMs` 9.0) and what keeps the #184 Otsu case byte-identical.
+    ///
+    /// 🔴 IT IS **NOT** A FITTED PHYSIOLOGICAL THRESHOLD, and must not be described as one. Fitting
+    /// one was attempted and ABANDONED on the evidence: taking the primary channel's own still/active
+    /// verdict as the label — the very verdict this fallback exists to substitute for — the best
+    /// achievable Youden J is only **0.414** (byte-sum) / 0.441 (decoded magnitudes), the optimum is
+    /// flat from 150 to 300, and the two rings with a usable label disagree (280 vs 390). That is
+    /// 471 labelled epochs from 2 rings, NEITHER of them the primary user's, because a night whose
+    /// primary channel is expressive enough to label is by definition not a night that needs this
+    /// fallback. A real threshold needs `[15:23)`'s decoded `activityMagnitudes` and supervised
+    /// labels; see #197.
+    static let motionIntensityActiveCut = 345
+
     static func motionIntensityFallbackMagnitudes(_ records: [BulkRecord],
-                                                  degenerate: Bool) -> [Float] {
+                                                  degenerate: Bool,
+                                                  absoluteActiveCut: Int = motionIntensityActiveCut) -> [Float] {
         let sums = records.map { $0.motionIntensityTail.reduce(0) { $0 + Int($1) } }
         let positive = sums.filter { $0 > 0 }.sorted()
         guard !positive.isEmpty else { return [Float](repeating: 0, count: records.count) }
-        let activeCut = degenerate
+        // A fixed seam does not care how much history has drained; the legacy ranks did.
+        let activeCut = absoluteActiveCut > 0 ? absoluteActiveCut : (degenerate
             ? otsuIntensityCut(positive)
-            : positive[Int((Double(positive.count - 1) * 0.80).rounded())]
+            : positive[Int((Double(positive.count - 1) * 0.80).rounded())])
         return sums.map { magnitude in
             guard magnitude > 0 else { return 0 }
             return magnitude >= activeCut ? 16 : 1

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/MotionIntensityAbsoluteCutTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/MotionIntensityAbsoluteCutTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import OpenCircuitKit
+
+// #197 — the intensity-tail light/active seam must be an ABSOLUTE value, not a rank over whatever
+// has drained.
+//
+// The defect these tests pin: both legacy seams (the 0.80 quantile and the Otsu split) are computed
+// over `positive`, i.e. over the record set being staged. So the same epoch could be "still" in one
+// sync and "movement" in the next, with no byte of physiology changed. 🟢 MEASURED on 2026-08-05:
+// the cut moved 249 → 247 → 247 → 249 across consecutive 5-minute truncation cuts and swung the
+// reported night 478 · 473 · 473 · 478.
+//
+// The central property is SET-INDEPENDENCE, and it is tested by construction: extend the record set
+// and assert the verdict on the ORIGINAL epochs does not move. Each such test has a twin that pins
+// the legacy behaviour, so the property can never pass vacuously.
+final class MotionIntensityAbsoluteCutTests: XCTestCase {
+
+    /// A worn, non-idle record whose `[15:20]` intensity tail sums to `tailSum`.
+    private func rec(_ counter: UInt32, tailSum: Int) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: 23)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xFF)
+        b[2] = UInt8((counter >> 8) & 0xFF); b[3] = UInt8(counter & 0xFF)
+        b[4] = 55; b[5] = 50; b[8] = 0x62          // HR/HRV/SpO2 — a sleep-vitals epoch
+        for k in 0..<5 { b[10 + k] = 1 }           // still primary channel
+        var left = tailSum
+        for k in 0..<5 {                            // spread the sum across [15:20]
+            let take = min(left, 255)
+            b[15 + k] = UInt8(take)
+            left -= take
+        }
+        XCTAssertEqual(left, 0, "fixture cannot express a tail sum above 1275")
+        return BulkRecord(b)!
+    }
+
+    private func records(_ sums: [Int]) -> [BulkRecord] {
+        sums.enumerated().map { rec(UInt32(1_000_000 + $0 * BulkRecord.epochSeconds), tailSum: $1) }
+    }
+
+    /// Straddles the shipped cut: 344 below, 345 exactly on it, 346 above.
+    private let base = [100, 200, 344, 345, 346, 500]
+
+    // MARK: - The property: a verdict may not depend on what else is in the set
+
+    func testAbsoluteCutIsIndependentOfWhatElseIsInTheSet() {
+        let short = BulkSleep.motionIntensityFallbackMagnitudes(records(base), degenerate: false)
+        // 20 large-movement epochs arrive on the next sync.
+        let long = BulkSleep.motionIntensityFallbackMagnitudes(
+            records(base + [Int](repeating: 1200, count: 20)), degenerate: false)
+        XCTAssertEqual(Array(long.prefix(base.count)), short,
+                       "the same epochs must keep the same verdict when more history drains in")
+        XCTAssertEqual(short, [1, 1, 1, 16, 16, 16],
+                       "seam is >= 345: 344 is still, 345 and above are movement")
+    }
+
+    /// THE TWIN. Without it the test above could pass for the wrong reason.
+    func testTheLegacyRankIsNotIndependentOfTheSet() {
+        let short = BulkSleep.motionIntensityFallbackMagnitudes(records(base), degenerate: false,
+                                                                absoluteActiveCut: 0)
+        let long = BulkSleep.motionIntensityFallbackMagnitudes(
+            records(base + [Int](repeating: 1200, count: 20)), degenerate: false, absoluteActiveCut: 0)
+        XCTAssertNotEqual(Array(long.prefix(base.count)), short,
+                          "fixture sanity: the legacy p80 rank MUST move when the set grows — "
+                          + "if this ever passes, the defect fixture stopped reproducing the defect")
+    }
+
+    func testAbsoluteCutIsIndependentOfTheSetOnTheDegenerateBranchToo() {
+        let short = BulkSleep.motionIntensityFallbackMagnitudes(records(base), degenerate: true)
+        let long = BulkSleep.motionIntensityFallbackMagnitudes(
+            records(base + [Int](repeating: 1200, count: 20)), degenerate: true)
+        XCTAssertEqual(Array(long.prefix(base.count)), short)
+        XCTAssertEqual(short, [1, 1, 1, 16, 16, 16],
+                       "the absolute seam replaces Otsu as well — #197 checked BOTH ranks")
+    }
+
+    func testTheLegacyOtsuSeamIsAlsoNotIndependentOfTheSet() {
+        let short = BulkSleep.motionIntensityFallbackMagnitudes(records(base), degenerate: true,
+                                                               absoluteActiveCut: 0)
+        let long = BulkSleep.motionIntensityFallbackMagnitudes(
+            records(base + [Int](repeating: 1200, count: 20)), degenerate: true, absoluteActiveCut: 0)
+        XCTAssertNotEqual(Array(long.prefix(base.count)), short,
+                          "fixture sanity: Otsu carries the same exposure the quantile does")
+    }
+
+    /// The property has to survive the layer the staging model actually calls.
+    func testMotionMagnitudesForwardsTheSeam() {
+        let recs = records(base)
+        XCTAssertEqual(BulkSleep.motionMagnitudes(from: recs, absoluteActiveCut: 400),
+                       BulkSleep.motionIntensityFallbackMagnitudes(recs, degenerate: false,
+                                                                   absoluteActiveCut: 400),
+                       "if this diverges, staging is not using the seam the tests pin")
+    }
+
+    // MARK: - The kill switch
+
+    func testZeroRestoresTheLegacyQuantileExactly() {
+        let sums = base
+        let got = BulkSleep.motionIntensityFallbackMagnitudes(records(sums), degenerate: false,
+                                                              absoluteActiveCut: 0)
+        // p80 of [100,200,344,345,346,500] is index round(5*0.8) = 4 → 346.
+        let expected = sums.map { $0 == 0 ? Float(0) : ($0 >= 346 ? 16 : 1) }
+        XCTAssertEqual(got, expected, "0 must reproduce the pre-#197 rank byte for byte")
+    }
+
+    func testZeroRestoresTheLegacyOtsuSeamExactly() {
+        let sums = base
+        let positive = sums.filter { $0 > 0 }.sorted()
+        let otsu = BulkSleep.otsuIntensityCut(positive)
+        let got = BulkSleep.motionIntensityFallbackMagnitudes(records(sums), degenerate: true,
+                                                              absoluteActiveCut: 0)
+        XCTAssertEqual(got, sums.map { $0 >= otsu ? Float(16) : Float(1) })
+    }
+
+    // MARK: - Invariants that must hold whichever seam is in force
+
+    func testAZeroTailIsAlwaysZeroMovement() {
+        // The ring's OWN "nothing moved" verdict outranks any seam.
+        for cut in [0, 345, 1_000_000] {
+            let m = BulkSleep.motionIntensityFallbackMagnitudes(records([0, 0, 500, 0]),
+                                                                degenerate: false,
+                                                                absoluteActiveCut: cut)
+            XCTAssertEqual(m[0], 0); XCTAssertEqual(m[1], 0); XCTAssertEqual(m[3], 0)
+        }
+    }
+
+    func testAnAllZeroTailProducesNoMovementAtAll() {
+        XCTAssertEqual(BulkSleep.motionIntensityFallbackMagnitudes(records([0, 0, 0]),
+                                                                   degenerate: false),
+                       [0, 0, 0])
+    }
+
+    /// Values must keep straddling the thresholds the rest of the pipeline is calibrated to:
+    /// `motionStillThreshold == 2` and `awakeMotion == 15`.
+    func testEmittedMagnitudesStraddleTheDownstreamThresholds() {
+        let m = BulkSleep.motionIntensityFallbackMagnitudes(records([100, 500]), degenerate: false)
+        XCTAssertLessThan(m[0], ActivityPeriod.motionStillThreshold, "still must read below the still bar")
+        XCTAssertGreaterThan(Int(m[1]), SleepStaging.Tuning.default.awakeMotion, "active must clear awakeMotion")
+    }
+
+    // MARK: - The constant itself
+
+    /// 345 is the MEDIAN per-night legacy cut over the corpus (16 night-staging sources → 344.5;
+    /// the primary user's own ring, n = 11 → 343). Its whole justification is that it preserves the
+    /// operating point the surrounding calibrations were fitted to, so it must stay inside the band
+    /// the per-night ranks actually occupied: 262 … 474.
+    func testDefaultSeamSitsInsideTheMeasuredCorpusBand() {
+        XCTAssertGreaterThanOrEqual(BulkSleep.motionIntensityActiveCut, 262)
+        XCTAssertLessThanOrEqual(BulkSleep.motionIntensityActiveCut, 474)
+    }
+
+    func testDefaultSeamIsEnabled() {
+        XCTAssertGreaterThan(BulkSleep.motionIntensityActiveCut, 0,
+                             "0 is the revert; shipping it disables the #197 fix")
+    }
+}

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/MotionTailFallbackTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/MotionTailFallbackTests.swift
@@ -33,9 +33,16 @@ final class MotionTailFallbackTests: XCTestCase {
         }
     }
 
+    /// ⚠️ FIXTURE MAGNITUDES RESCALED BY #197, INTENT UNCHANGED. This used to pair a tail of 32 with
+    /// one of 48 and expect 1 / 16. That only ever worked because the seam was a per-set RANK: with
+    /// two positive epochs in the whole night the larger one is "the top 20 %" however small it is.
+    /// Against the real corpus a sum of 48 is a trivial stir — positive tail sums run p10 = 25,
+    /// p50 = 230, p90 = 547 — so the old pairing asserted the rank artefact, not a measurement.
+    /// The distinction under test (small tail → light, real movement → active) is preserved, now
+    /// against the absolute `motionIntensityActiveCut`.
     func testTimelineUsesRepeatedEpochIntensityWhenPrimaryRunIsEntirelyFiller() {
-        let records = fillerNight(movingEpochs: [40: [0, 0, 32, 0, 0],
-                                                  41: [0, 16, 32, 0, 0]])
+        let records = fillerNight(movingEpochs: [40: [0, 0, 32, 0, 0],          // a stir, well below the seam
+                                                  41: [0, 200, 200, 0, 0]])     // 400 — real movement
         XCTAssertTrue(BulkSleep.usesMotionIntensityFallback(records))
 
         let timeline = BulkSleep.motionTimeline(from: records)
@@ -43,6 +50,21 @@ final class MotionTailFallbackTests: XCTestCase {
                        [1, 1, 1, 1, 1])
         XCTAssertEqual(Array(timeline[41 * 5..<(41 * 5 + 5)]).map(\.movement),
                        [16, 16, 16, 16, 16])
+    }
+
+    /// The rank artefact itself, now pinned as REMOVED (#197). A night whose only tail activity is a
+    /// couple of small stirs must read as light movement, not as an awakening — under the legacy
+    /// per-set rank the largest stir was promoted to `16` no matter how small it was.
+    func testSmallStirsAloneAreLightNotActive() {
+        let records = fillerNight(movingEpochs: [40: [0, 0, 32, 0, 0],
+                                                  41: [0, 16, 32, 0, 0]])
+        let timeline = BulkSleep.motionTimeline(from: records)
+        XCTAssertEqual(Array(timeline[41 * 5..<(41 * 5 + 5)]).map(\.movement), [1, 1, 1, 1, 1],
+                       "a 48-unit tail is a stir; only a per-set rank could call it an awakening")
+        XCTAssertEqual(BulkSleep.motionIntensityFallbackMagnitudes(records, degenerate: false,
+                                                                   absoluteActiveCut: 0)[41], 16,
+                       "fixture sanity: the legacy rank DID promote it — this test would be vacuous "
+                       + "if the fixture no longer reproduced the artefact")
     }
 
     func testMovementChartDoesNotReportAllZeroWhenIntensityStillHasMotion() {
@@ -56,9 +78,12 @@ final class MotionTailFallbackTests: XCTestCase {
         XCTAssertGreaterThan(summary.active, 0)
     }
 
+    /// ⚠️ Magnitudes rescaled by #197 (64 → 400, i.e. above the absolute seam rather than merely the
+    /// largest in a synthetic night); the assertions are untouched. See the note on
+    /// `testTimelineUsesRepeatedEpochIntensityWhenPrimaryRunIsEntirelyFiller`.
     func testConsecutiveIntensityMovementProducesAnAwakeInterval() {
-        let records = fillerNight(movingEpochs: [60: [0, 0, 64, 0, 0],
-                                                  61: [0, 0, 64, 0, 0]])
+        let records = fillerNight(movingEpochs: [60: [0, 200, 200, 0, 0],
+                                                  61: [0, 200, 200, 0, 0]])
         let summary = SleepStaging.summary(SleepStaging.classify(from: records)).minutes
 
         XCTAssertGreaterThan(summary.awake, 0,


### PR DESCRIPTION
Closes #197.

## The defect

`BulkSleep.motionIntensityFallbackMagnitudes` decided *"is this epoch movement?"* with a threshold computed over `positive` — every positive `[15:20]` tail sum **in the record set being staged**. Both seams did it: the 0.80 quantile and the Otsu split.

So the threshold was a function of **sync timing**. 🟢 Measured end-to-end on 2026-08-05 (AD/Gen2), staging the same capture truncated at 5-minute steps:

| cut | `positive.count` | threshold | epochs 89 / 193 | **asleep** |
|---|---|---|---|---|
| 08:12:44 | 87 | **249** | 1 (still) | **478** |
| 08:17:44 | 89 | **247** | 16 (> `awakeMotion` 15) | **473** |
| 08:22:44 | 90 | 247 | 16 | 473 |
| 08:27:44 | 91 | **249** | 1 | **478** |

A rank is also wrong in principle: it *forces* a fixed share of positive epochs to be "movement" on every night, so a night barely stirred and a night of thrashing both get their top 20 % called awake.

## The fix

An absolute `BulkSleep.motionIntensityActiveCut`, replacing **both** ranks. `0` restores the legacy behaviour byte-for-byte, and the seam is a parameter on `motionIntensityFallbackMagnitudes` / `motionMagnitudes` so tests can drive both paths.

### Why 345 — and what it is not

It is **the fixed value the per-night rank was already choosing, on average**: the median per-night legacy cut over the 16 corpus sources that stage a night is **344.5**, and the primary user's own ring (AD/Gen2, n = 11) has median **343**, so it isn't driven by one ring. Choosing it this way deliberately **preserves the operating point** — which is what keeps the three calibrations fitted to this population valid (`degenerateMaxQuietStillFraction` 0.50, `degenerateMinSlotOrderFraction` 0.75, `hrvPoolingNoiseFloorMs` 9.0) and the #184 Otsu case byte-identical.

🔴 **It is not a fitted physiological threshold, and it is documented as not being one.** Fitting one was attempted and abandoned on the evidence. Taking the primary channel's own still/active verdict as the label — the verdict this fallback exists to substitute for — the best achievable Youden J is **0.414** (byte sum) / 0.441 (decoded `activityMagnitudes`), the optimum is **flat from 150 to 300**, and the two rings with a usable label **disagree** (280 vs 390). That is 471 labelled epochs from 2 rings, *neither of them the primary user's* — because a night whose primary channel is expressive enough to label is by definition not a night that needs this fallback. A real threshold needs supervised labels; that is left open in #197's follow-on.

## Measured

- **Truncation sweep, 5-min steps, end-to-end.** 08-05 goes from **2 sign changes (the −5 min step) to zero** — flat at 485 across all 11 cuts. 08-09, 08-04@12-58 and 06-27 stay at 0. ⚠️ 06-30 keeps **one** sign change (−7 min) that is byte-for-byte identical with the fix and without it — pre-existing, a different cause, **not** claimed as fixed.
- **Corpus: 16 of 18 nights byte-identical.** The two that move are the point of the change:
  - **08-05 export 473 → 485** — which is exactly what the 08-05 *diagnostics* bundle already reported for that same night. Two different record sets covering one night now agree.
  - 08-02's in-bed start 5 min earlier, asleep unchanged.
- Both #191 wake times pinned: **08-09 575 min / 09:08:51**, **08-05 485 min / 08:10:14**.
- **1335 tests / 0 failures**, RingKitVerify passes, iOS app builds.
- **7/7 mutations caught**, including reverting the constant to 0 and applying the seam to only one of the two branches. Mutating it to 900 breaks the pre-existing `FR04DegeneratePrimaryMotionTests`, which is the evidence that 345 preserves that calibration.

## ⚠️ Two existing fixtures were rescaled — disclosed, not slipped in

`MotionTailFallbackTests` paired tail sums of 32 vs 48 (and 64) and expected the larger to be "active". That only ever held because the seam was a per-set rank: with two positive epochs in the night, the larger one **is** the top 20 %, however small. Against the corpus those are trivial stirs — positive tail sums run p10 = 25, p50 = 230, p90 = 547 — so the old pairing asserted the artefact rather than a measurement.

The moving epochs are now 400 (real movement) and **every assertion is unchanged**. A new test, `testSmallStirsAloneAreLightNotActive`, pins the removed artefact directly, with a twin assertion proving the fixture still reproduces it under `absoluteActiveCut: 0` so it can never pass vacuously.

## Why this mattered beyond ±5 min

It unblocks the `[15:20]` fallback work in #195/#184. #195 declined to widen the dead `constantFiller` gate precisely because widening it moves nights onto this mapping, and measured the same night going −12 min in one bundle and +45 in another. That is now fixed underneath it.

Ground truth remains n = 2 wake times, same person, same ring — this change is argued on **stability**, not accuracy. Not device-validated.