### PR TITLE
fix(sleep): desk-activity wake gate — stop a sedentary evening being …

### DIFF
--- a/ios/OpenCircuitKit/Package.swift
+++ b/ios/OpenCircuitKit/Package.swift
@@ -23,5 +23,9 @@ let package = Package(
         // CLT-friendly verifier: `swift run RingKitVerify` works without Xcode,
         // asserting the same real-capture fixtures. Stopgap until Xcode is present.
         .executableTarget(name: "RingKitVerify", dependencies: ["OpenCircuitKit"]),
+        // Field-triage tool: replays a wearer's exported 0x4c records through the shipping
+        // sleep pipeline and prints the decision trace. Read-only; changes no behaviour.
+        // `swift run SleepReplay <export.json>` — see Sources/SleepReplay/main.swift.
+        .executableTarget(name: "SleepReplay", dependencies: ["OpenCircuitKit"]),
     ]
 )

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepDetection.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepDetection.swift
@@ -58,6 +58,22 @@ public struct HeartRateSample: Sendable, Equatable {
     }
 }
 
+/// One epoch's verdict from the ring's OWN activity magnitudes — `BulkRecord.activityMagnitudes`,
+/// the five 12-bit nibble-packed values in `[15:23)` (🟢 layout MEASURED, PROTOCOL.md §5.3 / #195).
+/// `quiet == true` means all five read zero: the ring itself saying nothing moved this epoch.
+///
+/// This is the ONLY thing the desk-activity gate reads — a BINARY predicate with an absolute floor,
+/// never a magnitude, a rank or a quantile. That distinction is the whole safety argument: see
+/// `deskWakeZeroShareThreshold`.
+public struct ActivityQuietSample: Sendable, Equatable {
+    public let time: Date
+    public let quiet: Bool
+    public init(time: Date, quiet: Bool) {
+        self.time = time
+        self.quiet = quiet
+    }
+}
+
 public enum Activity: Equatable, Sendable { case sleep, active }
 
 public struct ActivityPeriod: Equatable, Sendable {
@@ -109,6 +125,134 @@ public struct ActivityPeriod: Equatable, Sendable {
     /// Minimum HR readings (globally, and inside a block) before the gate will act, so a single
     /// stray reading can neither set a bogus floor nor flip a block.
     static let minHRSamplesForGate = 3
+
+    // MARK: - Desk-activity wake gate (#204)
+    //
+    // THE HOLE THIS FILLS. The HR gate above catches an awake-but-still block by its HEART; nothing
+    // catches one by its MOVEMENT, because the primary `[10:15]` motion channel does not register
+    // desk work. 🟢 MEASURED on two ground-truthed evenings from one wearer (FR02.018, Gen 2,
+    // Australia/Melbourne) in which the wearer was sitting at a computer:
+    //
+    //   period                                  n    epochs > motion baseline
+    //   Aug-16 evening, at a computer          152    19
+    //   Aug-17 evening, at a computer           61     0
+    //   Aug-17/18 REAL SLEEP                   157     0
+    //
+    // The primary channel reads the SAME value at a keyboard as it does in deep sleep, so the
+    // detector cannot break the run, `mainSleepBlock` welds evening to night, and the HR gate —
+    // which judges a whole period on its MEDIAN — cannot trim a head. On this wearer's 2026-08-17
+    // night that produced ONE unbroken 14 h 03 m "sleep" block, 17:49:54 → 07:53:12.
+    //
+    // WHAT THE RING DID RECORD. `activityMagnitudes` (`[15:23)`) is non-zero throughout both
+    // computer sessions and zero through most of real sleep. Share of epochs reading ALL-ZERO:
+    //
+    //   Aug-15 evening (before a correctly-staged night)      9 %
+    //   Aug-15/16 REAL SLEEP                                 79 %
+    //   Aug-16 daytime                                       10 %
+    //   Aug-16 evening, at a computer  [ground truth]         2 %
+    //   Aug-17 evening, up and about                          0 %
+    //   Aug-17 evening, dozing         [ground truth]        14 %
+    //   Aug-17 evening, at a computer  [ground truth]         0 %
+    //   Aug-17/18 REAL SLEEP                                 72 %
+    //
+    // Real sleep 72–79 %, every awake state 0–14 %, on two independent nights. The gate sits in
+    // that gap.
+    //
+    // ⚠️ WHY THIS IS NOT THE MEASURED TRAP `motionSource` WARNS ABOUT. That warning is about
+    // mapping the tail to a MAGNITUDE through a rank (a p80 quantile with no absolute floor), which
+    // moved 15 of 18 corpus nights by −100…+45 min and moved the SAME night in opposite directions
+    // in two bundles. This gate never computes a magnitude. It reads one binary predicate —
+    // `activityMagnitudesAreZero`, whose absolute floor is the number zero — and thresholds its
+    // SHARE over a rolling window. A record set cannot move where zero is.
+    //
+    // ⚠️ It also deliberately relaxes the "consumers may use it only through `BulkSleep.motionSource`"
+    // constraint on `motionIntensityTail`. That constraint exists to stop the two motion channels
+    // being MIXED into one magnitude scale; this gate keeps them separate — the primary channel
+    // still decides stillness, and this only ever VETOES a stillness verdict the ring's own activity
+    // record contradicts.
+    //
+    // ONE-DIRECTIONAL, like the wear and HR gates: it can only ever turn sleep into active.
+
+    /// Share of epochs in the rolling window that must read ALL-ZERO activity magnitudes for the
+    /// window to be allowed to count as sleep. Below this share the epoch is forced ACTIVE.
+    ///
+    /// **0 DISABLES THE GATE ENTIRELY** — the kill switch every other pass in this file carries.
+    /// At 0 the override is skipped outright and detection is byte-identical to pre-#204.
+    ///
+    /// 🟡 FIT ON TWO NIGHTS, ONE WEARER. 0.35 sits between the highest awake reading measured
+    /// (0.14, the Aug-17 doze) and the lowest sleep reading measured (0.72). That is a wide gap,
+    /// but it is two nights — this is a starting point to be re-fit against accumulated
+    /// `SleepEditLabel` corrections, NOT a settled value. The dozing figure is the one to watch:
+    /// evening dozing is genuinely intermediate, and a threshold this high will trim a doze back
+    /// to its stillest core.
+    public static let deskWakeZeroShareThreshold: Double = 0.35
+
+    /// Rolling window (in epochs) the share is measured over, centred on the epoch being judged.
+    /// 18 × 150 s = 45 min. Long enough that normal sleep stirring cannot drag a window under the
+    /// threshold (real-sleep windows measured 0.67–1.00 across both nights), short enough to place
+    /// the evening→sleep transition within ~15 min of the wearer's reported time.
+    static let deskWakeWindowEpochs = 18
+
+    /// Nominal epoch cadence, kept local so this detector stays device-agnostic (openwhoop port);
+    /// the RingConn 0x4c step is 150 s (`BulkRecord.epochSeconds`). Mirrors `rescueEpochStep`.
+    static let deskEpochStep: TimeInterval = 150
+
+    /// Per-epoch AWAKE verdicts from the ring's own activity record: `true` where the centred
+    /// window's all-zero share falls BELOW `threshold`. `epochs` must be time-sorted.
+    static func deskActivityAwake(_ epochs: [ActivityQuietSample],
+                                  threshold: Double = deskWakeZeroShareThreshold,
+                                  windowEpochs: Int = deskWakeWindowEpochs) -> [Bool] {
+        let n = epochs.count
+        guard n > 0, windowEpochs > 0, threshold > 0 else {
+            return [Bool](repeating: false, count: n)
+        }
+        // Prefix sums so the rolling share is O(n) rather than O(n·w).
+        var prefix = [Int](repeating: 0, count: n + 1)
+        for i in 0 ..< n { prefix[i + 1] = prefix[i] + (epochs[i].quiet ? 1 : 0) }
+        let half = windowEpochs / 2
+        return (0 ..< n).map { i in
+            let lo = max(0, i - half), hi = min(n, i + half + 1)
+            return Double(prefix[hi] - prefix[lo]) / Double(hi - lo) < threshold
+        }
+    }
+
+    /// Force `magnitudes` to the ACTIVE sentinel on every motion sample whose epoch the desk gate
+    /// judged awake. Runs AFTER `motionAboveLocalFloor` on purpose: the rolling idle floor is
+    /// computed from the unmodified channel, so the override cannot feed back into it.
+    ///
+    /// No-op — byte-identical to pre-#204 — when the threshold is 0, when no activity timeline is
+    /// supplied, or when no epoch is judged awake.
+    static func applyDeskActivityOverride(_ magnitudes: inout [Float], times: [Date],
+                                          activityQuiet: [ActivityQuietSample],
+                                          threshold: Double = deskWakeZeroShareThreshold,
+                                          windowEpochs: Int = deskWakeWindowEpochs) {
+        guard threshold > 0, !activityQuiet.isEmpty, magnitudes.count == times.count else { return }
+        let epochs = activityQuiet.sorted { $0.time < $1.time }
+        let awake = deskActivityAwake(epochs, threshold: threshold, windowEpochs: windowEpochs)
+        guard awake.contains(true) else { return }
+        let starts = epochs.map(\.time)
+        for i in magnitudes.indices {
+            // The motion timeline is a 5× sub-sample expansion of each epoch, so match a sample to
+            // the last epoch that STARTS at or before it and lies within one epoch step. Matching by
+            // time RANGE (not equality) keeps this correct for any sub-sample layout, and leaves a
+            // sample that falls in a data hole unmatched rather than mis-attributed.
+            guard let e = epochIndex(for: times[i], starts: starts), awake[e] else { continue }
+            magnitudes[i] = .greatestFiniteMagnitude
+        }
+    }
+
+    /// Index of the last epoch starting at or before `t`, or nil when `t` sits more than one epoch
+    /// step past it (a data hole, or before the first epoch).
+    static func epochIndex(for t: Date, starts: [Date]) -> Int? {
+        var lo = 0, hi = starts.count
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if starts[mid] <= t { lo = mid + 1 } else { hi = mid }
+        }
+        let i = lo - 1
+        guard i >= 0, t.timeIntervalSince(starts[i]) < deskEpochStep else { return nil }
+        return i
+    }
 
     /// Sleep-vitals rescue (the SYMMETRIC counterpart to the HR gate). The motion detector is blind
     /// to a still-but-AWAKE period (→ HR gate). It is EQUALLY blind the other way: a MOVING-but-ASLEEP
@@ -218,12 +362,21 @@ public struct ActivityPeriod: Equatable, Sendable {
     /// of the worn samples) so whatever the device idles at maps to ~0, then apply the same
     /// threshold. A constant-floor timeline (every existing test, an idle ring) maps to all-zero
     /// → still, exactly as before — so this is a no-op for Gen 2 while fixing Gen 3.
-    public static func detectFromMotion(_ history: [MotionSample]) -> [ActivityPeriod] {
+    /// `activityQuiet:` (optional) threads the ring's OWN per-epoch activity record through the
+    /// DESK-ACTIVITY GATE — the fix for an awake-but-still stretch the primary channel cannot see
+    /// (see the `deskWakeZeroShareThreshold` block). Empty (the default) leaves detection
+    /// byte-identical to pre-#204.
+    public static func detectFromMotion(_ history: [MotionSample],
+                                        activityQuiet: [ActivityQuietSample] = [],
+                                        threshold: Double = deskWakeZeroShareThreshold) -> [ActivityPeriod] {
         guard history.count >= 2 else { return [] }
         // The rolling floor and `detect` both assume a time-ordered timeline; sort defensively so an
         // unsorted caller (e.g. the nap path feeds the concatenated 0x00+0x03 channels) is correct.
         let history = history.sorted { $0.time < $1.time }
-        let relative = motionAboveLocalFloor(history)
+        var relative = motionAboveLocalFloor(history)
+        // One-directional: only ever raises a magnitude to the ACTIVE sentinel, never lowers one.
+        applyDeskActivityOverride(&relative, times: history.map(\.time), activityQuiet: activityQuiet,
+                                  threshold: threshold)
         return detect(times: history.map(\.time), deltas: relative,
                       stillThreshold: motionStillThreshold,
                       maxGap: gravityMaxGap - motionGapSubSampleCorrection,
@@ -320,7 +473,7 @@ public struct ActivityPeriod: Equatable, Sendable {
         return out
     }
 
-    /// Sleep/Active detection (motion) with two post-filters that only ever REMOVE sleep, never add it:
+    /// Sleep/Active detection (motion) with three post-filters that only ever REMOVE sleep, never add it:
     ///   • WEAR GATE (#41): a `.sleep` block whose median skin temperature reads off-wrist / on the
     ///     charger is reclassified `.active`, so a perfectly still ring on the nightstand can't
     ///     masquerade as a night. A block with no temperature coverage is left as detected — absence
@@ -328,15 +481,22 @@ public struct ActivityPeriod: Equatable, Sendable {
     ///   • HR GATE: a still block whose median HR runs well above the night's resting floor (an
     ///     awake-but-still period — sitting out late, a long sedentary evening) is reclassified
     ///     `.active`. The ring is WORN here, so the wear gate can't catch it; HR is the discriminator.
+    ///   • DESK-ACTIVITY GATE (#204, `activityQuiet:`): epochs the ring's OWN activity magnitudes say
+    ///     were not still are forced `.active` BEFORE segmentation, so the run SPLITS there. Unlike
+    ///     the two gates above — which judge a whole period on its median and so cannot trim a HEAD —
+    ///     this one acts per epoch, which is what a sedentary evening welded onto the night needs.
+    ///     Empty timeline (the default) or threshold 0 ⇒ inert.
     /// `temperatureSamples` / `heartRateSamples` may be unordered and sparse; only readings inside a
     /// block are considered, and an empty set makes that gate a no-op.
     public static func detectFromMotion(_ history: [MotionSample],
                                         temperatureSamples: [TemperatureSample],
                                         heartRateSamples: [HeartRateSample] = [],
                                         sleepVitalTimes: [Date] = [],
+                                        activityQuiet: [ActivityQuietSample] = [],
+                                        threshold: Double = deskWakeZeroShareThreshold,
                                         wornMinC: Double = wornMinTemperatureC,
                                         awakeHRMargin: Int = awakeHRMarginBPM) -> [ActivityPeriod] {
-        let base = detectFromMotion(history)
+        let base = detectFromMotion(history, activityQuiet: activityQuiet, threshold: threshold)
         let wearGated = wearGate(base, temperatureSamples, wornMinC: wornMinC)
         let hrGated = heartRateGate(wearGated, heartRateSamples, marginBPM: awakeHRMargin)
         return sleepVitalsRescue(hrGated, heartRateSamples, sleepVitalTimes, marginBPM: awakeHRMargin)
@@ -345,7 +505,7 @@ public struct ActivityPeriod: Equatable, Sendable {
     /// The night's resting-floor HR estimate: `sleepHRFloorPercentile` over the DISTINCT HR levels
     /// seen tonight (deduped so a long high-HR stretch can't drag the floor up by sheer count — see
     /// `heartRateGate`). `nil` when there aren't enough readings to judge.
-    static func sleepHRFloor(_ hr: [HeartRateSample]) -> Int? {
+    public static func sleepHRFloor(_ hr: [HeartRateSample]) -> Int? {
         guard hr.count >= minHRSamplesForGate else { return nil }
         let levels = Array(Set(hr.map(\.bpm))).sorted()
         guard !levels.isEmpty else { return nil }

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepStaging.swift
@@ -395,6 +395,16 @@ public enum SleepStaging {
         /// therefore a synthetic unworn block over REAL night bytes, not a corpus night. See #194.
         public var stagedWearGate: Bool
 
+        /// Share of epochs in the rolling window that must read ALL-ZERO activity magnitudes for an
+        /// epoch to be allowed to stage as asleep — the STAGED half of the desk-activity gate (#204).
+        /// The coarse half runs in `ActivityPeriod.applyDeskActivityOverride` and fixes the in-bed
+        /// ENVELOPE; this one marks any desk epoch that survives INSIDE the envelope as awake, so the
+        /// two layers cannot disagree about the same evening (the #194 failure shape).
+        /// **0 DISABLES it** — byte-identical to pre-#204 staging. Defaults to the detector's own
+        /// constant so one number moves both layers. See `ActivityPeriod.deskWakeZeroShareThreshold`
+        /// for the measurements and the 🟡 two-night caveat.
+        public var deskWakeZeroShareThreshold: Double
+
         public init(awakeMotion: Int = 15,
                     deepHRPercentile: Double = 0.42,
                     remHRPercentile: Double = 0.86,
@@ -429,7 +439,8 @@ public enum SleepStaging {
                     preOnsetBedtimeMaxGapEpochs: Int = 5,
                     cadenceWakeQuietEpochs: Int = 20,
                     cadenceWakeMaxQuietEpochs: Int = 240,
-                    stagedWearGate: Bool = true) {
+                    stagedWearGate: Bool = true,
+                    deskWakeZeroShareThreshold: Double = ActivityPeriod.deskWakeZeroShareThreshold) {
             self.awakeMotion = awakeMotion
             self.deepHRPercentile = deepHRPercentile
             self.remHRPercentile = remHRPercentile
@@ -465,6 +476,7 @@ public enum SleepStaging {
             self.cadenceWakeQuietEpochs = cadenceWakeQuietEpochs
             self.cadenceWakeMaxQuietEpochs = cadenceWakeMaxQuietEpochs
             self.stagedWearGate = stagedWearGate
+            self.deskWakeZeroShareThreshold = deskWakeZeroShareThreshold
         }
 
         public static let `default` = Tuning()
@@ -677,6 +689,18 @@ public enum SleepStaging {
         // is not a physiological channel — it is the ring's own SpO2 duty cycle, read by
         // `markCadenceWakeOffset` alone (#190).
         var rowLayouts: [BulkRecord.Layout] = []
+        // Parallel to `rows`: the DESK-ACTIVITY verdict (#204). Computed over the WHOLE in-block run
+        // before the row loop, because the rolling share needs neighbours that the loop may skip
+        // (a leading epoch with no HR yet). Idle epochs report quiet-by-template rather than by
+        // measurement, so they are excluded from the evidence exactly as `activityQuietTimeline` does.
+        var rowDeskAwake: [Bool] = []
+        let deskAwakeAll: [Bool] = {
+            let quiet = inBlock.map {
+                ActivityQuietSample(time: $0.date(epoch: epoch),
+                                    quiet: $0.layout == .idle ? true : $0.activityMagnitudesAreZero)
+            }
+            return ActivityPeriod.deskActivityAwake(quiet, threshold: tuning.deskWakeZeroShareThreshold)
+        }()
         // Per-epoch motion energy is measured ABOVE a LOCAL idle floor (same rolling estimate as
         // detection). Gen 2 idles at ~1, Gen 3 at ~15–16 and DRIFTS across the night with posture
         // (16→24→39, 🟢 FR05.008 capture 2026-06-23). The old `$1 == 1 ? 0 : …` hard-coded Gen 2's
@@ -700,6 +724,7 @@ public enum SleepStaging {
             let motion = max(0, Int(rawMotion[idx] - floor[idx]))
             rows.append((r.date(epoch: epoch), hr, lastHRV, motion, lastSpo2, lastRR, r.hrvRMSSD != nil))
             rowLayouts.append(r.layout)
+            rowDeskAwake.append(deskAwakeAll[idx])
         }
         guard rows.count >= 2 else { return [] }
 
@@ -755,7 +780,11 @@ public enum SleepStaging {
         // the rescued pre-wake morning back off via `sleepSpan`. Scoping it to the tail is what keeps a
         // genuine mid-night WASO (an interior awakening with sustained sleep AFTER it) from being absorbed
         // as sleep — only the morning is rescued, not every restless mid-night.
-        let motionAwakeStrict = rows.map { $0.motion > tuning.awakeMotion }
+        // MOTION-awake now has TWO sources, both movement evidence: the primary `[10:15]` channel
+        // above its local idle floor, OR the ring's own activity magnitudes saying this stretch was
+        // not still (#204). The second is what sees desk work, which the first cannot express — see
+        // `ActivityPeriod.deskWakeZeroShareThreshold`. Inert when the threshold is 0.
+        let motionAwakeStrict = rows.indices.map { rows[$0].motion > tuning.awakeMotion || rowDeskAwake[$0] }
         // Tail boundary from the STRICT (un-softened) span: the epoch just after the end of the last
         // sustained asleep run. `motionAwakeVitalsHalfWindow <= 0` disables the rescue entirely (tail =
         // end of night → no epoch is softened → byte-identical to the pre-rescue staging).

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
@@ -791,6 +791,22 @@ public enum BulkSleep {
         records.compactMap { $0.hrvRMSSD != nil ? $0.date(epoch: epoch) : nil }
     }
 
+    /// Per-epoch verdicts from the ring's OWN activity magnitudes (`[15:23)`, 🟢 #195) for the
+    /// DESK-ACTIVITY GATE (`ActivityPeriod.applyDeskActivityOverride`, #204) — the awake-but-still
+    /// signal the primary `[10:15]` channel cannot express. Built from the SAME records as the
+    /// motion/HR/sleep-vitals timelines, so no extra channel is threaded.
+    ///
+    /// Idle (unworn) epochs are EXCLUDED rather than reported quiet: their activity block is zero by
+    /// template, not by measurement, so counting them would let a charging stretch vouch for the
+    /// stillness of the epochs around it.
+    public static func activityQuietTimeline(from records: [BulkRecord],
+                                             epoch: Int = Command.syncEpoch) -> [ActivityQuietSample] {
+        records.compactMap { r in
+            r.layout == .idle ? nil
+                : ActivityQuietSample(time: r.date(epoch: epoch), quiet: r.activityMagnitudesAreZero)
+        }
+    }
+
     /// Restrict `records` to those whose epoch falls within `hint`, or return them
     /// unchanged when no hint is given. Extension point for the sleep-schedule abstraction:
     /// the app can pass the user's bedtime→wake window (see ios/OpenCircuit/SleepSchedule)
@@ -814,7 +830,8 @@ public enum BulkSleep {
         let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch),
                                                       temperatureSamples: temperatures,
                                                       heartRateSamples: heartRateTimeline(from: scoped, epoch: epoch),
-                                                      sleepVitalTimes: sleepVitalTimeline(from: scoped, epoch: epoch))
+                                                      sleepVitalTimes: sleepVitalTimeline(from: scoped, epoch: epoch),
+                                                      activityQuiet: activityQuietTimeline(from: scoped, epoch: epoch))
         // Clustered span (brief awakenings bridged), not just the first/longest fragment — see
         // mainSleepBlock. A drifting Gen-3 floor or a real mid-sleep stir otherwise splits the night.
         return ActivityPeriod.mainSleepBlock(periods)
@@ -850,7 +867,8 @@ public enum BulkSleep {
         let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: scoped, epoch: epoch),
                                                       temperatureSamples: temperatures,
                                                       heartRateSamples: heartRateTimeline(from: scoped, epoch: epoch),
-                                                      sleepVitalTimes: sleepVitalTimeline(from: scoped, epoch: epoch))
+                                                      sleepVitalTimes: sleepVitalTimeline(from: scoped, epoch: epoch),
+                                                      activityQuiet: activityQuietTimeline(from: scoped, epoch: epoch))
         // Main in-bed block = the clustered sleep span (brief awakenings bridged via maxSleepPause),
         // not just the longest single fragment — so a drift-fragmented Gen-3 night isn't truncated.
         guard let block = ActivityPeriod.mainSleepBlock(periods) else { return [] }
@@ -966,7 +984,8 @@ public enum BulkSleep {
         let periods = ActivityPeriod.detectFromMotion(motionTimeline(from: records, epoch: epoch),
                                                       temperatureSamples: temperatures,
                                                       heartRateSamples: heartRateTimeline(from: records, epoch: epoch),
-                                                      sleepVitalTimes: sleepVitalTimeline(from: records, epoch: epoch))
+                                                      sleepVitalTimes: sleepVitalTimeline(from: records, epoch: epoch),
+                                                      activityQuiet: activityQuietTimeline(from: records, epoch: epoch))
         let sleepBlocks = periods.filter {
             $0.activity == .sleep && $0.duration > ActivityPeriod.minSleepDuration
         }

--- a/ios/OpenCircuitKit/Sources/SleepReplay/main.swift
+++ b/ios/OpenCircuitKit/Sources/SleepReplay/main.swift
@@ -1,0 +1,482 @@
+// SleepReplay — replay a night's raw 0x4c records through the SHIPPING sleep pipeline and
+// print the decision trace, so a "the night started hours too early" report can be located
+// at a specific pass rather than argued about from a screenshot.
+//
+// WHY A SEPARATE TOOL. Every stage of the pipeline is already unit-tested against SYNTHETIC
+// records; what no test can supply is a real wearer's night that the model got wrong. The
+// JSON export carries `epochArchive[].recordsBase64` — the exact `[BulkRecord]` the app
+// staged from — so this replays it byte-for-byte through the same public entry points
+// (`ActivityPeriod.detectFromMotion` → `BulkSleep.latestNightRecords` → `SleepStaging.classify`)
+// and reports WHERE the onset came from.
+//
+// It is READ-ONLY and offline: it opens one file, prints, and exits. It changes no behaviour.
+//
+//   swift run SleepReplay <export.json> [--tz Australia/Sydney] [--ring <id>]
+//
+// ⚠️ RETENTION: `EpochArchive.retention` is 30 h, so an export made more than ~30 h after the
+// night carries no raw records for it. The tool says so rather than replaying a neighbouring
+// night by accident.
+
+import Foundation
+import OpenCircuitKit
+
+// MARK: - CLI
+
+let rawArgs = Array(CommandLine.arguments.dropFirst())
+func flag(_ name: String) -> String? {
+    guard let i = rawArgs.firstIndex(of: name), i + 1 < rawArgs.count else { return nil }
+    return rawArgs[i + 1]
+}
+guard let path = rawArgs.first(where: { !$0.hasPrefix("--") }) else {
+    print("""
+    usage: swift run SleepReplay <export.json> [--tz <IANA zone>] [--ring <ringID>]
+
+      <export.json>  an OpenCircuit JSON export (Settings -> Export -> Format: JSON).
+                     CSV will not work: the raw records are JSON-only.
+      --tz           IANA zone to print wall-clock times in (default: this machine's).
+      --ring         replay only this ringID (default: every ring in the file).
+    """)
+    exit(2)
+}
+
+let zone = flag("--tz").flatMap(TimeZone.init(identifier:)) ?? .current
+let ringFilter = flag("--ring")
+
+var calendar = Calendar(identifier: .gregorian)
+calendar.timeZone = zone
+
+let clock: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "MMM d HH:mm:ss"
+    f.timeZone = zone
+    f.locale = Locale(identifier: "en_US_POSIX")
+    return f
+}()
+
+func t(_ d: Date) -> String { clock.string(from: d) }
+func t(_ d: Date?) -> String { d.map(t) ?? "—" }
+
+func dur(_ s: TimeInterval) -> String {
+    let m = Int((s / 60).rounded())
+    return m >= 60 ? "\(m / 60)h\(String(format: "%02d", m % 60))m" : "\(m)m"
+}
+
+func rule(_ title: String) {
+    print("")
+    print("── \(title) " + String(repeating: "─", count: max(0, 74 - title.count)))
+}
+
+func median(_ xs: [Int]) -> Int? {
+    guard !xs.isEmpty else { return nil }
+    let s = xs.sorted()
+    return s[s.count / 2]
+}
+func median(_ xs: [Double]) -> Double? {
+    guard !xs.isEmpty else { return nil }
+    let s = xs.sorted()
+    return s[s.count / 2]
+}
+
+// MARK: - Load
+
+guard let blob = FileManager.default.contents(atPath: path),
+      let root = (try? JSONSerialization.jsonObject(with: blob)) as? [String: Any] else {
+    print("error: could not read \(path) as JSON")
+    exit(1)
+}
+
+print("SleepReplay — \(path)")
+print("  schemaVersion \(root["schemaVersion"] as? Int ?? -1)   exportedAt \(root["exportedAt"] as? String ?? "?")")
+print("  printing times in \(zone.identifier)")
+if let meta = root["meta"] as? [String: Any] {
+    let bits = ["appVersion", "build", "ringModel", "firmware", "deviceTimeZone"]
+        .compactMap { k in (meta[k] as? String).map { "\(k)=\($0)" } }
+    if !bits.isEmpty { print("  " + bits.joined(separator: "  ")) }
+}
+
+// Raw records, per ring. `epochArchive` is the archive staging actually ran on; the
+// per-drain `historySyncEvidence` blobs are a LOSSY ring buffer and are used only as a
+// fallback (and unioned in, since they can hold epochs the archive has since pruned).
+struct RingRecords { let ringID: String; var records: [BulkRecord]; var archiveBacked: Bool }
+var byRing: [String: RingRecords] = [:]
+
+for a in (root["epochArchive"] as? [[String: Any]] ?? []) {
+    guard let ringID = a["ringID"] as? String,
+          let b64 = a["recordsBase64"] as? String,
+          let data = Data(base64Encoded: b64) else { continue }
+    byRing[ringID] = RingRecords(ringID: ringID, records: EpochArchive.decode(data), archiveBacked: true)
+}
+for e in (root["historySyncEvidence"] as? [[String: Any]] ?? []) {
+    guard let ringID = e["ringID"] as? String,
+          let b64 = e["rawRecordBlobBase64"] as? String,
+          let data = Data(base64Encoded: b64) else { continue }
+    let recs = EpochArchive.decode(data)
+    guard !recs.isEmpty else { continue }
+    if var existing = byRing[ringID] {
+        // Union, dedup by counter — merge() also prunes to retention, which is what the app did.
+        existing.records = EpochArchive.merge(existing: existing.records, incoming: recs)
+        byRing[ringID] = existing
+    } else {
+        byRing[ringID] = RingRecords(ringID: ringID, records: recs, archiveBacked: false)
+    }
+}
+
+// Skin temperature drives the #41 wear gate on both the coarse and staged paths, so feed it
+// exactly as the app does. It is not ring-scoped in the export, so every ring gets all of it.
+let temperatures: [TemperatureSample] = {
+    let iso = ISO8601DateFormatter()
+    return (root["samples"] as? [[String: Any]] ?? []).compactMap { s in
+        guard s["kind"] as? String == MetricKind.temperature.rawValue,
+              let start = (s["start"] as? String).flatMap({ iso.date(from: $0) }),
+              let v = s["value"] as? Double else { return nil }
+        return TemperatureSample(time: start, celsius: v)
+    }
+}()
+
+// What the app actually SHIPPED for these nights — the thing the user saw in Apple Health.
+rule("what the app shipped (sleepSessions)")
+let sessions = root["sleepSessions"] as? [[String: Any]] ?? []
+if sessions.isEmpty {
+    print("  (no sleepSessions in this export)")
+}
+for s in sessions {
+    let night = s["night"] as? String ?? "?"
+    let offsetISO = ISO8601DateFormatter()
+    offsetISO.formatOptions = [.withInternetDateTime]
+    func d(_ k: String) -> Date? { (s[k] as? String).flatMap { offsetISO.date(from: $0) } }
+    let inBed = d("inBedStart"), onset = d("sleepOnset"), wake = d("sleepWake"), inBedEnd = d("inBedEnd")
+    let edited = (s["isManuallyEdited"] as? Bool ?? false) ? "  [manually edited]" : ""
+    print("  \(night)  inBed \(t(inBed)) → \(t(inBedEnd))   onset \(t(onset))   wake \(t(wake))\(edited)")
+    if let onset, let wake {
+        print("           onset→wake \(dur(wake.timeIntervalSince(onset)))"
+              + (inBed.map { "   inBed→onset \(dur(onset.timeIntervalSince($0)))" } ?? ""))
+    }
+    if let hyp = s["hypnogram"] as? [[String: Any]], !hyp.isEmpty {
+        var totals: [String: TimeInterval] = [:]
+        for seg in hyp {
+            let stage = seg["stage"] as? String ?? "?"
+            totals[stage, default: 0] += (seg["durationSec"] as? Double ?? 0)
+        }
+        let line = totals.sorted { $0.key < $1.key }.map { "\($0.key) \(dur($0.value))" }.joined(separator: "  ")
+        print("           hypnogram: \(hyp.count) segments — \(line)")
+    }
+}
+
+// MARK: - Per-ring replay
+
+let epoch = Command.syncEpoch
+
+for ringID in byRing.keys.sorted() {
+    guard ringFilter == nil || ringFilter == ringID else { continue }
+    let ring = byRing[ringID]!
+    let records = ring.records.sorted { $0.counter < $1.counter }
+
+    print("")
+    print(String(repeating: "═", count: 80))
+    print("RING \(ringID)   \(records.count) records"
+          + (ring.archiveBacked ? "" : "   ⚠️ evidence blobs only (no epochArchive) — LOSSY"))
+    print(String(repeating: "═", count: 80))
+
+    guard records.count >= 2 else { print("  too few records to replay"); continue }
+    let first = records.first!.date(epoch: epoch), last = records.last!.date(epoch: epoch)
+    print("  span \(t(first)) → \(t(last))   (\(dur(last.timeIntervalSince(first))))")
+
+    // The three timelines every pass is built from — identical construction to BulkSleep.mainSleep.
+    let motion = BulkSleep.motionTimeline(from: records, epoch: epoch)
+    let hr = BulkSleep.heartRateTimeline(from: records, epoch: epoch)
+    let vitals = BulkSleep.sleepVitalTimeline(from: records, epoch: epoch)
+    let quiet = BulkSleep.activityQuietTimeline(from: records, epoch: epoch)
+    let tempsInSpan = temperatures.filter { $0.time >= first.addingTimeInterval(-3600)
+                                         && $0.time <= last.addingTimeInterval(3600) }
+    print("  motion samples \(motion.count)   HR readings \(hr.count)"
+          + "   sleep-vitals epochs \(vitals.count)   temp samples in span \(tempsInSpan.count)")
+
+    // ── 1. Data holes ────────────────────────────────────────────────────────────────────
+    // A hole > gravityMaxGap splits the detector's runs AND splits `contiguousFragments`,
+    // which is what makes each side stage independently (its own HR floor, its own bands).
+    rule("1. data holes (> \(Int(ActivityPeriod.gravityMaxGap / 60)) min — these split fragments)")
+    var holes = 0
+    for i in 1 ..< records.count {
+        let gap = TimeInterval(Int(records[i].counter) - Int(records[i - 1].counter))
+        guard gap > ActivityPeriod.gravityMaxGap else { continue }
+        holes += 1
+        print("  \(t(records[i - 1].date(epoch: epoch))) → \(t(records[i].date(epoch: epoch)))   \(dur(gap))")
+    }
+    if holes == 0 { print("  none — one contiguous run") }
+
+    // ── 2. Coarse detection, ungated vs gated ────────────────────────────────────────────
+    // `detectFromMotion(_:)` is motion only; the four-argument form applies the wear gate
+    // (#41) then the HR gate then the sleep-vitals tail rescue. Diffing them names the gate.
+    rule("2. coarse detection — which sleep blocks the gates removed")
+    let ungated = ActivityPeriod.detectFromMotion(motion)
+    let gated = ActivityPeriod.detectFromMotion(motion,
+                                                temperatureSamples: tempsInSpan,
+                                                heartRateSamples: hr,
+                                                sleepVitalTimes: vitals,
+                                                activityQuiet: quiet)
+    let floor = ActivityPeriod.sleepHRFloor(hr)
+    let threshold = floor.map { $0 + ActivityPeriod.awakeHRMarginBPM }
+    print("  HR floor (p10 of DISTINCT levels across the whole timeline): "
+          + (floor.map { "\($0) bpm" } ?? "n/a")
+          + "   → HR-gate threshold \(threshold.map { "\($0) bpm" } ?? "n/a")")
+    print("  (a still block is kept as sleep while its MEDIAN HR is at or below that threshold)")
+    print("")
+    print("  sleep blocks ≥ 15 min, after gating:")
+    var anyBlock = false
+    for p in gated where p.activity == .sleep && p.duration >= 15 * 60 {
+        anyBlock = true
+        let inside = hr.filter { $0.time >= p.start && $0.time <= p.end }.map(\.bpm)
+        let temp = tempsInSpan.filter { $0.time >= p.start && $0.time <= p.end }.map(\.celsius)
+        let med = median(inside).map { "\($0)" } ?? "—"
+        let headroom = (median(inside).flatMap { m in threshold.map { $0 - m } })
+            .map { $0 >= 0 ? "\($0) bpm under" : "\(-$0) bpm over" } ?? "—"
+        print("    \(t(p.start)) → \(t(p.end))  \(dur(p.duration).padded(7))"
+              + "  medianHR \(med.padded(4)) (\(headroom) threshold)"
+              + "  n=\(inside.count)"
+              + (median(temp).map { String(format: "  medianTemp %.1f°C", $0) } ?? ""))
+    }
+    if !anyBlock { print("    (none)") }
+
+    let killed = ungated.filter { u in
+        u.activity == .sleep && u.duration >= 15 * 60
+            && !gated.contains { $0.activity == .sleep && $0.start == u.start && $0.end == u.end }
+    }
+    print("")
+    if killed.isEmpty {
+        print("  gates removed NOTHING — every still block above survived into the night candidates.")
+    } else {
+        print("  gates REMOVED these still blocks (good — this is the machinery working):")
+        for p in killed {
+            let inside = hr.filter { $0.time >= p.start && $0.time <= p.end }.map(\.bpm)
+            print("    \(t(p.start)) → \(t(p.end))  \(dur(p.duration).padded(7))"
+                  + "  medianHR \(median(inside).map { "\($0)" } ?? "—")")
+        }
+    }
+
+    // ── 3. Clustering into one "main sleep block" ────────────────────────────────────────
+    // `mainSleepBlock` chains sleep periods separated by < maxSleepPause. A bridge listed
+    // here is an awake stretch that was absorbed into the night wholesale.
+    rule("3. clustering — gaps bridged by maxSleepPause (\(Int(ActivityPeriod.maxSleepPause / 60)) min)")
+    let sleeps = gated.filter { $0.activity == .sleep }.sorted { $0.start < $1.start }
+    var bridged = 0
+    for (a, b) in zip(sleeps, sleeps.dropFirst()) {
+        let gap = b.start.timeIntervalSince(a.end)
+        guard gap > 0, gap < ActivityPeriod.maxSleepPause else { continue }
+        bridged += 1
+        print("  bridged \(t(a.end)) → \(t(b.start))   \(dur(gap))   (awake, counted inside the night)")
+    }
+    if bridged == 0 { print("  no gaps bridged") }
+    if let block = ActivityPeriod.mainSleepBlock(gated) {
+        print("  → main block  \(t(block.start)) → \(t(block.end))   \(dur(block.duration))")
+    } else {
+        print("  → no main block")
+    }
+
+    // ── 4. Night scoping ─────────────────────────────────────────────────────────────────
+    // `latestNightRecords` picks the anchor night, chains earlier fragments within
+    // maxIntraNightGap, then FLOORS the start at anchor.end − maxNightSpan. Hitting that
+    // floor exactly is the signature of a window that wanted to be even wider.
+    rule("4. night scoping (latestNightRecords)")
+    let night = BulkSleep.latestNightRecords(from: records, temperatures: tempsInSpan, epoch: epoch)
+    if night.isEmpty || night.count == records.count {
+        print("  scoping returned \(night.count == records.count ? "EVERYTHING (no overnight block found)" : "nothing")")
+    }
+    if let ns = night.first?.date(epoch: epoch), let ne = night.last?.date(epoch: epoch) {
+        let span = ne.timeIntervalSince(ns)
+        print("  window \(t(ns)) → \(t(ne))   \(dur(span))   (\(night.count) records)")
+        // The window carries a ±30 min margin, so compare against maxNightSpan + both margins.
+        let cap = BulkSleep.maxNightSpan + 3600
+        if span >= cap - 300 {
+            print("  ⚠️ AT THE maxNightSpan CAP (\(dur(BulkSleep.maxNightSpan)) + margins) — the")
+            print("     detected cluster wanted to be WIDER and was clipped. The true head of the")
+            print("     over-wide block is EARLIER than the window start above.")
+        }
+    }
+
+    // ── 5. Fragments ─────────────────────────────────────────────────────────────────────
+    // `SleepStaging.classify` stages each fragment INDEPENDENTLY — its own HR floor, its own
+    // percentile bands. An evening fragment therefore gets a full Deep/Core/REM mini-night.
+    rule("5. fragments inside the night window (each staged INDEPENDENTLY)")
+    let frags = BulkSleep.contiguousFragments(night)
+    for (i, f) in frags.enumerated() {
+        guard let fs = f.first?.date(epoch: epoch), let fe = f.last?.date(epoch: epoch) else { continue }
+        let fhr = f.compactMap(\.heartRate)
+        print("  #\(i + 1)  \(t(fs)) → \(t(fe))  \(dur(fe.timeIntervalSince(fs)).padded(7))"
+              + "  \(f.count) epochs"
+              + "  HR min/med/max \(fhr.min().map(String.init) ?? "—")/"
+              + "\(median(fhr).map(String.init) ?? "—")/\(fhr.max().map(String.init) ?? "—")")
+    }
+    if frags.count > 1 {
+        print("  ⚠️ \(frags.count) fragments — each computes its OWN sleeping floor and stage bands,")
+        print("     so an evening fragment can be staged as a self-contained night.")
+    }
+
+    // ── 6. Staging ───────────────────────────────────────────────────────────────────────
+    rule("6. staging (SleepStaging.classify) — the hypnogram that reaches Apple Health")
+    let staged = SleepStaging.classify(from: night, temperatures: tempsInSpan, epoch: epoch)
+    if let w = SleepStaging.sleepWindow(staged) {
+        print("  onset \(t(w.onset))   wake \(t(w.wake))   asleep-span \(dur(w.wake.timeIntervalSince(w.onset)))")
+    } else {
+        print("  no asleep segments")
+    }
+    if let bed = staged.filter({ $0.stage == .inBed }).map(\.start).min(),
+       let bedEnd = staged.filter({ $0.stage == .inBed }).map(\.end).max() {
+        print("  inBed \(t(bed)) → \(t(bedEnd))   \(dur(bedEnd.timeIntervalSince(bed)))")
+    }
+    let totals = SleepStaging.stageTotals(staged)
+    print("  totals: " + SleepStage.allCases
+        .compactMap { s in totals[s].map { "\(s.rawValue) \(dur($0))" } }
+        .joined(separator: "   "))
+    print("  total asleep \(dur(SleepStaging.totalAsleep(staged)))")
+
+    // ── 7. Why onset landed where it did ─────────────────────────────────────────────────
+    // Both onset-correction passes (`markDescentOnsetAwake`, `markLeadInWakeOnset`) search
+    // only the first `onsetSearchEpochs` of a fragment. If real onset sits beyond that
+    // horizon they CANNOT reach it, and onset falls to the first sustained quiet run instead.
+    rule("7. onset-search horizon — can the onset passes even REACH the real onset?")
+    let d = SleepStaging.Tuning.default
+    let horizon = TimeInterval(d.onsetSearchEpochs * BulkRecord.epochSeconds)
+    print("  default onsetSearchEpochs = \(d.onsetSearchEpochs) epochs × \(BulkRecord.epochSeconds)s = \(dur(horizon)) from each fragment's start")
+    for (i, f) in frags.enumerated() {
+        guard let fs = f.first?.date(epoch: epoch) else { continue }
+        print("    fragment #\(i + 1) horizon ends \(t(fs.addingTimeInterval(horizon)))")
+    }
+    print("  → any real onset LATER than its fragment's horizon is unreachable by both onset passes.")
+    print("")
+    print("  sweep (everything else held at defaults):")
+    print("    onsetSearchEpochs   onset            wake             asleep")
+    for k in [d.onsetSearchEpochs, 96, 192, 288, 384] {
+        let tuned = SleepStaging.Tuning(onsetSearchEpochs: k)
+        let s = SleepStaging.classify(from: night, temperatures: tempsInSpan, epoch: epoch, tuning: tuned)
+        let w = SleepStaging.sleepWindow(s)
+        let tag = k == d.onsetSearchEpochs ? " (default)" : ""
+        print("    \(String(k).padded(6))\(tag.padded(12))\(t(w?.onset).padded(17))\(t(w?.wake).padded(17))\(dur(SleepStaging.totalAsleep(s)))")
+    }
+
+    // ── 8. HR-gate margin sweep ──────────────────────────────────────────────────────────
+    // The coarse gate's margin decides whether a sedentary evening survives as "sleep" at
+    // all. If tightening it collapses the block start onto the real bedtime, the gate — not
+    // staging — is where the night is being lost.
+    rule("8. coarse HR-gate margin sweep (default \(ActivityPeriod.awakeHRMarginBPM) bpm)")
+    print("    margin   main block start   end                span")
+    for m in [ActivityPeriod.awakeHRMarginBPM, 20, 15, 12, 10, 8] {
+        let g = ActivityPeriod.detectFromMotion(motion,
+                                                temperatureSamples: tempsInSpan,
+                                                heartRateSamples: hr,
+                                                sleepVitalTimes: vitals,
+                                                activityQuiet: quiet,
+                                                awakeHRMargin: m)
+        let b = ActivityPeriod.mainSleepBlock(g)
+        let tag = m == ActivityPeriod.awakeHRMarginBPM ? "*" : " "
+        print("    \(String(m).padded(3))\(tag.padded(6))\(t(b?.start).padded(19))\(t(b?.end).padded(19))"
+              + (b.map { dur($0.duration) } ?? "—"))
+    }
+    print("    (* = shipping default)")
+
+    // ── 9b. Staging wake-margin sweep ────────────────────────────────────────────────────
+    // `wakeHRMarginBPM` decides, per epoch, whether smoothed HR sits far enough above the
+    // fragment's sleeping floor to be WAKE. It is the one knob that separates quiet
+    // wakefulness from sleep, and it is a fixed bpm — so it fails for a wearer whose sitting
+    // HR and sleeping HR differ by less than the margin. `earliestAsleep` is the tell: if it
+    // jumps hours later as the margin tightens, the leading "sleep" was HR-indistinguishable.
+    rule("9b. staging wake margin sweep (default \(Int(d.wakeHRMarginBPM)) bpm above the fragment floor)")
+    print("    margin   onset            wake             asleep    of which Deep")
+    for m in [d.wakeHRMarginBPM, 15, 12, 10, 9, 8, 6] {
+        let tuned = SleepStaging.Tuning(wakeHRMarginBPM: m)
+        let sg = SleepStaging.classify(from: night, temperatures: tempsInSpan, epoch: epoch, tuning: tuned)
+        let w = SleepStaging.sleepWindow(sg)
+        let deep = SleepStaging.stageTotals(sg)[.asleepDeep] ?? 0
+        let tag = m == d.wakeHRMarginBPM ? "*" : " "
+        print("    \(String(Int(m)).padded(3))\(tag.padded(6))\(t(w?.onset).padded(17))"
+              + "\(t(w?.wake).padded(17))\(dur(SleepStaging.totalAsleep(sg)).padded(10))\(dur(deep))")
+    }
+    print("    (* = shipping default)")
+
+    // ── 8b. Desk-activity gate (#204) ────────────────────────────────────────────────────
+    rule("8b. desk-activity gate — zero-share threshold sweep (default \(ActivityPeriod.deskWakeZeroShareThreshold))")
+    // Only the COARSE half is swept here: `latestNightRecords` reads the module constant, so a
+    // staged-onset column would be computed on the shipping window at every row and read as if the
+    // knob had not moved. Section 6 above is the staged result at the shipping default.
+    print("    thresh   main block start   end                span")
+    for th in [0.0, 0.20, 0.30, ActivityPeriod.deskWakeZeroShareThreshold, 0.45, 0.60] {
+        let g = ActivityPeriod.detectFromMotion(motion, temperatureSamples: tempsInSpan,
+                                                heartRateSamples: hr, sleepVitalTimes: vitals,
+                                                activityQuiet: quiet, threshold: th)
+        let b = ActivityPeriod.mainSleepBlock(g)
+        let tag = th == ActivityPeriod.deskWakeZeroShareThreshold ? "*" : (th == 0 ? "off" : "")
+        print("    \(String(format: "%.2f", th).padded(6))\(tag.padded(4))\(t(b?.start).padded(19))"
+              + "\(t(b?.end).padded(19))\(b.map { dur($0.duration) } ?? "—")")
+    }
+    print("    (* = shipping default;  off = gate disabled, pre-#204 behaviour)")
+
+    // ── 9. Naps ──────────────────────────────────────────────────────────────────────────
+    // A SEPARATE path to Apple Health. `NapDetection.naps` writes every accepted daytime
+    // still-block as sleep (`HealthKitWriter.flushNaps`), with its own staged Deep/Light/REM
+    // hypnogram — so an evening block that never entered the night above can still land in
+    // Health and be folded into "the night" by any app that aggregates sleep samples.
+    //
+    // ⚠️ THE HR GATE IS NOT APPLIED ON THIS PATH. `NapDetection.naps` calls
+    // `detectFromMotion(timeline, temperatureSamples:)` with NO heartRateSamples, so the
+    // awake-but-still defence that section 2 measured is inert here. The only physiological
+    // gate a nap must clear is `minNapSleepVitalsShare`.
+    rule("9. naps — the OTHER path into Apple Health (HR gate NOT applied here)")
+    let mainBlock = ActivityPeriod.mainSleepBlock(gated)
+    let naps = NapDetection.naps(from: records, mainSleep: mainBlock,
+                                 temperatures: tempsInSpan, epoch: epoch)
+    if naps.isEmpty {
+        print("  no naps detected")
+    }
+    for n in naps {
+        let stages = SleepStaging.stageTotals(n.segments)
+            .sorted { $0.key.rawValue < $1.key.rawValue }
+            .map { "\($0.key.rawValue) \(dur($0.value))" }
+            .joined(separator: " ")
+        print("  \(t(n.start)) → \(t(n.end))  \(dur(n.duration).padded(7))"
+              + "  asleep \(dur(n.asleep).padded(7))\(n.isLongNap ? "  [isLongNap]" : "")")
+        print("        → written to Apple Health as: \(stages)")
+    }
+
+    // Every candidate the nap path considered, with the reason it was kept or dropped —
+    // `sleepVitalsShare` is private, so it is recomputed here from the public `layout`
+    // (same rule: worn epochs whose layout is .sleepVitals, over all worn epochs).
+    print("")
+    print("  candidates (still blocks ≥ \(Int(NapDetection.minNapDuration / 60)) min, motion+wear gates only):")
+    let napPeriods = ActivityPeriod.detectFromMotion(motion, temperatureSamples: tempsInSpan)
+    for p in napPeriods where p.activity == .sleep && p.duration >= NapDetection.minNapDuration {
+        let worn = records.filter {
+            let x = $0.date(epoch: epoch)
+            return x >= p.start && x <= p.end && $0.layout != .idle
+        }
+        let share = worn.isEmpty ? 0
+            : Double(worn.filter { $0.layout == .sleepVitals }.count) / Double(worn.count)
+        let overlapsNight = mainBlock.map { p.start < $0.end && p.end > $0.start } ?? false
+        let overnight = SleepWindow.isOvernightBlock(start: p.start, end: p.end, calendar: calendar)
+        let inside = hr.filter { $0.time >= p.start && $0.time <= p.end }.map(\.bpm)
+        let verdict: String
+        if overlapsNight { verdict = "dropped — overlaps the main night" }
+        else if overnight { verdict = "dropped — overnight midpoint (not a nap)" }
+        else if share < NapDetection.minNapSleepVitalsShare {
+            verdict = String(format: "dropped — sleep-vitals share %.2f < %.2f", share, NapDetection.minNapSleepVitalsShare)
+        } else {
+            verdict = String(format: "KEPT as a nap — sleep-vitals share %.2f", share)
+        }
+        // What the HR gate WOULD have said, had this path applied it.
+        let wouldGate: String = {
+            guard let th = threshold, let m = median(inside), inside.count >= 3 else { return "" }
+            return m > th ? "   [HR gate WOULD have rejected: median \(m) > \(th)]" : ""
+        }()
+        print("    \(t(p.start)) → \(t(p.end))  \(dur(p.duration).padded(7))"
+              + "  medianHR \((median(inside).map { "\($0)" } ?? "—").padded(4))  \(verdict)\(wouldGate)")
+    }
+}
+
+print("")
+
+// MARK: - Small helpers
+
+extension String {
+    /// Left-justify to `n` columns so the tables above line up without a formatter dependency.
+    func padded(_ n: Int) -> String {
+        count >= n ? self + " " : self + String(repeating: " ", count: n - count)
+    }
+}

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/DeskActivityGateTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/DeskActivityGateTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+@testable import OpenCircuitKit
+
+// #204 — the DESK-ACTIVITY wake gate.
+//
+// 🟢 GROUNDED on two ground-truthed evenings from one wearer (FR02.018, Gen 2, Australia/Melbourne)
+// who was sitting at a computer. The primary `[10:15]` motion channel reads the SAME value at a
+// keyboard as it does in deep sleep — 0 of 61 epochs above baseline on 2026-08-17, 0 of 157 during
+// that night's real sleep — so the detector could not break the run and produced ONE unbroken
+// 14 h 03 m "sleep" block, 17:49:54 → 07:53:12, with sleep credited from 19:40.
+//
+// The ring's OWN activity magnitudes (`[15:23)`, 🟢 #195) do separate the two. Share of epochs
+// reading ALL-ZERO, measured on both nights:
+//     real sleep            72 % / 79 %
+//     at a computer          0 % /  2 %
+//     up and about           0 % / 10 %
+//     evening dozing        14 %
+// The gate thresholds that share over a rolling window. Replayed byte-exactly against both archives
+// it moves the 2026-08-18 night 19:40 → 01:20 (wearer reports being at a computer until 00:30) and
+// leaves the already-correct 2026-08-16 night at 01:02 against a shipped 01:00.
+//
+// ⚠️ FIXTURE DISCIPLINE (the flat-motion trap, inherited from SleepStagingLeadingWakeTests): a
+// CONSTANT motion byte de-floors to STILL, so an "awake" stretch built from a constant value stages
+// as SLEEP. That is exactly the shape under test — the evening must be awake on the ACTIVITY
+// MAGNITUDES ALONE — so every fixture keeps `[10:15]` uniformly still and each test asserts its
+// premise (the kill-switch run) before asserting the fix.
+final class DeskActivityGateTests: XCTestCase {
+
+    private let step: UInt32 = 150
+    private let base: UInt32 = 0x0c220000
+
+    /// Pack five 12-bit magnitudes into `[15:23)` exactly as `activityMagnitudes` decodes them:
+    /// magnitude *k* is nibbles 3k, 3k+1, 3k+2 counting from the HIGH nibble of `[15]`.
+    private func packMagnitudes(_ m: [Int], into b: inout [UInt8]) {
+        var nibbles = [UInt8]()
+        for v in m {
+            nibbles.append(UInt8((v >> 8) & 0xf))
+            nibbles.append(UInt8((v >> 4) & 0xf))
+            nibbles.append(UInt8(v & 0xf))
+        }
+        for (i, n) in nibbles.enumerated() {
+            let idx = 15 + i / 2
+            if i.isMultiple(of: 2) { b[idx] = (b[idx] & 0x0f) | (n << 4) }
+            else { b[idx] = (b[idx] & 0xf0) | n }
+        }
+    }
+
+    /// One epoch. `magnitude` 0 ⇒ the ring says nothing moved; > 0 ⇒ it recorded activity.
+    /// `motion` stays uniform so the primary channel always reads STILL (see fixture discipline).
+    private func rec(_ counter: UInt32, hr: UInt8, hrv: UInt8 = 0, magnitude: Int,
+                     motion: UInt8 = 1) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: 23)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xFF)
+        b[2] = UInt8((counter >> 8) & 0xFF); b[3] = UInt8(counter & 0xFF)
+        b[4] = hr
+        b[5] = hrv
+        b[8] = hrv > 0 ? 0x62 : 0x12          // sleep-vitals vs activity template
+        for k in 0 ..< 5 { b[10 + k] = motion }
+        packMagnitudes([Int](repeating: magnitude, count: 5), into: &b)
+        return BulkRecord(b)!
+    }
+
+    private func date(_ counter: UInt32) -> Date {
+        Date(timeIntervalSince1970: Double(Int(counter) + Command.syncEpoch))
+    }
+
+    /// `eveningEpochs` still-but-ACTIVE epochs (non-zero magnitudes), then `nightEpochs` still and
+    /// quiet ones. Motion is uniformly still throughout, so ONLY the magnitudes differ.
+    private func night(eveningEpochs: Int, nightEpochs: Int,
+                       eveningMagnitude: Int = 300) -> [BulkRecord] {
+        var out: [BulkRecord] = []
+        for i in 0 ..< eveningEpochs {
+            out.append(rec(base + UInt32(i) * step, hr: 75, magnitude: eveningMagnitude))
+        }
+        for i in 0 ..< nightEpochs {
+            out.append(rec(base + UInt32(eveningEpochs + i) * step, hr: 55, hrv: 55, magnitude: 0))
+        }
+        return out
+    }
+
+    private func mainBlock(_ records: [BulkRecord], threshold: Double) -> ActivityPeriod? {
+        ActivityPeriod.mainSleepBlock(
+            ActivityPeriod.detectFromMotion(BulkSleep.motionTimeline(from: records),
+                                            temperatureSamples: [],
+                                            heartRateSamples: BulkSleep.heartRateTimeline(from: records),
+                                            sleepVitalTimes: BulkSleep.sleepVitalTimeline(from: records),
+                                            activityQuiet: BulkSleep.activityQuietTimeline(from: records),
+                                            threshold: threshold))
+    }
+
+    // MARK: - The fix
+
+    func testDeskEveningIsSplitOffTheNight() {
+        let evening = 60, nightLen = 120           // 2 h 30 m desk, then 5 h asleep
+        let records = night(eveningEpochs: evening, nightEpochs: nightLen)
+        let nightStart = date(base + UInt32(evening) * step)
+
+        // PREMISE (kill switch): with the gate off the evening and the night are ONE block that
+        // opens at the very first epoch — the reported bug shape.
+        guard let off = mainBlock(records, threshold: 0) else { return XCTFail("no block with gate off") }
+        XCTAssertEqual(off.start, date(base), "premise: gate off welds evening to night")
+        XCTAssertGreaterThan(nightStart.timeIntervalSince(off.start), 2 * 3600)
+
+        // FIX: the block now opens at the night, within one rolling half-window of its true start.
+        guard let on = mainBlock(records, threshold: ActivityPeriod.deskWakeZeroShareThreshold) else {
+            return XCTFail("no block with gate on")
+        }
+        let halfWindow = Double(ActivityPeriod.deskWakeWindowEpochs / 2) * Double(BulkRecord.epochSeconds)
+        XCTAssertEqual(on.start.timeIntervalSince(nightStart), 0, accuracy: halfWindow,
+                       "block should open at the quiet night, not the desk evening")
+        XCTAssertGreaterThan(on.start.timeIntervalSince(off.start), 2 * 3600 - halfWindow)
+    }
+
+    // MARK: - Safety properties
+
+    func testKillSwitchIsByteIdenticalToOmittingTheTimeline() {
+        let records = night(eveningEpochs: 60, nightEpochs: 120)
+        let motion = BulkSleep.motionTimeline(from: records)
+        let withTimelineDisabled = ActivityPeriod.detectFromMotion(
+            motion, activityQuiet: BulkSleep.activityQuietTimeline(from: records), threshold: 0)
+        let withoutTimeline = ActivityPeriod.detectFromMotion(motion)
+        XCTAssertEqual(withTimelineDisabled, withoutTimeline,
+                       "threshold 0 must be byte-identical to pre-#204")
+    }
+
+    func testEmptyActivityTimelineIsANoOp() {
+        let records = night(eveningEpochs: 60, nightEpochs: 120)
+        let motion = BulkSleep.motionTimeline(from: records)
+        XCTAssertEqual(ActivityPeriod.detectFromMotion(motion, activityQuiet: []),
+                       ActivityPeriod.detectFromMotion(motion))
+    }
+
+    func testAllQuietNightIsUntouched() {
+        // Every epoch reads all-zero magnitudes — a motionless archive. The gate must not fire.
+        let records = (0 ..< 120).map { rec(base + UInt32($0) * step, hr: 55, hrv: 55, magnitude: 0) }
+        let motion = BulkSleep.motionTimeline(from: records)
+        XCTAssertEqual(
+            ActivityPeriod.detectFromMotion(motion,
+                                            activityQuiet: BulkSleep.activityQuietTimeline(from: records)),
+            ActivityPeriod.detectFromMotion(motion),
+            "a night the ring reports as motionless must be unchanged")
+    }
+
+    func testOccasionalStirringDoesNotVetoSleep() {
+        // A real night stirs: ~25 % of the wearer's measured sleep epochs carry non-zero magnitudes.
+        // Every 4th epoch active is well inside the window threshold and must stay asleep.
+        var records: [BulkRecord] = []
+        for i in 0 ..< 160 {
+            records.append(rec(base + UInt32(i) * step, hr: 55, hrv: 55,
+                               magnitude: i.isMultiple(of: 4) ? 400 : 0))
+        }
+        guard let block = mainBlock(records, threshold: ActivityPeriod.deskWakeZeroShareThreshold) else {
+            return XCTFail("stirring night lost its block entirely")
+        }
+        XCTAssertEqual(block.start, date(base), "a stirring night must keep its full span")
+    }
+
+    // MARK: - Units
+
+    func testRollingShareThresholdBoundary() {
+        // 20 epochs, 7 quiet ⇒ share 0.35 at the centre. The predicate is STRICTLY less-than, so a
+        // window sitting exactly ON the threshold counts as sleep, not wake.
+        let quiet = (0 ..< 20).map {
+            ActivityQuietSample(time: self.date(self.base + UInt32($0) * self.step), quiet: $0 < 7)
+        }
+        let atThreshold = ActivityPeriod.deskActivityAwake(quiet, threshold: 0.35, windowEpochs: 20)
+        let justAbove = ActivityPeriod.deskActivityAwake(quiet, threshold: 0.36, windowEpochs: 20)
+        XCTAssertFalse(atThreshold[10], "share == threshold is not awake (strict <)")
+        XCTAssertTrue(justAbove[10], "share just under threshold is awake")
+    }
+
+    func testZeroThresholdMarksNothingAwake() {
+        let quiet = (0 ..< 20).map {
+            ActivityQuietSample(time: self.date(self.base + UInt32($0) * self.step), quiet: false)
+        }
+        XCTAssertFalse(ActivityPeriod.deskActivityAwake(quiet, threshold: 0, windowEpochs: 18).contains(true))
+    }
+
+    func testEpochIndexRefusesToMatchAcrossADataHole() {
+        let starts = [date(base), date(base + step)]
+        // A sample one step past the LAST epoch belongs to no epoch — it sits in the hole after it.
+        XCTAssertNil(ActivityPeriod.epochIndex(for: date(base + step * 2), starts: starts))
+        XCTAssertEqual(ActivityPeriod.epochIndex(for: date(base + step + 30), starts: starts), 1)
+        XCTAssertNil(ActivityPeriod.epochIndex(for: date(base - 1), starts: starts),
+                     "a sample before the first epoch matches nothing")
+    }
+
+    func testIdleEpochsAreExcludedFromTheEvidence() {
+        // The idle/unworn template zeroes the activity block BY TEMPLATE, not by measurement, so it
+        // must not vouch for the stillness of the epochs around it.
+        var idle = [UInt8](repeating: 0, count: 23)
+        idle[0] = UInt8(base >> 24); idle[1] = UInt8((base >> 16) & 0xFF)
+        idle[2] = UInt8((base >> 8) & 0xFF); idle[3] = UInt8(base & 0xFF)
+        idle[4] = 0x05; idle[5] = 0x00; idle[6] = 0x0c; idle[7] = 0x00; idle[9] = 0x0a
+        for k in 0 ..< 5 { idle[10 + k] = 1 }
+        let idleRecord = BulkRecord(idle)!
+        XCTAssertEqual(idleRecord.layout, .idle, "premise: this is the idle template")
+
+        let records = [idleRecord, rec(base + step, hr: 75, magnitude: 300)]
+        let quiet = BulkSleep.activityQuietTimeline(from: records)
+        XCTAssertEqual(quiet.count, 1, "the idle epoch contributes no evidence")
+        XCTAssertFalse(quiet[0].quiet)
+    }
+}


### PR DESCRIPTION
…staged as sleep

The primary [10:15] motion channel does not register desk work: it reads the SAME value at a keyboard as it does in deep sleep. 🟢 MEASURED on two ground-truthed evenings (FR02.018, Gen 2, Australia/Melbourne) in which the wearer was sitting at a computer — 0 of 61 epochs above the motion baseline on 2026-08-17, and 0 of 157 during that night's real sleep.

So the detector cannot break the run. `mainSleepBlock` welds evening to night, and the HR gate — which judges a whole period on its MEDIAN — cannot trim a HEAD: the 2026-08-17 night came out as ONE unbroken 14h03m "sleep" block, 17:49:54 → 07:53:12, with sleep credited from 19:40 against a wearer who was at a computer until 00:30. No existing knob fixes it. Sweeping the coarse HR margin 25 → 10 does not move the block start at all and at 8 the whole night vanishes; sweeping the staged wake margin 18 → 6 moves onset by 27 min while shedding 3h24m of real sleep. It is not a tuning problem.

The ring DID record the movement, in `activityMagnitudes` ([15:23), 🟢 #195). Share of epochs reading ALL-ZERO, both nights:

    real sleep                                72 % / 79 %
    at a computer   [ground truth]             0 % /  2 %
    up and about                               0 % / 10 %
    evening dozing  [ground truth]            14 %

So threshold that share over a centred 45-min rolling window and force the epoch ACTIVE below 0.35. Unlike the wear and HR gates this acts PER EPOCH and BEFORE segmentation, so the run splits — which is what a sedentary evening welded onto the night needs. One-directional, like both of them: it can only ever turn sleep into active.

Replayed byte-exactly against both archives:

    2026-08-18   onset 19:40 → 01:20   asleep 10h09m → 6h02m   (truth: computer until 00:30)
    2026-08-16   onset 01:00 → 01:02   asleep  8h26m → 8h24m   (already correct; stays correct)

Sweeping the threshold 0.20 → 0.60 moves onset by only ~22 min on either night, so the knob is not hypersensitive — deliberately unlike the two margins above.

⚠️ This deliberately relaxes the "consumers may use it only through `BulkSleep.motionSource`" constraint on the intensity tail. That constraint exists to stop the two motion channels being MIXED into one magnitude scale — the measured trap that moved 15 of 18 corpus nights by −100…+45 min, and moved the same night in opposite directions in two bundles. This gate never computes a magnitude: it thresholds the SHARE of a binary predicate whose floor is the number zero. A record set cannot move where zero is.

⚠️ 🟡 THE THRESHOLD IS FIT ON TWO NIGHTS, ONE WEARER. 0.35 sits between the highest awake reading measured (0.14) and the lowest sleep reading (0.72). Wide, but two nights is two nights — to be re-fit against accumulated `SleepEditLabel` corrections. Evening dozing is genuinely intermediate and will be trimmed back to its stillest core.

Kill switch: `ActivityPeriod.deskWakeZeroShareThreshold = 0` disables the gate outright and is byte-identical to pre-#204, mirroring every other pass in SleepDetection. All 1464 pre-existing tests pass unchanged — synthetic fixtures carry zero activity magnitudes, so the gate is inert on them, and that is pinned by a test rather than left to luck.

Also adds `SleepReplay`, a CLT triage tool (mirroring RingKitVerify) that replays an export's raw records through the shipping pipeline and prints the decision trace — how this was diagnosed, and how it will be validated. Requires `sleepHRFloor` to be public so the tool reports the real floor rather than a copy that could drift.