### PR TITLE
docs+app: drop the "activate in the official app" prerequisite (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ written to **Apple Health** — nothing is sent to a server.
 
 - 🔗 **Standalone, no cloud key** — the ring's per-connection authentication is fully
   reverse-engineered (an SM3 challenge keyed only on the ring's *own* MAC), so OpenCircuit
-  connects and streams on its own, with **no RingConn account or app needed for everyday
-  use**. A ring you've already set up with the official app is bonded and works
-  immediately. *(One case is still being verified: a brand-new ring that has never been
-  activated in the official app on any phone — see issue #106.)*
+  connects and streams on its own, with **no RingConn account or app ever needed**.
+  Confirmed on a brand-new ring straight out of the box, before the official app had ever
+  been installed (Gen 3, firmware FR05.005 — [issue #106](https://github.com/perezjuanj/OpenCircuit/issues/106)),
+  as well as on rings already set up with the official app.
 - 💍 Works with **any RingConn Gen 2 ring**, and **multiple rings per phone**.
 - 🔄 Background sync, keepalive, and periodic auto-measure for continuous tracking.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -882,6 +882,12 @@ the `0x10`/`0x87` descriptor `[1]`, §5.4 🟢 — already decoded.)
 ### 5.8 Per-connection AUTH (the activation gate) 🟢 CRACKED — issue #54
 > ✅ **Standalone confirmed on-device 2026-06-16:** with the official app logged out, OpenCircuit
 > activated the ring and streamed on its own. No official app needed. (+ heartbeat + bonding below.)
+> ✅ **Never-activated ring confirmed 2026-08-11 🟢 (issue #106, now CLOSED):** an independent tester
+> ran OpenCircuit against a factory-fresh Gen 3 (shipped on `FR05.005`) **before the official app was
+> ever installed** — live HR and SpO₂ worked as expected. So there is **no first-time provisioning /
+> cloud-activation step at all**: the SM3 challenge below plus the local LE-SC bond are the whole
+> gate, for any owner of any ring. (They saw the `notStreaming` banner intermittently; it cleared on
+> its own. Installing the official app afterwards took firmware to `FR05.010`, still fine.)
 The `01 01 <…>` arg is a deterministic **challenge→response auth** — what "activates" the ring for
 streaming. Sequence every connect: host `01 00 00` → ring `81 00 <chal> <xor>`; host must answer
 `01 01 <r0> <r1> <r2> 00`. **🟢 ALGORITHM (RE'd 2026-06-16 from the official app's Dart AOT

--- a/docs/RUNBOOK_SNOOP_SINGLE_SESSION.md
+++ b/docs/RUNBOOK_SNOOP_SINGLE_SESSION.md
@@ -23,7 +23,7 @@ Generated from an issue-triage sweep (2026-07-05). Companion to
 | **#94** all-day stress | 🟡 partial | E | online-vs-offline probe: is stress on-wire or cloud? |
 | **#95** daily Activity Score | 🟡 partial | B | 4-level intensity band ground truth (decode belongs to #93) |
 | **#96** ring write actions (iOS) | ✅ yes | F, H | same write opcodes as #88 (this is the iOS consumer) |
-| **#106** any-owner gate (fresh ring) | 🟡 fallback | — | only if OpenCircuit standalone test fails (see Notes) |
+| **#106** any-owner gate (fresh ring) | ✅ CLOSED | — | answered 2026-08-11 without a capture — no fresh-ring session needed (see Notes) |
 
 **Excluded / cannot fold into this session** — see Notes:
 - **#87** temp / waking-RR fetch — overnight-only (separate night capture).
@@ -177,9 +177,9 @@ separate in the log.
   battery ≥ 30%, else the app refuses (`osaStartFail`). Separate night session; watch
   `keyOSAStartMonitor` write + dense page `0x15`/`0x16`. **Do not attempt in this daytime
   session.**
-- **#106 fresh-ring test is a FALLBACK only** — needs a *factory-fresh, never-activated
-  ring* + a phone never paired to it. Primary path is the OpenCircuit standalone test;
-  only run the official-app first-time-onboarding capture if that standalone test fails.
+- **#106 fresh-ring test — DO NOT RUN, already answered.** A tester connected OpenCircuit to a
+  factory-fresh Gen 3 (`FR05.005`) *before ever installing the official app* and got live HR +
+  SpO₂ (2026-08-11). There is no first-time activation step; PROTOCOL.md §5.8 records it.
 - **#92 (OTA) is a documented non-goal — do NOT trigger a firmware update.** Bricking
   risk; excluded.
 - **Bond-stealing:** run the whole session on the phone that owns the ring's bond. Do not

--- a/ios/OpenCircuit/BLE/RingSession.swift
+++ b/ios/OpenCircuit/BLE/RingSession.swift
@@ -92,10 +92,12 @@ final class RingSession: NSObject {
     /// An unsubscribed notify char silently drops every inbound frame.
     private(set) var notifySubscribed = false
     /// True when the link is up + subscribed but the ring delivers only `0x81` status replies and
-    /// NO data frames (`0x10`/`0x82`/`0x15`/`0x47`/`0x4c`/`0x11`) — the signature of a ring that
-    /// hasn't been activated/bonded by the official app (it accepts writes but answers nothing, so
-    /// Measure/Sync would just time out). Cleared the instant a data frame arrives. We INFER this
-    /// (don't claim to KNOW it's unactivated), per the `reconnectStalled` precedent.
+    /// NO data frames (`0x10`/`0x82`/`0x15`/`0x47`/`0x4c`/`0x11`) — it accepts writes but answers
+    /// nothing, so Measure/Sync would just time out. Cleared the instant a data frame arrives.
+    /// This is NOT an "un-activated ring" signature: #106 confirmed a ring that had never been
+    /// signed into the official app streams on our SM3 auth alone, and the same tester saw this
+    /// flag set transiently and clear itself. We INFER a silent link (don't claim to KNOW why),
+    /// per the `reconnectStalled` precedent.
     private(set) var notStreaming = false
     /// Whether any non-`0x81` (data/activity) frame has arrived since connect. Drives `notStreaming`
     /// — the cold status reads always elicit `0x81`, so "frames arrived" alone can't tell us the
@@ -245,7 +247,7 @@ final class RingSession: NSObject {
     /// so steps/battery still recover even when a live read starts immediately after a sync.
     private var pendingDeviceStatusRefresh = false
     /// Fires once after the notify subscription is confirmed: if no DATA frame has arrived within
-    /// `firstFrameTimeout`, flips `notStreaming` (ring not activated/bonded). #54.
+    /// `firstFrameTimeout`, flips `notStreaming` (link up, ring silent). #54.
     private var streamWatchdogTask: Task<Void, Never>?
     /// Re-applies the user's persisted automatic-workout preference once per authenticated
     /// connection. The ring-side setting is not queryable, so a remembered local `true` must not
@@ -253,8 +255,8 @@ final class RingSession: NSObject {
     private var automaticWorkoutReassertTask: Task<Void, Never>?
     private var automaticWorkoutDetectionAppliedThisConnection = false
     /// Seconds after a confirmed subscription to wait for the ring's first DATA frame. The keepalive
-    /// starts writing status/fetch immediately on `ready`, so an activated ring answers well within
-    /// this; only an un-activated ring stays silent past it.
+    /// starts writing status/fetch immediately on `ready`, so a healthy ring answers well within
+    /// this; only a ring that is off-wrist, held by another app, or otherwise silent passes it.
     private static let firstFrameTimeout: TimeInterval = 10
 
     /// Cached nightly sleep window — skin-temp capture is gated to this span (see the
@@ -1067,9 +1069,9 @@ final class RingSession: NSObject {
     }
 
     /// After the notify subscription is confirmed, wait `firstFrameTimeout` for the ring's first
-    /// DATA frame. If none arrives (only the cold `0x81` status replies), the ring is almost
-    /// certainly not activated/bonded — surface `notStreaming` so the UI can say "open the official
-    /// app once to activate" instead of letting Measure/Sync silently time out (#54).
+    /// DATA frame. If none arrives (only the cold `0x81` status replies), surface `notStreaming` so
+    /// the UI can say what to check (worn? another app holding the ring?) instead of letting
+    /// Measure/Sync silently time out (#54).
     private func startStreamWatchdog() {
         streamWatchdogTask?.cancel()
         streamWatchdogTask = Task { [weak self] in
@@ -1077,7 +1079,7 @@ final class RingSession: NSObject {
             guard let self, !Task.isCancelled else { return }
             if self.notifySubscribed, !self.gotDataFrame {
                 self.notStreaming = true
-                ringLog.notice("activation: subscribed but no data frame in \(Self.firstFrameTimeout, privacy: .public)s — ring likely not activated/bonded (#54)")
+                ringLog.notice("stream: subscribed but no data frame in \(Self.firstFrameTimeout, privacy: .public)s — link up, ring silent (#54)")
             }
         }
     }
@@ -4521,7 +4523,7 @@ extension RingSession: CBPeripheralDelegate {
 
     /// Notify-subscription result (#54). `ready` only means the characteristic was DISCOVERED; this
     /// is the first point we know whether notifications will actually flow. On failure (e.g. the
-    /// data char needs an encrypted/bonded link the ring won't grant when un-activated) we surface
+    /// data char needs an encrypted link the ring hasn't granted yet) we surface
     /// `notStreaming` immediately instead of writing commands into the void; on success we arm the
     /// first-DATA-frame watchdog.
     nonisolated func peripheral(_ peripheral: CBPeripheral,

--- a/ios/OpenCircuit/ContentView.swift
+++ b/ios/OpenCircuit/ContentView.swift
@@ -938,13 +938,14 @@ struct ContentView: View {
                     }
                 }
             }
-            // Link up + subscribed but the ring sends only status replies, no data (#54) — the
-            // un-activated/un-bonded signature. Until the activate step is reverse-engineered, the
-            // only fix is to open the official app once; say so instead of spinning forever.
-            if connected, session?.notStreaming == true { activationHint }
+            // Link up + subscribed but the ring sends only status replies, no data (#54). The
+            // official app is NOT the fix — a never-activated ring streams on our SM3 auth alone
+            // (#106, confirmed out-of-box on Gen 3 FR05.005) — so point at the real causes
+            // (off-wrist / another app holding the ring) instead of spinning forever.
+            if connected, session?.notStreaming == true { notStreamingHint }
             // Connected + streaming, but the ring is on the charger (#61, confirmed byte) or reads
             // off-wrist (#56, estimated) — surface it instead of silently backing the auto-measure
-            // off. notStreaming takes precedence (an un-activated ring's wear state is meaningless),
+            // off. notStreaming takes precedence (a silent ring's wear state is meaningless),
             // and we hide it during an active measurement so it can't contradict the "measuring" cue.
             if connected, session?.notStreaming != true, session?.monitoring != true,
                session?.charging == true || session?.appearsNotWorn == true {
@@ -1150,14 +1151,16 @@ struct ContentView: View {
         return AnyShapeStyle(.tertiary)
     }
 
-    /// Shown when `RingSession.notStreaming` — the ring is connected but not delivering data (not
-    /// yet activated/bonded by the official app). #54.
-    private var activationHint: some View {
+    /// Shown when `RingSession.notStreaming` — the ring is connected but not delivering data (#54).
+    /// The copy no longer tells users to "activate" in the official app: #106 confirmed a ring that
+    /// had never been signed into the official app streams on our SM3 auth alone, and the same
+    /// tester saw this banner appear transiently and clear on its own.
+    private var notStreamingHint: some View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
             VStack(alignment: .leading, spacing: 2) {
                 Text("Ring isn't streaming").font(.subheadline.weight(.medium))
-                Text("Connected, but the ring isn't sending data. Open the official RingConn app once to activate it, then fully close it (swipe it away) and return here — only one app can pull the ring at a time.")
+                Text("Connected, but the ring hasn't sent data yet. Check that it's on your finger and off the charger, and fully close the official RingConn app if it's running — only one app can pull the ring at a time. This often clears on the next reconnect.")
                     .font(.caption).foregroundStyle(.secondary)
             }
         }
@@ -1204,7 +1207,7 @@ struct ContentView: View {
         return "Measuring SpO₂…"
     }
     /// Inline failure banner: shown when a user-initiated measure timed out without a lock.
-    /// Styled like `activationHint` (orange, inside the connection card) for visual consistency.
+    /// Styled like `notStreamingHint` (orange, inside the connection card) for visual consistency.
     /// Dismissed naturally when the user taps Measure again. (#55)
     private var measureFailedHint: some View {
         HStack(alignment: .top, spacing: 8) {

--- a/ios/OpenCircuit/OnboardingView.swift
+++ b/ios/OpenCircuit/OnboardingView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 /// First-run onboarding (#103). A short, dismissible, re-openable flow that orients a new
 /// (non-developer) user before they land on the dashboard:
 ///   1. what OpenCircuit does — local-first, writes to Apple Health, nothing leaves the device;
-///   2. the one-time prerequisite — activate the ring once in the official RingConn app;
+///   2. getting started — no official app or account needed (confirmed on a never-activated ring,
+///      #106); just close the official app if it's installed, since only one app can hold the ring;
 ///   3. permission priming — why Bluetooth + Apple Health are requested (the system prompts come
 ///      later, when the user first connects / authorizes Health — onboarding only explains them);
 ///   4. the not-affiliated / not-a-medical-device disclaimer.
@@ -26,7 +27,7 @@ struct OnboardingView: View {
         VStack(spacing: 0) {
             TabView(selection: $page) {
                 welcome.tag(0)
-                prerequisite.tag(1)
+                gettingStarted.tag(1)
                 permissions.tag(2)
                 disclaimer.tag(3)
             }
@@ -64,11 +65,12 @@ struct OnboardingView: View {
         }
     }
 
-    private var prerequisite: some View {
-        page(icon: "1.circle", tint: .indigo, title: "One-time setup") {
-            bullet("If your ring is new, set it up once in the official RingConn app to activate it — "
-                 + "then fully close that app (swipe it away). Only one app can talk to the ring at a "
-                 + "time. After that, OpenCircuit connects on its own.")
+    private var gettingStarted: some View {
+        page(icon: "1.circle", tint: .indigo, title: "Getting started") {
+            bullet("No RingConn account and no official app needed — OpenCircuit connects to your "
+                 + "ring on its own, even a brand-new ring straight out of the box.")
+            bullet("If the official RingConn app is installed, fully close it (swipe it away) before "
+                 + "using OpenCircuit — only one app can talk to the ring at a time.")
             bullet("Keep your phone nearby — especially overnight — so OpenCircuit can capture your "
                  + "full night of sleep and skin-temperature data.")
             bullet("Charge the ring as usual; OpenCircuit picks up where it left off.")

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/Opcodes.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/Opcodes.swift
@@ -161,13 +161,13 @@ public enum Command {
         0xe3: [0x1b, 0xe9, 0x85], 0xe5: [0x52, 0x0b, 0xe1], 0xf9: [0x36, 0x09, 0xb2],
     ]   // 24/256 entries from captures (incl. 2026-06-16 login e5→52 0b e1). Full f() needs the APK.
 
-    /// 🔴 UNKNOWN — the one-time login/activation command (if any) the official app sends so the
-    /// ring starts streaming to a fresh client. NOT present in any steady-state capture; reverse-
-    /// engineer from a first-time-provisioning / login btsnoop (issue #54), then fill + wire at the
-    /// discovery handler. Current evidence (§0/§5.8) points to the LE-SC bond itself being the gate
-    /// (local LTK, no cloud key) — in which case there is no app-layer command to send, only the
-    /// CoreBluetooth auto-bond. Placeholder so the call site can land before the bytes are known:
-    // public static func activate(/* token from login */) -> [UInt8] { … }
+    /// 🟢 CLOSED (#106) — there is NO one-time login/activation command. The long-suspected
+    /// provisioning step never existed: a factory-fresh ring that had never been signed into the
+    /// official app (Gen 3, shipped on firmware FR05.005) streamed live HR and SpO₂ to
+    /// OpenCircuit out of the box. The only gate is the per-connection SM3 challenge (§5.8,
+    /// `RingAuth`) plus the LE-SC "Just Works" bond CoreBluetooth negotiates locally — no cloud
+    /// key, no app secret, no app-layer activate frame. The former `activate(token:)` placeholder
+    /// is intentionally removed.
 }
 
 /// BLE transport handles (🟢). The ring is driven through this pair, not discrete

--- a/ios/README.md
+++ b/ios/README.md
@@ -51,10 +51,10 @@ written to **Apple Health** — nothing is sent to a server.
 
 - 🔗 **Standalone, no cloud key** — the ring's per-connection authentication is fully
   reverse-engineered (an SM3 challenge keyed only on the ring's *own* MAC), so OpenCircuit
-  connects and streams on its own, with **no RingConn account or app needed for everyday
-  use**. A ring you've already set up with the official app is bonded and works
-  immediately. *(One case is still being verified: a brand-new ring that has never been
-  activated in the official app on any phone — see issue #106.)*
+  connects and streams on its own, with **no RingConn account or app ever needed**.
+  Confirmed on a brand-new ring straight out of the box, before the official app had ever
+  been installed (Gen 3, firmware FR05.005 — [issue #106](https://github.com/perezjuanj/OpenCircuit/issues/106)),
+  as well as on rings already set up with the official app.
 - 💍 Works with **any RingConn Gen 2 ring**, and **multiple rings per phone**.
 - 🔄 Background sync, keepalive, and periodic auto-measure for continuous tracking.
 


### PR DESCRIPTION
Closes #106.

## What answered it

@kruftindustries ran OpenCircuit against a **factory-fresh RingConn Gen 3 (shipped on `FR05.005`) before the official app had ever been installed** — live HR and SpO₂ worked as expected. Installing the official app afterwards bumped firmware to `FR05.010`, still fine.

So the long-suspected first-time provisioning / cloud-activation step **does not exist**. The per-connection SM3 challenge (PROTOCOL.md §5.8) plus the LE-SC "Just Works" bond CoreBluetooth negotiates locally are the whole gate — for any owner of any ring.

## Changes (copy + comments only, no behavior change)

| Where | Before | After |
|---|---|---|
| `README.md`, `ios/README.md` | "One case is still being verified… never activated in the official app — see #106" | "no RingConn account or app **ever** needed", with the out-of-box confirmation cited |
| `OnboardingView` page 2 | "One-time setup — set it up once in the official RingConn app to activate it" | "Getting started — no account and no official app needed"; keeps the one-app-at-a-time note (still a real constraint) |
| `ContentView` | `activationHint`: "Open the official RingConn app once to activate it…" | `notStreamingHint`: points at the real causes (off-wrist / charger / another app holding the link) and notes it usually clears on reconnect |
| `Opcodes.swift` | 🔴 UNKNOWN `activate(token:)` placeholder | 🟢 CLOSED — no such command exists |
| `RingSession.swift` | comments + log line asserting "ring not activated/bonded" | infer a *silent link* only, per the `reconnectStalled` precedent |
| `docs/PROTOCOL.md` §5.8 | standalone-confirmed (logged-out app) | + never-activated ring confirmed 🟢 |
| `docs/RUNBOOK_SNOOP_SINGLE_SESSION.md` | #106 fresh-ring capture listed as a fallback | marked **DO NOT RUN — already answered** |

The banner itself is deliberately kept: the same tester saw "connected but not streaming" intermittently and it cleared on its own, so `notStreaming` is still a useful signal — it just had the wrong explanation attached.

## Verification

- `xcodebuild … -scheme OpenCircuit -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED**
- `swift test` in `ios/OpenCircuitKit` → **1335 tests, 0 failures**