### PR TITLE
fix(ios): imperial weight field only accepted the first digit

### DIFF
--- a/ios/OpenCircuit/UserProfile.swift
+++ b/ios/OpenCircuit/UserProfile.swift
@@ -30,9 +30,14 @@ struct UserProfileSettingsView: View {
     // Height is edited via local feet/inches buffers, seeded from `heightCm` on appear and
     // written back on change. Binding the text fields straight to a `heightCm`-derived value
     // reset them on every keystroke (the shared @AppStorage write re-rendered the field
-    // mid-edit), which made the inches field nearly uneditable — couldn't enter 10/11.
+    // mid-edit), which made the inches field nearly uneditable — couldn't enter 10/11. The
+    // imperial weight field below had the identical problem for any 2+ digit value.
     @State private var heightFeetInput = 0
     @State private var heightInchesInput = 0
+    /// Local lb editing buffer, seeded from `weightKg` on appear — mirrors the ft/in buffers
+    /// above for the same reason (a live `weightKg`-converting Binding reset the field on
+    /// every keystroke, so only the first digit of e.g. "250" would ever stick).
+    @State private var weightLbInput = 0
 
     /// Presents the onboarding/welcome flow again from About ▸ "How it works" (#103).
     @State private var showOnboarding = false
@@ -178,11 +183,19 @@ struct UserProfileSettingsView: View {
                                 .multilineTextAlignment(.trailing)
                             Text("kg").foregroundStyle(.secondary)
                         } else {
-                            TextField("lb", value: weightLb, format: .number.precision(.fractionLength(0)))
-                                .keyboardType(.decimalPad)
+                            TextField("lb", value: $weightLbInput, format: .number)
+                                .keyboardType(.numberPad)
                                 .multilineTextAlignment(.trailing)
+                                .onChange(of: weightLbInput) { _, _ in commitWeight() }
                             Text("lb").foregroundStyle(.secondary)
                         }
+                    }
+                    // Seed the lb buffer from the current `weightKg` when the imperial field is
+                    // (or becomes) visible — on first appear AND when the user flips the unit
+                    // picker to imperial — mirroring the height ft/in seeding below (#151).
+                    .onAppear { if bodyUnit == .imperial { seedWeightInput() } }
+                    .onChange(of: bodyUnitRaw) { _, newRaw in
+                        if newRaw == BodyUnit.imperial.rawValue { seedWeightInput() }
                     }
                 }
                 LabeledContent("Height") {
@@ -740,9 +753,16 @@ struct UserProfileSettingsView: View {
     private static let lbPerKg = 2.2046226218
     private static let cmPerIn = 2.54
 
-    private var weightLb: Binding<Double> {
-        Binding(get: { weightKg * Self.lbPerKg },
-                set: { weightKg = max($0, 0) / Self.lbPerKg })
+    /// Seed the local lb editing field from the stored weight. Done on appear (and when the
+    /// unit picker switches to imperial) so the text field holds its own state and typing
+    /// isn't reset by the shared `weightKg` store — see `weightLbInput` above (#151).
+    private func seedWeightInput() {
+        weightLbInput = Int((weightKg * Self.lbPerKg).rounded())
+    }
+
+    /// Write the local lb field back to `weightKg`, clamping to non-negative.
+    private func commitWeight() {
+        weightKg = Double(max(weightLbInput, 0)) / Self.lbPerKg
     }
 
     /// Total height in whole inches (rounded), the basis for the ft/in split.


### PR DESCRIPTION
## Summary
- Reported bug: in the imperial (lb) unit mode, the Profile weight field wouldn't accept multi-digit entry — the first typed digit stuck and further digits got dropped, making it impossible to enter weights of 200+ lb.
- Root cause: the lb `TextField(value:format:)` was bound directly to `weightLb`, a computed property returning a fresh `Binding<Double>` on every `body` evaluation whose `get`/`set` round-trip through `weightKg` (`@AppStorage`) on every keystroke. Each write triggers a re-render mid-edit, and the field re-syncs its displayed text from the newly computed `get()` value, wiping out digits typed after the first. This is the exact same failure mode already diagnosed and fixed for the height ft/in fields in this file (#151).
- Fix: mirror the height fields' existing pattern — a local `@State private var weightLbInput: Int` buffer, seeded from `weightKg` on `.onAppear` and whenever the unit picker switches to imperial, with edits committed back into `weightKg` via `.onChange(of:)`. The metric kg field is untouched (it already binds straight to `$weightKg`).

## Test plan
- [x] Full Xcode / iOS Simulator isn't available in this environment (only Command Line Tools are installed — no `xcodebuild`, no `iphonesimulator` SDK, no `simctl`), so this could not be built or run live.
- [x] `swiftc -parse` on the edited file to confirm no syntax errors.
- [x] Manually traced the fix against the existing, already-shipped height ft/in pattern (`seedHeightInputs()` / `commitHeight()`), which uses the identical local-`@State`-buffer approach to solve the identical symptom for a different field.
- [ ] Needs a real device/simulator smoke test before merge: enter weights across 200–999 lb (plus 199/200/999 boundaries), confirm metric kg entry is unaffected, and confirm values convert correctly both ways when switching the unit picker.