### PR TITLE
fix(sleep): stage the night on a raised primary-motion floor (Gen 2 Air, FR04.011)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -597,15 +597,24 @@ run's own distribution, never from a device or firmware string:
 |---|---|---|---|
 | baseline | `01` (Gen 2), `0f`=15 (Gen 3), or a drifting `16→24→39` plateau — **constant within the epoch**, so a rolling local floor cancels it at any level | Gen 2 / Gen 3 | `[10:15]` (unchanged) |
 | fixed template | a two-level intra-epoch **step** (slots 0–1 ≈ 27.6, slots 2–4 ≈ 34.9 on *every* epoch) ± 2 noise; survives de-flooring because the step is *inside* one epoch | Gen 2 Air, **FR04.009** | `[15:20]` intensity tail |
-| **raised floor** | counts wander **freely** in 40–90 with the occasional `1`; the sub-samples differ epoch to epoch and no slot ordering is phase-locked, so it is *not* a template — but the channel's own **minimum never returns to `01`** | Gen 2 Air, **FR04.011** | `[15:23)` decoded magnitudes |
+| **raised floor** | a pedestal that is **flat *within* an epoch** (median intra-epoch spread **1 count** on motionless epochs) but whose **level wanders between epochs**, 1 → 126 across the night — further and faster than the ~30-min rolling local floor can track, so de-flooring does *not* cancel it; no slot ordering is phase-locked, so it is not a template either | Gen 2 Air, **FR04.011** | `[15:23)` decoded magnitudes |
 
 The **raised-floor** case is new. 🟡 Measured on **one device, two nights, 715 worn epochs**: the
 primary byte takes value `1` on only 356 of 3575 sub-samples and otherwise clusters around 17,
 41–53, 71 and 84–86 *during obviously motionless sleep*; per-night medians ≈ 75–95 with the
-per-night 25th percentile at 54 on one night and 1 on the other. All five sub-samples are equal on
-only ≈ 8 % of epochs, so neither `motionIsPlaceholder` nor `motionResolvesStillness` fires and the
-FR04.009 gate (`slotOrderConsistency`) correctly refuses it — the variation really is free, it just
-never comes back down. On device the symptom is a total staging failure: every history drain ends
+per-night 25th percentile at 54 on one night and 1 on the other.
+
+🟢 **The variation is BETWEEN epochs, not within one** — an earlier revision of this note had that
+backwards. All five sub-samples are *exactly* equal on only ≈ 8 % of epochs, but they are *nearly*
+equal on nearly all of them: median intra-epoch spread **1 count**, p90 **6**, over the ring's own
+motionless epochs. So `motionResolvesStillness`, which asks whether the five sit within
+`motionStillThreshold` of one another, **does** fire — on **78 %** of quiet epochs — and it is
+wrong to do so, because the channel it is blessing cannot arbitrate stillness. Nor does the minimum
+"never return to `01`": the per-epoch minimum runs p10 **1** / p50 **40** / p90 **93**. What breaks
+de-flooring is the *rate* the pedestal's level drifts at, not a floor stuck permanently off `01` —
+after `motionAboveLocalFloor` only **32 %** of quiet epochs read still (the detector needs ≥ 70 %).
+`motionIsPlaceholder` and the FR04.009 gate (`slotOrderConsistency`) do correctly refuse it. On
+device the symptom is a total staging failure: every history drain ends
 `nightRowOutcome = noStagedSegments` with 0 staged segments while HR/HRV/RR/SpO₂ record all night.
 
 🟡 The **decoded** `[15:23)` magnitudes are clean on the same records: the per-epoch magnitude sum

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -589,6 +589,32 @@ baseline (still/asleep) and spike at arousals/turns — the per-epoch **stillnes
 Phase 5 `SleepDetection` needs (likely the IMU stream; no separate `0x47` accel needed).
 Baseline `01` = "still", not "unworn".
 
+🟡 **…on the firmware that HAS a baseline. Three shapes of `[10:15]` are now known, and two of
+them cannot express stillness at all** — `BulkSleep.motionSource` picks the run's channel from the
+run's own distribution, never from a device or firmware string:
+
+| shape | `[10:15]` while motionless | seen on | detector reads |
+|---|---|---|---|
+| baseline | `01` (Gen 2), `0f`=15 (Gen 3), or a drifting `16→24→39` plateau — **constant within the epoch**, so a rolling local floor cancels it at any level | Gen 2 / Gen 3 | `[10:15]` (unchanged) |
+| fixed template | a two-level intra-epoch **step** (slots 0–1 ≈ 27.6, slots 2–4 ≈ 34.9 on *every* epoch) ± 2 noise; survives de-flooring because the step is *inside* one epoch | Gen 2 Air, **FR04.009** | `[15:20]` intensity tail |
+| **raised floor** | counts wander **freely** in 40–90 with the occasional `1`; the sub-samples differ epoch to epoch and no slot ordering is phase-locked, so it is *not* a template — but the channel's own **minimum never returns to `01`** | Gen 2 Air, **FR04.011** | `[15:23)` decoded magnitudes |
+
+The **raised-floor** case is new. 🟡 Measured on **one device, two nights, 715 worn epochs**: the
+primary byte takes value `1` on only 356 of 3575 sub-samples and otherwise clusters around 17,
+41–53, 71 and 84–86 *during obviously motionless sleep*; per-night medians ≈ 75–95 with the
+per-night 25th percentile at 54 on one night and 1 on the other. All five sub-samples are equal on
+only ≈ 8 % of epochs, so neither `motionIsPlaceholder` nor `motionResolvesStillness` fires and the
+FR04.009 gate (`slotOrderConsistency`) correctly refuses it — the variation really is free, it just
+never comes back down. On device the symptom is a total staging failure: every history drain ends
+`nightRowOutcome = noStagedSegments` with 0 staged segments while HR/HRV/RR/SpO₂ record all night.
+
+🟡 The **decoded** `[15:23)` magnitudes are clean on the same records: the per-epoch magnitude sum
+is exactly **0 for the median night epoch** (p50 = 0, p90 ≈ 700–800), rises to 100–450 at postural
+turns and above 1000 at the final wake, and its hourly profile tracks the HR/HRV dynamics. Note
+this is the *layout-correct* channel (five 12-bit magnitudes, above), **not** the byte-aligned
+`[15:20]` window the two older fallbacks use — the raised-floor branch is gated on and reads from
+`activityMagnitudes` / `activityMagnitudesAreZero` throughout.
+
 > **Sleep stages (Awake/Light/Deep/REM) are not stored per-epoch** — no stage label byte
 > found. The ring streams raw HR/HRV/SpO2/motion and the **app computes** the hypnogram,
 > matching openwhoop's approach and our Phase 5 plan: compute stages in Swift from these

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepDetailMetrics.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/Analytics/SleepDetailMetrics.swift
@@ -78,11 +78,13 @@ public enum SleepDetailMetrics {
         let scoped = records
             .sorted { $0.counter < $1.counter }
             .filter { r in window.map { $0.contains(r.date(epoch: epoch)) } ?? true }
-        let useIntensityFallback = BulkSleep.usesMotionIntensityFallback(scoped)
-        let mags = scoped.map { record in
-            useIntensityFallback
-                ? record.motionIntensityTail.reduce(0) { $0 + Int($1) }
-                : epochMotionEnergy(record)
+        let source = BulkSleep.motionSource(scoped)
+        let mags = scoped.map { record -> Int in
+            switch source {
+            case .primary: return epochMotionEnergy(record)
+            case .intensityTail: return record.motionIntensityTail.reduce(0) { $0 + Int($1) }
+            case .activityMagnitudes: return record.activityMagnitudes.reduce(0, +)
+            }
         }
         let cut = activeThreshold ?? derivedActiveCut(mags)
         return zip(scoped, mags).map { r, mag in

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
@@ -566,16 +566,44 @@ public enum BulkSleep {
 
     // MARK: - Raised primary floor (FR04.011)
 
-    /// Minimum share of WORN epochs on which the decoded magnitude channel must read exactly zero
-    /// before it is allowed to replace the primary one. This is the "is the substitute any good?"
-    /// half of the gate: a channel that never says "nothing moved" cannot arbitrate stillness, and
-    /// swapping onto it would trade one unusable channel for another.
+    /// Whether the primary `[10:15]` channel reads STILL on each epoch of `run` after the SAME
+    /// rolling local floor `SleepDetection.detectFromMotion` subtracts before classifying — one
+    /// verdict per input epoch, in order.
     ///
-    /// 🟡 0.40 is a CONSERVATIVE floor, not a separation point. Corpus-wide `activityMagnitudesAreZero`
-    /// is 30.0 % of all records (mixed day + night), and the two FR04.011 nights that motivated this
-    /// run 55–70 % across their worn epochs; 0.40 sits between, and a night that genuinely spends
-    /// under 40 % of its worn epochs motionless is not a night this rescue should be guessing at.
-    static let raisedFloorMinZeroMagnitudeFraction = 0.40
+    /// 🟢 THIS IS WHY IT EXISTS. `motionResolvesStillness` asks only whether an epoch's five
+    /// sub-samples sit within `motionStillThreshold` of ONE ANOTHER, on the argument that "a flat
+    /// plateau at any level cancels" against the rolling floor. That argument holds only while the
+    /// plateau's LEVEL is stable across the floor's own ~30-min window. On FR04.011 it is not: the
+    /// pedestal is flat inside an epoch (median intra-epoch spread 1 count on the ring's own
+    /// motionless epochs) yet wanders between 1 and 126 across the night, so the p10 floor sits far
+    /// below the current level and the residual survives de-flooring. The intra-epoch proxy scores
+    /// that channel 71 % "still" while the de-floored channel detection actually consumes scores it
+    /// 32 %. Predicting `detect()` therefore requires measuring what `detect()` reads.
+    ///
+    /// The per-epoch share threshold is `ActivityPeriod.gravityStillFraction` — the share `detect()`
+    /// itself requires of its rolling window — reused rather than restated so this predicate and the
+    /// detector it predicts cannot drift apart. NO new constant.
+    ///
+    /// Reads `raw[10..<15]` directly rather than going through `motionTimeline`, which would
+    /// re-enter `motionSource` and recurse.
+    static func primaryChannelIsStillAfterFloor(_ run: [BulkRecord],
+                                                epoch: Int = Command.syncEpoch) -> [Bool] {
+        var timeline: [MotionSample] = []
+        timeline.reserveCapacity(run.count * 5)
+        for r in run {
+            let base = r.date(epoch: epoch)
+            for k in 0 ..< 5 {
+                timeline.append(MotionSample(time: base.addingTimeInterval(Double(k) * 30),
+                                             movement: Float(r.raw[10 + k])))
+            }
+        }
+        let residual = ActivityPeriod.motionAboveLocalFloor(timeline)
+        return run.indices.map { i in
+            let still = residual[(i * 5) ..< (i * 5 + 5)]
+                .filter { $0 < ActivityPeriod.motionStillThreshold }.count
+            return Float(still) / 5 >= ActivityPeriod.gravityStillFraction
+        }
+    }
 
     /// Minimum MEDIAN per-epoch minimum sub-sample on the primary channel before its floor counts as
     /// "off the `01` baseline". The statistic is the median over quiet epochs of `min(raw[10..<15])`
@@ -599,24 +627,44 @@ public enum BulkSleep {
     ///   (1) the verdict is `activityMagnitudesAreZero`, the LAYOUT-CORRECT decode of `[15:23)`,
     ///       not the byte-aligned `[15:20]` window. This branch reads its motion off the decoded
     ///       magnitudes, so it must be gated on the same numbers it will consume; and
-    ///   (2) the "the residual is instrumentation, not movement" proof is a RAISED FLOOR rather than
-    ///       a fixed intra-epoch template. On FR04.011 the sub-samples genuinely differ epoch to
-    ///       epoch (all-five-equal share ≈ 8 %) and their ordering is not phase-locked, so
-    ///       `slotOrderConsistency` correctly refuses it — but the channel's own MINIMUM never
-    ///       returns to `01`, which is a pedestal no rolling local floor can subtract either.
+    ///   (2) the "the residual is instrumentation, not movement" proof is a RAISED, WANDERING FLOOR
+    ///       rather than a fixed intra-epoch template. Their ordering is not phase-locked, so
+    ///       `slotOrderConsistency` correctly refuses it — and 🟢 on the ring's OWN motionless
+    ///       epochs the five sub-samples are nearly EQUAL (median intra-epoch spread 1 count), so
+    ///       this is not a wide-spread channel either. What it is instead is a pedestal whose LEVEL
+    ///       wanders 1 → 126 across the night, i.e. faster and further than the ~30-min rolling
+    ///       floor can track. That is the whole failure, and it is invisible to any predicate that
+    ///       looks at one epoch at a time.
     ///
-    /// Gates (in order): the magnitude channel must resolve stillness on a real share of the run;
-    /// there must be an hour of it to judge; the primary must REFUSE to read still where the ring
-    /// says nothing moved (`degenerateMaxQuietStillFraction`, shared with #184 — this is what keeps
-    /// every flat/drifting placeholder night on the primary path, since a constant run always
-    /// resolves stillness); and only then, the floor test.
+    /// Gates (in order): there must be an hour of ring-verified motionless time to judge
+    /// (`degenerateMinQuietEpochs`, the #184 sibling's own quorum, which doubles as the "is the
+    /// substitute channel any good?" test — those epochs ARE the magnitude channel saying "nothing
+    /// moved"); the primary must REFUSE to read still where the ring says nothing moved
+    /// (`degenerateMaxQuietStillFraction`, shared with #184 — this is what keeps every flat or
+    /// drifting placeholder night on the primary path, since such a channel de-floors to zero); and
+    /// only then, the floor test.
+    ///
+    /// 🟢 THE STILLNESS CONJUNCT IS MEASURED THROUGH THE ROLLING FLOOR
+    /// (`primaryChannelIsStillAfterFloor`), NOT through the intra-epoch `motionResolvesStillness`
+    /// proxy this branch shipped with. See that function for the measurement; the short form is that
+    /// the proxy answers a question about ONE epoch while the failure lives in the drift BETWEEN
+    /// epochs, and on the real FR04.011 archive it scores the unusable channel 71 % still.
+    ///
+    /// ⚠️ THERE IS NO SHARE-OF-WORN CONJUNCT, deliberately. The `raisedFloorMinZeroMagnitudeFraction`
+    /// this branch shipped with (≥ 40 % of worn epochs motionless) was measured on NIGHT epochs but
+    /// evaluated wherever `motionSource` is called — and `latestNightRecords` calls it on the whole
+    /// 30 h `EpochArchive` union, ~22 h of which is an awake day. 🟢 On the real archive it reads
+    /// 0.278 over the union and 0.567 over the night alone, so the gate opened or stayed shut
+    /// depending on how much daytime had drained: the "the answer depends on when you synced" class
+    /// this file exists to remove. An absolute quorum is scope-stable; a share of the window is not.
     static func primaryFloorIsRaised(_ worn: [BulkRecord]) -> Bool {
-        let quiet = worn.filter(\.activityMagnitudesAreZero)
-        guard Double(quiet.count) >= Double(worn.count) * raisedFloorMinZeroMagnitudeFraction,
-              quiet.count >= degenerateMinQuietEpochs else { return false }
-        let stillCount = quiet.filter(\.motionResolvesStillness).count
-        guard Double(stillCount) < Double(quiet.count) * degenerateMaxQuietStillFraction else { return false }
-        return medianQuietMinimum(quiet) >= raisedFloorMinMedianQuietMinimum
+        let stillAfterFloor = primaryChannelIsStillAfterFloor(worn)
+        let quietIndices = worn.indices.filter { worn[$0].activityMagnitudesAreZero }
+        guard quietIndices.count >= degenerateMinQuietEpochs else { return false }
+        let stillCount = quietIndices.filter { stillAfterFloor[$0] }.count
+        guard Double(stillCount) < Double(quietIndices.count) * degenerateMaxQuietStillFraction
+        else { return false }
+        return medianQuietMinimum(quietIndices.map { worn[$0] }) >= raisedFloorMinMedianQuietMinimum
     }
 
     /// Median over `epochs` of each epoch's SMALLEST `[10:15]` sub-sample. `epochs` is non-empty

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/BulkSleep.swift
@@ -408,28 +408,18 @@ public enum BulkSleep {
     /// (charging data reads as still too).
     public static func motionTimeline(from records: [BulkRecord],
                                       epoch: Int = Command.syncEpoch) -> [MotionSample] {
-        let source = motionSource(records)
-        let fallbackMagnitudes: [Float]
-        let useIntensityFallback: Bool
-        if case .intensityTail(let degenerate) = source {
-            useIntensityFallback = true
-            fallbackMagnitudes = motionIntensityFallbackMagnitudes(records, degenerate: degenerate)
-        } else {
-            useIntensityFallback = false
-            fallbackMagnitudes = []
-        }
+        let fallbackMagnitudes = secondaryChannelMagnitudes(records)
         var out: [MotionSample] = []
         out.reserveCapacity(records.count * 5)
         for (recordIndex, r) in records.enumerated() {
             let base = r.date(epoch: epoch)
-            // The intensity tail is an epoch-level fallback, not five independently-timed samples.
-            // Repeat its derived light/active magnitude over the epoch's five 30-second slots so the
-            // detector retains its canonical cadence without inventing sub-epoch timing.
+            // Either secondary channel is an epoch-level fallback, not five independently-timed
+            // samples. Repeat its derived light/active magnitude over the epoch's five 30-second
+            // slots so the detector retains its canonical cadence without inventing sub-epoch timing.
             for k in 0 ..< 5 {
                 out.append(MotionSample(time: base.addingTimeInterval(Double(k) * 30),
-                                        movement: useIntensityFallback
-                                            ? fallbackMagnitudes[recordIndex]
-                                            : Float(r.raw[10 + k])))
+                                        movement: fallbackMagnitudes?[recordIndex]
+                                            ?? Float(r.raw[10 + k])))
             }
         }
         return out
@@ -444,6 +434,9 @@ public enum BulkSleep {
         /// `[15:20]`. `degenerate == false` is the original 2026-07-12 constant-filler shape;
         /// `degenerate == true` is the FR04.009 non-expressive-primary shape (#184).
         case intensityTail(degenerate: Bool)
+        /// `[15:23)` decoded as five 12-bit `activityMagnitudes` — the FR04.011 raised-floor shape.
+        /// A THIRD channel, not a third reason to read the second one: see `primaryFloorIsRaised`.
+        case activityMagnitudes
     }
 
     /// Pick the motion channel for a run. The primary `[10:15]` channel is unusable in TWO
@@ -454,10 +447,16 @@ public enum BulkSleep {
     ///     variation is a fixed intra-epoch template rather than movement (`primaryMotionIsDegenerate`).
     ///     🟢 FR04.009 (#184): a fixed two-level step (slots 0–1 ≈ 27.6, slots 2–4 ≈ 34.9 on EVERY
     ///     epoch) plus ±2 noise, which no cross-sample rolling floor can cancel.
-    /// The two are mutually exclusive by construction: a constant run has zero intra-epoch spread, so
-    /// it always `motionResolvesStillness` and can never be degenerate. Either way the run must ALSO
-    /// show at least two non-zero tail epochs, exactly as before, so a genuinely motionless archive
-    /// keeps the primary path.
+    ///   • RAISED FLOOR — the channel varies freely (so it is NOT the #184 fixed template) but never
+    ///     returns to the `01` baseline, so its "movement" is a pedestal the rolling floor cannot
+    ///     remove either (`primaryFloorIsRaised`). 🟡 FR04.011 on a Gen 2 Air; this one falls
+    ///     through to the DECODED `activityMagnitudes`, not to the byte-aligned tail.
+    /// The first two are mutually exclusive by construction: a constant run has zero intra-epoch
+    /// spread, so it always `motionResolvesStillness` and can never be degenerate. Either way the run
+    /// must ALSO show at least two non-zero tail epochs, exactly as before, so a genuinely motionless
+    /// archive keeps the primary path. The RAISED FLOOR reason is evaluated only after both have
+    /// declined, and carries the same "the channel must actually carry movement" conjunct against the
+    /// channel it selects — so no input that reached a verdict before it existed changes verdict.
     ///
     /// ⚠️ `constantFiller` IS DEAD CODE, AND WIDENING IT IS A MEASURED TRAP (#195 / #190). The
     /// all-or-nothing quantifier fires on **0 of the 18 sources** in the local corpus while the
@@ -482,10 +481,21 @@ public enum BulkSleep {
         guard worn.count >= 4 else { return .primary }
         let constantFiller = !worn.contains(where: { !$0.motionIsPlaceholder })
         let degenerate = constantFiller ? false : primaryMotionIsDegenerate(worn)
-        guard constantFiller || degenerate else { return .primary }
-        guard worn.lazy.filter({ $0.motionIntensityTail.contains(where: { $0 > 0 }) }).prefix(2).count == 2
+        if constantFiller || degenerate {
+            guard worn.lazy.filter({ $0.motionIntensityTail.contains(where: { $0 > 0 }) }).prefix(2).count == 2
+            else { return .primary }
+            return .intensityTail(degenerate: degenerate)
+        }
+        // Third rejection reason, third channel (FR04.011). Checked LAST so every input that reached
+        // a verdict before this change reaches the SAME verdict: the two tail branches are decided
+        // first and return unchanged, and a run that satisfies neither used to fall straight through
+        // to `.primary`.
+        guard primaryFloorIsRaised(worn) else { return .primary }
+        // The same "the channel must actually carry movement" conjunct the tail branches apply,
+        // asked of the channel we are about to switch TO.
+        guard worn.lazy.filter({ !$0.activityMagnitudesAreZero }).prefix(2).count == 2
         else { return .primary }
-        return .intensityTail(degenerate: degenerate)
+        return .activityMagnitudes
     }
 
     /// True when this run reads motion off the `[15:20]` intensity tail instead of `[10:15]`.
@@ -552,6 +562,70 @@ public enum BulkSleep {
         let stillCount = quiet.filter(\.motionResolvesStillness).count
         guard Double(stillCount) < Double(quiet.count) * degenerateMaxQuietStillFraction else { return false }
         return slotOrderConsistency(quiet) >= degenerateMinSlotOrderFraction
+    }
+
+    // MARK: - Raised primary floor (FR04.011)
+
+    /// Minimum share of WORN epochs on which the decoded magnitude channel must read exactly zero
+    /// before it is allowed to replace the primary one. This is the "is the substitute any good?"
+    /// half of the gate: a channel that never says "nothing moved" cannot arbitrate stillness, and
+    /// swapping onto it would trade one unusable channel for another.
+    ///
+    /// 🟡 0.40 is a CONSERVATIVE floor, not a separation point. Corpus-wide `activityMagnitudesAreZero`
+    /// is 30.0 % of all records (mixed day + night), and the two FR04.011 nights that motivated this
+    /// run 55–70 % across their worn epochs; 0.40 sits between, and a night that genuinely spends
+    /// under 40 % of its worn epochs motionless is not a night this rescue should be guessing at.
+    static let raisedFloorMinZeroMagnitudeFraction = 0.40
+
+    /// Minimum MEDIAN per-epoch minimum sub-sample on the primary channel before its floor counts as
+    /// "off the `01` baseline". The statistic is the median over quiet epochs of `min(raw[10..<15])`
+    /// — the quietest 30 s of a 150 s epoch the ring itself says had no movement, which on a healthy
+    /// channel IS the baseline.
+    ///
+    /// 🟡 MEASURED on ONE device (Gen 2 Air, FR04.011, two nights, 715 worn epochs): per-night median
+    /// 75–95 with the per-night 25th percentile at 54 and 1. Every healthy shape in this file's own
+    /// fixtures sits at its placeholder level and is excluded by the stillness conjunct below long
+    /// before this number binds (Gen-2 `01`, Gen-3 `0f` = 15, Gen-3's drifted `16→24→39`), so 16 is
+    /// chosen to clear the highest documented healthy placeholder (15) by one count and to sit far
+    /// below the observed FR04.011 population. It is NOT a fitted separation — one device, two
+    /// nights. Widen only against a second capture of this firmware family.
+    static let raisedFloorMinMedianQuietMinimum = 16
+
+    /// True when the primary `[10:15]` channel varies freely yet never comes back to baseline, so
+    /// every epoch carries a pedestal of phantom "movement" (#184's sibling failure, FR04.011).
+    ///
+    /// Same method as `primaryMotionIsDegenerate` — condition on the ring's OWN "nothing moved"
+    /// verdict and ask whether the primary channel agrees — with two deliberate differences:
+    ///   (1) the verdict is `activityMagnitudesAreZero`, the LAYOUT-CORRECT decode of `[15:23)`,
+    ///       not the byte-aligned `[15:20]` window. This branch reads its motion off the decoded
+    ///       magnitudes, so it must be gated on the same numbers it will consume; and
+    ///   (2) the "the residual is instrumentation, not movement" proof is a RAISED FLOOR rather than
+    ///       a fixed intra-epoch template. On FR04.011 the sub-samples genuinely differ epoch to
+    ///       epoch (all-five-equal share ≈ 8 %) and their ordering is not phase-locked, so
+    ///       `slotOrderConsistency` correctly refuses it — but the channel's own MINIMUM never
+    ///       returns to `01`, which is a pedestal no rolling local floor can subtract either.
+    ///
+    /// Gates (in order): the magnitude channel must resolve stillness on a real share of the run;
+    /// there must be an hour of it to judge; the primary must REFUSE to read still where the ring
+    /// says nothing moved (`degenerateMaxQuietStillFraction`, shared with #184 — this is what keeps
+    /// every flat/drifting placeholder night on the primary path, since a constant run always
+    /// resolves stillness); and only then, the floor test.
+    static func primaryFloorIsRaised(_ worn: [BulkRecord]) -> Bool {
+        let quiet = worn.filter(\.activityMagnitudesAreZero)
+        guard Double(quiet.count) >= Double(worn.count) * raisedFloorMinZeroMagnitudeFraction,
+              quiet.count >= degenerateMinQuietEpochs else { return false }
+        let stillCount = quiet.filter(\.motionResolvesStillness).count
+        guard Double(stillCount) < Double(quiet.count) * degenerateMaxQuietStillFraction else { return false }
+        return medianQuietMinimum(quiet) >= raisedFloorMinMedianQuietMinimum
+    }
+
+    /// Median over `epochs` of each epoch's SMALLEST `[10:15]` sub-sample. `epochs` is non-empty
+    /// (the caller guarantees it); the even-count case takes the lower of the two central values,
+    /// which biases the statistic DOWN, i.e. toward keeping the primary channel.
+    static func medianQuietMinimum(_ epochs: [BulkRecord]) -> Int {
+        let mins = epochs.map { Int($0.raw[10..<15].min() ?? 0) }.sorted()
+        guard !mins.isEmpty else { return 0 }
+        return mins[(mins.count - 1) / 2]
     }
 
     // MARK: - HRV pooling gate (#185 regression)
@@ -667,12 +741,27 @@ public enum BulkSleep {
     /// The staging model subtracts its rolling local floor afterward, exactly as on primary motion.
     static func motionMagnitudes(from records: [BulkRecord],
                                  absoluteActiveCut: Int = motionIntensityActiveCut) -> [Float] {
-        if case .intensityTail(let degenerate) = motionSource(records) {
-            return motionIntensityFallbackMagnitudes(records, degenerate: degenerate,
-                                                     absoluteActiveCut: absoluteActiveCut)
+        if let secondary = secondaryChannelMagnitudes(records, absoluteActiveCut: absoluteActiveCut) {
+            return secondary
         }
         return records.map { record in
             Float(record.motion.reduce(0) { $0 + Int($1) })
+        }
+    }
+
+    /// The per-epoch magnitudes of whichever SECONDARY channel this run selected, or `nil` when the
+    /// run stays on the primary `[10:15]` one. Single point of dispatch so `motionTimeline` and
+    /// `motionMagnitudes` cannot drift apart on which channel a run reads.
+    static func secondaryChannelMagnitudes(_ records: [BulkRecord],
+                                           absoluteActiveCut: Int = motionIntensityActiveCut) -> [Float]? {
+        switch motionSource(records) {
+        case .primary:
+            return nil
+        case .intensityTail(let degenerate):
+            return motionIntensityFallbackMagnitudes(records, degenerate: degenerate,
+                                                     absoluteActiveCut: absoluteActiveCut)
+        case .activityMagnitudes:
+            return activityMagnitudeFallbackMagnitudes(records)
         }
     }
 
@@ -763,6 +852,35 @@ public enum BulkSleep {
         return sums.map { magnitude in
             guard magnitude > 0 else { return 0 }
             return magnitude >= activeCut ? 16 : 1
+        }
+    }
+
+    /// The light/active seam for the DECODED magnitude channel, in `Σ activityMagnitudes` units.
+    /// Absolute for the same reason `motionIntensityActiveCut` is (#197): a per-night rank makes the
+    /// threshold a function of how much history has drained, and forces a fixed share of every
+    /// night to be "movement".
+    ///
+    /// 🟡 IT IS AN OBSERVED QUANTILE, NOT A FITTED THRESHOLD, and must not be described as one. On
+    /// the two FR04.011 nights this branch exists for, the per-epoch magnitude sum is EXACTLY 0 for
+    /// the median night epoch (p50 = 0) and p90 ≈ 700–800; postural turns land at 100–450 and the
+    /// final wake exceeds 1000. 700 is that p90 — the level above which ~10 % of the night's epochs
+    /// sit, which is where "several brief awakenings" lives — and the still population is at zero,
+    /// so the seam is nowhere near it. Two nights, ONE device. #197 records why a real number needs
+    /// supervised labels and why this project does not have them yet; nothing here changes that.
+    /// The 0-versus-positive split does the load-bearing work regardless of this constant: a still
+    /// epoch maps to `0` and a stir to `1`, both below `ActivityPeriod.motionStillThreshold`.
+    static let activityMagnitudeActiveCut = 700
+
+    /// Map the decoded `[15:23)` magnitudes onto the same `0 / 1 / 16` alphabet the intensity-tail
+    /// fallback emits, so detection and staging consume one scale whichever channel a run picked.
+    static func activityMagnitudeFallbackMagnitudes(
+        _ records: [BulkRecord],
+        absoluteActiveCut: Int = activityMagnitudeActiveCut
+    ) -> [Float] {
+        records.map { record in
+            let sum = record.activityMagnitudes.reduce(0, +)
+            guard sum > 0 else { return 0 }
+            return sum >= absoluteActiveCut ? 16 : 1
         }
     }
 

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/FR04RaisedPrimaryFloorTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/FR04RaisedPrimaryFloorTests.swift
@@ -1,0 +1,238 @@
+import XCTest
+@testable import OpenCircuitKit
+
+/// Regression coverage for the RingConn Gen 2 Air on FW **FR04.011** — the sibling of #184's
+/// FR04.009 shape, and a DIFFERENT failure that the #184 gate correctly refuses.
+///
+/// On this firmware the primary `[10:15]` channel never returns to the `01` baseline: its counts
+/// wander in the 40–90 band with the occasional `1`, and — unlike FR04.009 — they wander FREELY.
+/// The five sub-samples of one epoch usually differ (so `motionIsPlaceholder` never fires), their
+/// spread is far wider than `motionStillThreshold` (so `motionResolvesStillness` never fires), and
+/// no slot pair keeps a fixed ordering (so `slotOrderConsistency` correctly reports "this is not an
+/// instrumentation template" and `primaryMotionIsDegenerate` returns false). The run therefore kept
+/// `.primary`, whose permanent pedestal of phantom movement swamps `detect()`: every drain ended
+/// `noStagedSegments` with zero staged segments while HR/HRV/RR/SpO2 recorded all night.
+///
+/// The decoded `[15:23)` magnitudes (#195) are clean on the same records — exactly 0 for the median
+/// night epoch — so the fix widens `motionSource` with a third, floor-based rejection reason.
+///
+/// All data here is SYNTHETIC — it reproduces the failure SHAPE, not a person's night. No captured
+/// health data is committed (CLAUDE.md).
+final class FR04RaisedPrimaryFloorTests: XCTestCase {
+
+    private let step = UInt32(BulkRecord.epochSeconds)
+
+    /// Deterministic small noise — NOT `random`, so the suite never flakes.
+    private var seed: UInt64 = 0x2545_F491_4F6C_DD1D
+    private func next(_ bound: Int) -> Int {
+        seed ^= seed << 13; seed ^= seed >> 7; seed ^= seed << 17
+        return Int(seed % UInt64(bound))
+    }
+
+    /// Build one 23-byte record. `magnitudes` are the five 12-bit `[15:23)` values, nibble-packed
+    /// exactly as `BulkRecord.activityMagnitudes` decodes them, so the fixture exercises the real
+    /// bit layout rather than a byte-aligned approximation of it.
+    private func record(_ counter: UInt32, hr: UInt8, hrv: UInt8,
+                        primary: [UInt8], magnitudes: [Int], sleepVitals: Bool) -> BulkRecord {
+        var b = [UInt8](repeating: 0, count: BulkRecord.length)
+        b[0] = UInt8(counter >> 24); b[1] = UInt8((counter >> 16) & 0xff)
+        b[2] = UInt8((counter >> 8) & 0xff); b[3] = UInt8(counter & 0xff)
+        b[4] = hr
+        if sleepVitals { b[5] = hrv; b[7] = 120; b[8] = 96 } else { b[8] = 0x12 }
+        for i in 0..<5 { b[10 + i] = primary[i] }
+
+        var nibbles = [UInt8](repeating: 0, count: 16)
+        for (k, m) in magnitudes.enumerated() {
+            let v = max(0, min(4095, m))
+            nibbles[k * 3] = UInt8((v >> 8) & 0x0f)
+            nibbles[k * 3 + 1] = UInt8((v >> 4) & 0x0f)
+            nibbles[k * 3 + 2] = UInt8(v & 0x0f)
+        }
+        for i in 0..<8 { b[15 + i] = (nibbles[i * 2] << 4) | nibbles[i * 2 + 1] }
+        return BulkRecord(b)!
+    }
+
+    /// The FR04.011 still shape: a raised, FREELY VARYING primary channel and all-zero magnitudes.
+    /// Levels are drawn from the observed clusters (17, 41–53, 71, 84–86) with the occasional `1`,
+    /// and each of the five sub-samples is drawn independently — so no slot ordering is phase-locked.
+    private func raisedFloorStillEpoch(_ c: UInt32, hr: UInt8 = 52) -> BulkRecord {
+        let levels: [UInt8] = [1, 17, 41, 45, 49, 53, 71, 84, 85, 86]
+        let primary = (0..<5).map { _ in levels[next(levels.count)] }
+        return record(c, hr: hr, hrv: UInt8(38 + next(14)),
+                      primary: primary, magnitudes: [0, 0, 0, 0, 0], sleepVitals: true)
+    }
+
+    /// A postural turn: the magnitude channel rises to the observed 100–450 band. Below the seam,
+    /// so it must read as LIGHT movement, not an awakening.
+    private func turnEpoch(_ c: UInt32) -> BulkRecord {
+        let levels: [UInt8] = [41, 49, 71, 84, 86]
+        let primary = (0..<5).map { _ in levels[next(levels.count)] }
+        return record(c, hr: 58, hrv: UInt8(40 + next(10)), primary: primary,
+                      magnitudes: [40, 60, 30, 50, 20], sleepVitals: true)
+    }
+
+    /// A genuine awakening / the morning: magnitudes well over 1000 in total, on an activity-layout
+    /// epoch with an awake heart rate.
+    private func awakeEpoch(_ c: UInt32) -> BulkRecord {
+        let primary = (0..<5).map { _ in UInt8(120 + next(130)) }
+        return record(c, hr: UInt8(84 + next(14)), hrv: 0, primary: primary,
+                      magnitudes: [900, 850, 1100, 700, 950], sleepVitals: false)
+    }
+
+    /// ~9 h: an awake evening, a long still night with a handful of turns, then the morning.
+    private func fr04_011Night() -> [BulkRecord] {
+        var c: UInt32 = 0x0c60_0000
+        var out: [BulkRecord] = []
+        for _ in 0..<12 { out.append(awakeEpoch(c)); c += step }
+        for i in 0..<180 {
+            // Six brief turns spread through the night.
+            out.append(i % 30 == 17 ? turnEpoch(c) : raisedFloorStillEpoch(c)); c += step
+        }
+        for _ in 0..<12 { out.append(awakeEpoch(c)); c += step }
+        return out
+    }
+
+    /// The classic Gen-2 night the fix must NOT touch: an `01` baseline that reads still everywhere.
+    private func baselineNight() -> [BulkRecord] {
+        var c: UInt32 = 0x0c60_0000
+        var out: [BulkRecord] = []
+        for _ in 0..<12 { out.append(awakeEpoch(c)); c += step }
+        for i in 0..<180 {
+            let still = record(c, hr: 52, hrv: 45, primary: [1, 1, 1, 1, 1],
+                               magnitudes: [0, 0, 0, 0, 0], sleepVitals: true)
+            out.append(i % 30 == 17 ? turnEpoch(c) : still); c += step
+        }
+        for _ in 0..<12 { out.append(awakeEpoch(c)); c += step }
+        return out
+    }
+
+    // MARK: - (a) the run now selects the magnitude channel
+
+    func testFixtureReproducesTheFieldShape() {
+        let worn = fr04_011Night().filter { $0.layout != .idle }
+        let night = worn.filter(\.activityMagnitudesAreZero)
+
+        XCTAssertGreaterThanOrEqual(BulkSleep.medianQuietMinimum(night), 16,
+                                    "fixture sanity: the primary floor sits off the `01` baseline")
+        XCTAssertLessThan(Double(night.filter(\.motionIsPlaceholder).count) / Double(night.count), 0.20,
+                          "fixture sanity: the five sub-samples usually DIFFER, so the constant-filler "
+                          + "branch cannot fire")
+        XCTAssertLessThan(BulkSleep.slotOrderConsistency(night),
+                          BulkSleep.degenerateMinSlotOrderFraction,
+                          "fixture sanity: this is NOT the #184 fixed template — the ordering is free, "
+                          + "which is exactly why `primaryMotionIsDegenerate` refuses it")
+        XCTAssertFalse(BulkSleep.primaryMotionIsDegenerate(worn),
+                       "the #184 gate must keep refusing this shape; that is the bug being fixed")
+    }
+
+    func testRaisedFloorSelectsTheDecodedMagnitudeChannel() {
+        let recs = fr04_011Night()
+        XCTAssertTrue(BulkSleep.primaryFloorIsRaised(recs.filter { $0.layout != .idle }))
+        XCTAssertEqual(BulkSleep.motionSource(recs), .activityMagnitudes)
+    }
+
+    /// The `0 / 1 / 16` alphabet the tail fallback emits, on the decoded channel: still → 0,
+    /// a turn → 1 (light), the morning → 16 (active).
+    func testMagnitudeChannelMapsStillTurnAndWakeOntoTheSharedScale() {
+        let recs = fr04_011Night()
+        let mags = BulkSleep.motionMagnitudes(from: recs)
+
+        XCTAssertEqual(mags[0], 16, "the morning/evening epochs exceed the seam")
+        XCTAssertEqual(mags[12 + 17], 1, "a 200-unit postural turn is light movement, not an awakening")
+        XCTAssertEqual(mags[12 + 18], 0, "a still epoch is the channel's own zero")
+    }
+
+    // MARK: - (b) the night stages
+
+    func testRaisedFloorNightStagesWithPlausibleOnsetAndEfficiency() throws {
+        let recs = fr04_011Night()
+
+        let segments = BulkSleep.stagedSegments(from: BulkSleep.latestNightRecords(from: recs))
+        XCTAssertFalse(segments.isEmpty,
+                       "the reported failure: every drain ended `noStagedSegments` with 0 staged "
+                       + "segments on an archive whose vitals decoded all night")
+
+        let block = try XCTUnwrap(BulkSleep.mainSleep(from: recs))
+        let firstStill = recs[12].date(epoch: Command.syncEpoch)
+        XCTAssertLessThan(abs(block.start.timeIntervalSince(firstStill)), 45 * 60,
+                          "onset lands within minutes of the still stretch, not hours into it")
+        XCTAssertGreaterThan(block.duration, 5 * 3600)
+
+        let minutes = SleepStaging.summary(SleepStaging.classify(from: recs)).minutes
+        XCTAssertGreaterThan(minutes.inBed, 0)
+        let efficiency = Double(minutes.asleep) / Double(minutes.inBed)
+        XCTAssertGreaterThan(efficiency, 0.70, "a night of measured stillness is not mostly awake")
+        XCTAssertLessThanOrEqual(efficiency, 1.0)
+    }
+
+    // MARK: - (c) the classic baseline night is untouched
+
+    func testClassicBaselineNightKeepsThePrimaryChannel() {
+        let recs = baselineNight()
+        XCTAssertFalse(BulkSleep.primaryFloorIsRaised(recs.filter { $0.layout != .idle }),
+                       "an `01` baseline resolves stillness everywhere, so the shared "
+                       + "`degenerateMaxQuietStillFraction` conjunct rejects it before the floor test")
+        XCTAssertEqual(BulkSleep.motionSource(recs), .primary)
+        XCTAssertFalse(BulkSleep.stagedSegments(from: BulkSleep.latestNightRecords(from: recs)).isEmpty,
+                       "and it still stages, off the primary channel, exactly as before")
+    }
+
+    // MARK: - the two new gates, in isolation
+
+    /// A raised floor is NOT enough on its own: if the magnitude channel cannot say "nothing moved"
+    /// on a real share of the run, swapping onto it trades one unusable channel for another.
+    func testRaisedFloorWithoutAZeroMagnitudePopulationStaysOnPrimary() {
+        var c: UInt32 = 0x0c60_0000
+        let recs = (0..<200).map { _ -> BulkRecord in
+            defer { c += step }
+            let levels: [UInt8] = [41, 49, 71, 84, 86]
+            return record(c, hr: 52, hrv: 45,
+                          primary: (0..<5).map { _ in levels[next(levels.count)] },
+                          magnitudes: [7, 3, 11, 5, 9], sleepVitals: true)
+        }
+        XCTAssertFalse(BulkSleep.primaryFloorIsRaised(recs))
+        XCTAssertEqual(BulkSleep.motionSource(recs), .primary)
+    }
+
+    /// And a clean magnitude channel is not enough either: a primary channel whose floor is at or
+    /// near the baseline is doing its job, however much it varies above it.
+    func testCleanMagnitudesWithABaselineFloorStayOnPrimary() {
+        var c: UInt32 = 0x0c60_0000
+        let recs = (0..<200).map { i -> BulkRecord in
+            defer { c += step }
+            // Floor pinned at 1; the other four sub-samples vary widely above it. The baseline slot
+            // ROTATES, or slot 0 would be the minimum on every epoch — a phase-locked ordering that
+            // the #184 template gate would (rightly) claim first, leaving this test asserting
+            // nothing about the floor.
+            let base: [UInt8] = [1] + (0..<4).map { _ in UInt8(1 + next(90)) }
+            let primary = (0..<5).map { base[($0 + i) % 5] }
+            return record(c, hr: 52, hrv: 45, primary: primary,
+                          magnitudes: i % 25 == 0 ? [40, 60, 30, 50, 20] : [0, 0, 0, 0, 0],
+                          sleepVitals: true)
+        }
+        XCTAssertEqual(BulkSleep.medianQuietMinimum(recs.filter(\.activityMagnitudesAreZero)), 1)
+        XCTAssertFalse(BulkSleep.primaryFloorIsRaised(recs))
+        XCTAssertEqual(BulkSleep.motionSource(recs), .primary)
+    }
+
+    /// Sub-hour runs are never judged, matching `degenerateMinQuietEpochs`: a night arriving as
+    /// several short fragments keeps today's behaviour instead of flipping verdict between scopes.
+    func testShortRunIsNeverJudged() {
+        var c: UInt32 = 0x0c60_0000
+        let recs = (0..<20).map { _ -> BulkRecord in
+            defer { c += step }
+            return raisedFloorStillEpoch(c)
+        }
+        XCTAssertFalse(BulkSleep.primaryFloorIsRaised(recs))
+        XCTAssertEqual(BulkSleep.motionSource(recs), .primary)
+    }
+
+    /// The nibble packing the fixture writes is the one `activityMagnitudes` reads. If this ever
+    /// drifts, every magnitude assertion above becomes vacuous.
+    func testFixtureNibblePackingRoundTrips() {
+        let r = record(0x0c60_0000, hr: 60, hrv: 45, primary: [1, 1, 1, 1, 1],
+                       magnitudes: [0, 1, 4095, 1302, 97], sleepVitals: true)
+        XCTAssertEqual(r.activityMagnitudes, [0, 1, 4095, 1302, 97])
+        XCTAssertFalse(r.activityMagnitudesAreZero)
+    }
+}

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/FR04RaisedPrimaryFloorTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/FR04RaisedPrimaryFloorTests.swift
@@ -227,6 +227,79 @@ final class FR04RaisedPrimaryFloorTests: XCTestCase {
         XCTAssertEqual(BulkSleep.motionSource(recs), .primary)
     }
 
+    // MARK: - the shape the FIELD archive actually has
+
+    /// 🟢 THE SHIPPED FIXTURE ABOVE IS NOT THE FIELD SHAPE, and the difference is the whole bug.
+    /// `raisedFloorStillEpoch` draws all five sub-samples INDEPENDENTLY, so a "still" epoch spans
+    /// 1…86 within itself. On the real FR04.011 archive (715 worn epochs, one night plus the
+    /// preceding day) the ring's OWN motionless epochs are nearly FLAT inside the epoch — median
+    /// intra-epoch spread **1 count**, p90 **6** — so `motionResolvesStillness` fires on **78 %** of
+    /// them and `primaryFloorIsRaised` rejected the real archive while accepting the fixture.
+    ///
+    /// What the field channel really does is hold a flat pedestal whose LEVEL wanders (per-epoch
+    /// minimum p10 1 / p50 40 / p90 93 across the night), far faster and further than the ~30-min
+    /// `motionAboveLocalFloor` window can track. This fixture reproduces THAT: flat within an epoch,
+    /// wandering between epochs. It must select the magnitude channel, and it must do so at BOTH the
+    /// scopes production evaluates `motionSource` at — the night slice and the whole archive union.
+    private func wanderingPedestalNight(includeDay: Bool) -> [BulkRecord] {
+        var c: UInt32 = 0x0c60_0000
+        var out: [BulkRecord] = []
+        if includeDay {
+            // ~14 h of an ordinary awake day, which is what `latestNightRecords` hands `motionSource`
+            // out of the 30 h archive union. It must not change the verdict.
+            for _ in 0..<336 { out.append(awakeEpoch(c)); c += step }
+        }
+        for _ in 0..<12 { out.append(awakeEpoch(c)); c += step }
+        // The observed FR04.011 plateau levels (the commit's own clusters), held for a few epochs
+        // at a time and then stepped — flat inside an epoch, wandering between them.
+        let plateaus = [1, 17, 41, 45, 49, 53, 71, 84, 85, 86]
+        var level = 45
+        for i in 0..<180 {
+            if i % 4 == 0 { level = plateaus[next(plateaus.count)] }
+            let primary = (0..<5).map { _ in UInt8(max(0, level + next(3) - 1)) }
+            let still = record(c, hr: 52, hrv: UInt8(38 + next(14)),
+                               primary: primary, magnitudes: [0, 0, 0, 0, 0], sleepVitals: true)
+            out.append(i % 30 == 17 ? turnEpoch(c) : still); c += step
+        }
+        for _ in 0..<12 { out.append(awakeEpoch(c)); c += step }
+        return out
+    }
+
+    func testWanderingPedestalFixtureMatchesTheFieldStatistics() {
+        let worn = wanderingPedestalNight(includeDay: false).filter { $0.layout != .idle }
+        let quiet = worn.filter(\.activityMagnitudesAreZero)
+        let stillShare = Double(quiet.filter(\.motionResolvesStillness).count) / Double(quiet.count)
+        XCTAssertGreaterThan(stillShare, BulkSleep.degenerateMaxQuietStillFraction,
+                             "fixture sanity: like the field archive, the ring's motionless epochs are "
+                             + "FLAT inside the epoch — so the intra-epoch proxy the branch shipped with "
+                             + "says `still` and would reject this channel outright")
+        XCTAssertGreaterThanOrEqual(BulkSleep.medianQuietMinimum(quiet), 16)
+        XCTAssertFalse(BulkSleep.primaryMotionIsDegenerate(worn))
+    }
+
+    func testWanderingPedestalSelectsTheMagnitudeChannelAtEveryScope() {
+        for includeDay in [false, true] {
+            let recs = wanderingPedestalNight(includeDay: includeDay)
+            XCTAssertTrue(BulkSleep.primaryFloorIsRaised(recs.filter { $0.layout != .idle }),
+                          "includeDay=\(includeDay): the de-floored stillness conjunct must see through "
+                          + "a flat-but-wandering pedestal")
+            XCTAssertEqual(BulkSleep.motionSource(recs), .activityMagnitudes,
+                           "includeDay=\(includeDay): the verdict must not depend on how much daytime "
+                           + "happens to be in the archive union — that is the scope-dependence the "
+                           + "removed share-of-worn conjunct introduced")
+        }
+    }
+
+    func testWanderingPedestalNightStages() throws {
+        let recs = wanderingPedestalNight(includeDay: true)
+        let segments = BulkSleep.stagedSegments(from: BulkSleep.latestNightRecords(from: recs))
+        XCTAssertFalse(segments.isEmpty,
+                       "the reported failure: `noStagedSegments` on every drain while HR/HRV/RR/SpO2 "
+                       + "decoded all night")
+        let block = try XCTUnwrap(BulkSleep.mainSleep(from: recs))
+        XCTAssertGreaterThan(block.duration, 5 * 3600)
+    }
+
     /// The nibble packing the fixture writes is the one `activityMagnitudes` reads. If this ever
     /// drifts, every magnitude assertion above becomes vacuous.
     func testFixtureNibblePackingRoundTrips() {


### PR DESCRIPTION
> **Revised 2026-09-02** after the reporter supplied a real FR04.011 archive and I replayed it. The branch was landing the right *rescue* on the wrong *premise*, and both conjuncts of the gate turned out to be measuring the wrong thing — including one that rejected the very archive this PR was written for. See [**What changed in this revision**](#what-changed-in-this-revision). The first revision's analysis is left in the history (`e8dcd56`) rather than squashed away, since the correction is the interesting part.

## What

Adds a **third rejection reason** to `BulkSleep.motionSource` — a *raised, wandering* primary-motion floor — and a third `MotionSource` case that reads the decoded `[15:23)` `activityMagnitudes` instead of the byte-aligned `[15:20]` tail.

## Why: a Gen 2 Air on FR04.011 stages nothing at all

Reported from a Gen 2 Air on firmware **FR04.011**, build 52. Every history drain ends `nightRowOutcome = noStagedSegments` with `stagedSleepSegments = 0` — 19 of 24 evidence rows over two nights; the remaining rows have no night row at all. HR/HRV/RR/SpO₂ are recorded fine, with sleep-vitals epochs present all night. It is a blank card on a complete archive, the #184 symptom with a different cause.

**Field evidence** (numbers only; no raw epochs are included in this PR):

- Over **715 worn epochs**, the primary `[10:15]` byte takes the `01` "still" baseline value on only **356 of 3575** sub-samples. The rest cluster around **17, 41–53, 71, 84–86** *during obviously motionless sleep*.
- Per-night medians **≈ 75–95**, with the per-night 25th percentile at **54** on one night and **1** on the other.
- 🟢 **Within an epoch the five sub-samples are nearly *equal*** — median intra-epoch spread **1 count**, p90 **6**, over the ring's own motionless epochs. (They are *exactly* equal only ~8 % of the time, which is what the first revision measured and then over-read; see below.)
- 🟢 **The wander is *between* epochs**: the pedestal's level moves **1 → 126** across the night, and the per-epoch minimum runs p10 **1** / p50 **40** / p90 **93**.
- The decoded 12-bit `activityMagnitudes` channel is clean on the *same* records: the per-epoch magnitude sum is **exactly 0 for the median night epoch** (p50 = 0, p90 ≈ 700–800), rises to **100–450** at postural turns and **> 1000** at the final wake, and its hourly profile matches the HR/HRV dynamics.

## How the detector fails today

`motionSource` has two reasons to reject the primary channel, and FR04.011 satisfies neither:

- **Constant filler** — needs every worn epoch to be `motionIsPlaceholder`. The level moves, so no.
- **Non-expressive (#184, FR04.009)** — needs both `degenerateMaxQuietStillFraction` *and* `degenerateMinSlotOrderFraction`. The second gate **correctly fails**: no slot pair keeps a fixed ordering, so `slotOrderConsistency` rightly reports "this is not an instrumentation template". It isn't one.

So the run keeps `.primary`. `motionAboveLocalFloor` subtracts a per-window level, which cancels a flat plateau **whose level is stable across the floor's ~30-minute window** — Gen-2 `01`, Gen-3 `0f`, the drifting `16→24→39`. FR04.011's pedestal is flat *inside* an epoch but wanders further and faster than that window can track, so the p10 floor sits well below the current level and a large residual survives de-flooring. After de-flooring only **32 %** of quiet epochs read still, against the **≥ 70 %** (`gravityStillFraction`) that `detect()` requires. The phantom movement swamps detection and no block is staged.

## The new rule

`primaryFloorIsRaised(worn)` — same method as `primaryMotionIsDegenerate` (condition on the ring's own "nothing moved" verdict, then ask whether the primary agrees), with two deliberate differences:

1. The verdict is **`activityMagnitudesAreZero`**, the layout-correct decode from #195, not the byte-aligned `[15:20]` window. This branch *reads* the decoded magnitudes, so it is gated on the same numbers it will consume.
2. The "the residual is instrumentation, not movement" proof is a **raised, wandering floor** rather than a fixed template.

Gates, in order:

| gate | value | why |
|---|---|---|
| enough ring-verified motionless time to judge | `degenerateMinQuietEpochs` (24 epochs = 1 h), **reused** | below that there is no stageable night anyway — and those epochs *are* the magnitude channel saying "nothing moved", so this doubles as the "is the substitute any good?" test |
| primary refuses to read still **after de-flooring** | `degenerateMaxQuietStillFraction` (0.50), **reused from #184**, applied to `primaryChannelIsStillAfterFloor` | this is what keeps every flat or drifting placeholder night on the primary path — such a channel de-floors to zero and reads still |
| the floor is off baseline | median per-epoch `min(raw[10..<15])` ≥ **16** | clears the highest documented healthy placeholder (Gen-3 `0f` = 15) by one count |

The load-bearing addition is **`primaryChannelIsStillAfterFloor(_:)`**: it pushes the raw primary channel through the *production* `ActivityPeriod.motionAboveLocalFloor` and asks, per epoch, whether ≥ `gravityStillFraction` of the five residuals fall under `motionStillThreshold`. It measures what `detect()` actually consumes, and reuses the detector's own two constants rather than restating them, so the predicate and the detector it predicts cannot drift apart. It reads `raw[10..<15]` directly rather than via `motionTimeline`, which would re-enter `motionSource` and recurse.

The branch is evaluated **last**, after both tail reasons decline, and carries the same "the channel must actually carry movement" conjunct against the channel it selects — so **no input that reached a verdict before this change changes verdict**.

Selected runs map `Σ activityMagnitudes` onto the same `0 / 1 / 16` alphabet the tail fallback already emits, so detection, staging and the movement chart consume one scale whichever channel a run picked.

## What changed in this revision

Replaying the reporter's real archive (715 worn epochs, one night plus the preceding day) broke both conjuncts of the gate `e8dcd56` shipped:

**(a) The stillness conjunct measured the wrong axis.** `e8dcd56` gated on `motionResolvesStillness`, which asks whether an epoch's five sub-samples sit within `motionStillThreshold` of *one another*, reasoning that a flat plateau cancels against the rolling floor at any level. That reasoning holds only while the plateau's **level** is stable across the floor's own window — and here it is not. Because the pedestal *is* flat inside an epoch, the proxy fires on **78 %** of quiet epochs, scores the unusable channel "still", and the gate **rejected the real FR04.011 archive** while happily accepting the synthetic fixture. The proxy answers a question about one epoch; the failure lives in the drift between epochs. Replaced with the de-floored measurement above.

**(b) The share-of-worn conjunct was scope-dependent, and is deleted.** `raisedFloorMinZeroMagnitudeFraction ≥ 0.40` was measured on **night** epochs but evaluated wherever `motionSource` is called — and `latestNightRecords` hands it the whole **30 h `EpochArchive` union**, ~22 h of which is an awake day. On the real archive it reads **0.278** over the union against **0.567** over the night alone, so the gate opened or stayed shut depending on how much daytime happened to have drained: an answer that depends on *when you synced*. An absolute quorum is scope-stable; a share of the window is not. The surviving `degenerateMinQuietEpochs` already covers the duty it was carrying.

**Net effect on new constants: this PR now adds one 🟡 constant, not two.** `primaryChannelIsStillAfterFloor` introduces none — it borrows `gravityStillFraction` and `motionStillThreshold` from the detector it predicts.

Replaying the reporter's archive with the corrected gate stages **47 segments, onset 01:17, wake 08:40, efficiency 0.90**.

### Honest limits

- `raisedFloorMinMedianQuietMinimum = 16` is a **conservative floor, not a measured separation point**, tagged 🟡 in source per `CLAUDE.md`. It rests on one device.
- ⚠️ **The margin on the surviving stillness conjunct is thin.** On this single capture it clears `degenerateMaxQuietStillFraction` by only **0.028** at night-only scope. That is real but slim, and I would rather flag it than tune it against the one archive I have.
- 🙏 **A second FR04.011 capture is genuinely wanted** — ideally a different wearer, or at least a different night. It would do more for confidence in this branch than any further adjustment of the two thresholds. If anyone reading has a Gen 2 Air on FR04.011, a raw epoch archive would be very welcome.
- `activityMagnitudeActiveCut = 700` is an **observed p90, not a fitted threshold**, and the doc comment says so. #197's finding stands untouched: a real seam needs `[15:23)` magnitudes *and* supervised labels. The `0`-versus-positive split does the load-bearing work regardless — a still epoch maps to `0` and a stir to `1`, both below `motionStillThreshold`.

I deliberately did **not** widen `primaryMotionIsDegenerate` or touch the three calibrations fitted to the byte-aligned population (`degenerateMaxQuietStillFraction`, `degenerateMinSlotOrderFraction`, `hrvPoolingNoiseFloorMs`).

## Test coverage

`FR04RaisedPrimaryFloorTests`, now **12 tests**. All records are **synthetic**, built byte-by-byte in the test — including the nibble packing, which is round-trip asserted against `activityMagnitudes` so the magnitude assertions cannot go vacuous. No captured health data.

New in this revision, a **`wanderingPedestalNight` fixture built to the field statistics** — flat within an epoch (spread ≈ 1), level stepping between the observed plateau clusters:

- `testWanderingPedestalFixtureMatchesTheFieldStatistics` — pins the property that broke the first revision: on this fixture the intra-epoch proxy *does* read "still" above `degenerateMaxQuietStillFraction`, so a regression to `motionResolvesStillness` fails here loudly.
- `testWanderingPedestalSelectsTheMagnitudeChannelAtEveryScope` — asserts the verdict at **both** scopes production evaluates `motionSource` at (the night slice **and** the archive union). This is the regression (b) would otherwise reintroduce.
- `testWanderingPedestalNightStages` — the night stages, with a > 5 h main block.

The original fixture is **kept, not replaced**: it draws all five sub-samples independently, so it exercises a genuinely different shape, and both must select the magnitude channel. Retained alongside: a classic `01`-baseline night still selects `.primary` and still stages; both gates in isolation; and the sub-hour guard.

### Results

`swift test` in `ios/OpenCircuitKit`: **1838 tests, 11 skipped, 1 failure** — and that one failure is pre-existing:

```
SleepStagingTests.testMidNightWASOIsImmuneToTheRescueButTheMorningTailIsNot
XCTAssertEqualWithAccuracy failed: ("211.5") is not equal to ("182.5") +/- ("5.0")
```

I re-verified it reproduces **identically (211.5 vs 182.5) with my source changes stashed**, so it is not caused by this branch, and I have not touched it. Everything else passes, including the corpus replays, `SleepMonotonicityTests`, and every existing Gen-2/Gen-3 and FR04.009 motion fixture.

<details>
<summary>⚠️ Heads-up: the test target does not compile on Swift 6.2.1 (unrelated to this PR)</summary>

On `swift-driver 1.127.14.1 / Apple Swift 6.2.1 (swiftlang-6.2.1.4.8)`, arm64-apple-macosx26.0, a clean `master` fails to **build the test target** with type-checker timeouts in three test files, before any test runs:

- `SleepMonotonicityTests.swift:172` — the chained `+` string literal in the `XCTAssertEqual(collapses, [], …)` message
- `SleepConfidenceCopyTests.swift:136` — `silentFor: 4 * 3600` needing a `TimeInterval` annotation
- `AutomaticWorkoutDetectionTests.swift:28` — the `sample(cursor:bpm:steps:)` map closure

I patched these **locally only** to be able to run the suite, then reverted them — **none of it is in this branch**, since it is unrelated to the bug and you may prefer a different fix or a pinned toolchain. Happy to send it as a separate PR if useful. (This is also why the test numbers above come from a locally-patched checkout.)
</details>

## Docs

`docs/PROTOCOL.md` §5.3 tabulates all three known shapes of `[10:15]` against the channel the detector reads on each. **This revision corrects the raised-floor row and its paragraph**, which had the first revision's error baked in: it described the variation as within-epoch ("counts wander freely… the sub-samples differ epoch to epoch") and claimed the channel's minimum "never returns to `01`". Both are wrong — the variation is *between* epochs, and the per-epoch minimum runs p10 1 / p50 40 / p90 93. What defeats de-flooring is the *rate* the level drifts at, not a floor permanently stuck off `01`. Numbers only, no raw epochs.

I did **not** add a release-notes entry: the repo writes `docs/RELEASE_NOTES_bNN.md` per build at release time, and there is no `b52` file yet — I would rather not pre-empt how you write it. I also did not bump the build number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
