### PR TITLE
fix(ios): stop BLE session churn from starving all-day/sport drains

### DIFF
--- a/ios/OpenCircuit/BLE/RingScanner.swift
+++ b/ios/OpenCircuit/BLE/RingScanner.swift
@@ -55,6 +55,12 @@ final class RingScanner: NSObject {
     /// callback slot, not observed view state.
     @ObservationIgnored var onSessionReplaced: ((RingSession) -> Void)?
 
+    /// Carries `interruptedDrainChannel` from a torn-down session across the gap to whichever
+    /// session eventually replaces it (#reconnect) — that gap can be a same-tick reconnect
+    /// (`didConnect`/`willRestoreState`) or, after a real drop, the far side of a backoff retry.
+    /// Read and cleared the moment a new session is created; see `RingSession.resumeChannelHint`.
+    private var pendingDrainResume: HistoryDrainPlan.Step?
+
     /// LAZY (#142): created only when Bluetooth is actually needed (first connect / saved-ring
     /// restore), NOT at app launch. Allocating a `CBCentralManager` is what triggers the iOS
     /// Bluetooth permission prompt, so eager creation in `init()` fired the prompt before onboarding
@@ -443,6 +449,11 @@ final class RingScanner: NSObject {
     /// auto-measure/sync loops can never keep writing to the peripheral behind a newer one.
     private func teardownSession() {
         session?.stopLiveMonitoring()
+        // Read BEFORE `invalidate()` cancels `syncTask` (#reconnect): cancellation is cooperative —
+        // `drainChannel` only notices it on its next check, asynchronously — so this is the last
+        // point at which `activeDrainTrace` reliably reflects the channel that was actually in
+        // flight, rather than racing whatever `drainChannel`'s own cancellation branch records.
+        pendingDrainResume = session?.interruptedDrainChannel
         session?.invalidate()
         session = nil
     }
@@ -820,7 +831,10 @@ extension RingScanner: CBCentralManagerDelegate {
                 // restore) before replacing it, so its tasks don't keep writing to the peripheral
                 // behind the new session (#42).
                 self.teardownSession()
-                self.session = RingSession(peripheral: peripheral, localStore: self.localStore)
+                let restored = RingSession(peripheral: peripheral, localStore: self.localStore)
+                restored.resumeChannelHint = self.pendingDrainResume
+                self.pendingDrainResume = nil
+                self.session = restored
             case .connecting:
                 // Pending connect still in flight; `didConnect` will complete it.
                 self.state = .connecting(peripheral.name ?? "RingConn")
@@ -901,6 +915,8 @@ extension RingScanner: CBCentralManagerDelegate {
             // tasks can't keep driving the same peripheral behind the new session (#42).
             self.teardownSession()
             let newSession = RingSession(peripheral: peripheral, localStore: self.localStore)
+            newSession.resumeChannelHint = self.pendingDrainResume
+            self.pendingDrainResume = nil
             self.session = newSession
             self.armConnectStabilityReset()
             // Reconnect-resume (#reconnect): a mid-workout BLE drop tore down the old session and its

--- a/ios/OpenCircuit/BLE/RingSession.swift
+++ b/ios/OpenCircuit/BLE/RingSession.swift
@@ -413,6 +413,22 @@ final class RingSession: NSObject {
     private var activeDrainTrace: HistoryChannelTrace?
     private var historySyncTrigger = "foreground"
 
+    /// One-shot resume hint (#reconnect): `RingScanner.teardownSession()` reads
+    /// `interruptedDrainChannel` off the OLD session before tearing it down and hands it to this
+    /// replacement session. The next `performHistoryDrain` moves that channel to the front of its
+    /// plan — see `HistoryDrainPlan.resuming` — then clears this, win or lose, so it never becomes a
+    /// standing reorder. `nil` on an ordinary reconnect that didn't interrupt anything.
+    var resumeChannelHint: HistoryDrainPlan.Step?
+
+    /// The channel actively mid-wait (open sent, no `0x82`/pages yet, or streaming but unfinished)
+    /// right now — read by `RingScanner.teardownSession()` BEFORE it cancels `syncTask`, so this
+    /// reflects the true in-flight channel rather than whatever `drainChannel`'s cancellation branch
+    /// races to record. `nil` when no drain is running or the drain hasn't opened a channel yet.
+    var interruptedDrainChannel: HistoryDrainPlan.Step? {
+        guard syncTask != nil, let trace = activeDrainTrace else { return nil }
+        return HistoryDrainPlan.Step(channel: trace.channel, label: trace.label)
+    }
+
     private var bulkRecords: [BulkRecord] = []
     private var bulkFinalized = false    // captured pages already committed (sleep/vitals) — stop-time safety net skips re-commit
     private var didRestageFromArchive = false   // once-per-session: surface retained-but-unstaged archive epochs (#119)
@@ -3339,13 +3355,20 @@ final class RingSession: NSObject {
         // live on channel 0x02 — `HistoryDrainPlan` appends it foreground-only and last: it is not
         // worth spending a bounded background wake on workout review data, and the official two-day
         // retention window means the next foreground open is sufficient.
-        let plan = HistoryDrainPlan.steps(
+        var plan = HistoryDrainPlan.steps(
             inBackground: inBackground,
             allDayOnly: allDayOnly,
             sportEnabled: automaticWorkoutDetectionEnabled,
             now: Date(),
             nightWindowEnd: nightWindow?.end,
             morningCatchUpWindow: Self.morningCatchUpWindow)
+        // Consume the resume hint ONCE, win or lose (#reconnect) — a channel that lost the race
+        // against the last session replacement gets first crack this pass; see
+        // `HistoryDrainPlan.resuming` for why this differs from the rejected standing reorder above.
+        if let hint = resumeChannelHint {
+            resumeChannelHint = nil
+            plan = HistoryDrainPlan.resuming(hint, in: plan)
+        }
         for step in plan {
             if Task.isCancelled { break }
             await drainChannel(channel: step.channel, label: step.label)

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/HistoryDrainPlan.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/HistoryDrainPlan.swift
@@ -117,4 +117,28 @@ public enum HistoryDrainPlan {
         if !inBackground, sportEnabled { steps.append(sportStep) }
         return steps
     }
+
+    /// Move `step` to the front of `plan` when present, so a channel that was still waiting on the
+    /// ring when a BLE reconnect tore down the session gets first crack on the very next attempt
+    /// instead of being re-queued behind whatever already won that race (2026-09-04: a session-churn
+    /// investigation found `all-day`/`sport` starved almost every cycle, behind `sleep`, which always
+    /// goes first in the foreground plan and so had first claim on each connection window before the
+    /// next churn cut in).
+    ///
+    /// ⚠️ THIS IS NOT THE REORDER HEURISTIC REJECTED ABOVE. That one inferred "starvation" from
+    /// aggregate outcome history recomputed every pass, and was killed because the signal was
+    /// polluted by a user-cancelled `syncTask` and by the `allDayOnly` prime, and because it thrashed.
+    /// This is a single, first-hand fact — `RingSession.interruptedDrainChannel` reads which channel
+    /// THIS session's OWN teardown cut off, synchronously, before anything is cancelled — applied
+    /// ONCE per replacement session and then discarded regardless of outcome, not accumulated or
+    /// recomputed. It cannot fire for a user Measure-cancel (that cancels `syncTask` in place, without
+    /// going through `RingScanner.teardownSession()`), and a stale hint against a plan that excludes
+    /// it (e.g. the `allDayOnly` prime's `[allDayStep]`) is simply a no-op — `#119` is untouched.
+    public static func resuming(_ step: Step, in plan: [Step]) -> [Step] {
+        guard let index = plan.firstIndex(of: step), index != 0 else { return plan }
+        var reordered = plan
+        reordered.remove(at: index)
+        reordered.insert(step, at: 0)
+        return reordered
+    }
 }

--- a/ios/OpenCircuitKit/Sources/OpenCircuitKit/HistorySyncAssessment.swift
+++ b/ios/OpenCircuitKit/Sources/OpenCircuitKit/HistorySyncAssessment.swift
@@ -16,6 +16,16 @@ public enum HistoryChannelOutcome: String, Codable, Sendable {
     /// says WE never asked (a connectivity problem, and the ring is exonerated). A tester export
     /// showing 27 all-day `noAck`s looked like a ring-side channel limit; it was a flaky link.
     case linkDown
+    /// The channel was still waiting on the ring (no ACK, no pages) when OUR OWN session was torn
+    /// down — a BLE reconnect replaced it mid-wait. Split out of `.noAck` (2026-09-04) for the same
+    /// reason `.linkDown` was: the two mean opposite things. `.noAck` says a LIVE link sat idle and
+    /// the ring never answered; this says the question was still in flight when we stopped listening
+    /// for our own reasons, so the ring is exonerated and no protocol signal should be inferred. A
+    /// tester export dominated by "session replaced — no drain ran" with `all-day`/`sport` `noAck`
+    /// on nearly every cycle (while `sleep`, going first in the foreground plan, occasionally won the
+    /// race) looked like the ring refusing those channels; it was session churn cutting them off
+    /// before their turn. See `HistoryDrainPlan.resuming` for how this is used to recover.
+    case cancelled
 
     /// Safe to re-stage/persist sleep from this channel.
     public var allowsSleepCommit: Bool { self == .complete }
@@ -95,8 +105,14 @@ public struct HistoryChannelTrace: Equatable, Codable, Sendable {
         if page47Count > 0 { return .ppgOnly }
         if sawSyncAck { return .empty }
         // Ordered AFTER every "we heard something" branch: if pages or an ACK arrived, the link
-        // plainly worked and a stale write-failure flag must not override real evidence.
+        // plainly worked and a stale write-failure flag (or a cancellation that landed just after)
+        // must not override real evidence.
         if openWriteFailed == true { return .linkDown }
+        // Ordered AFTER `.linkDown`: `openWriteFailed` is only ever paired with `.linkUnusable`
+        // (never `.cancelled`, see `RingSession.drainChannel`), so this never shadows it — it only
+        // catches the case `.linkDown` doesn't: the write succeeded and we were genuinely waiting
+        // on the ring when OUR OWN session teardown cancelled the wait.
+        if exitReason == .cancelled { return .cancelled }
         return .noAck
     }
 }

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HistoryDrainPlanTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HistoryDrainPlanTests.swift
@@ -107,6 +107,31 @@ final class HistoryDrainPlanTests: XCTestCase {
         XCTAssertEqual(HistoryDrainPlan.sportStep.channel, Command.syncChannelSport)
     }
 
+    // MARK: resuming — one-shot resume for a channel cut off by session replacement (#reconnect)
+
+    func testResumingMovesTheHintedStepToTheFront() {
+        let base = [HistoryDrainPlan.sleepStep, HistoryDrainPlan.allDayStep, HistoryDrainPlan.sportStep]
+        let resumed = HistoryDrainPlan.resuming(HistoryDrainPlan.allDayStep, in: base)
+        XCTAssertEqual(labels(resumed), ["all-day", "sleep", "sport"])
+    }
+
+    func testResumingIsANoOpWhenTheHintedStepIsAlreadyFirst() {
+        let base = [HistoryDrainPlan.sleepStep, HistoryDrainPlan.allDayStep]
+        XCTAssertEqual(labels(HistoryDrainPlan.resuming(HistoryDrainPlan.sleepStep, in: base)),
+                       ["sleep", "all-day"])
+    }
+
+    func testResumingIsANoOpWhenTheHintedStepIsNotInThePlan() {
+        // The allDayOnly workout prime's plan is `[allDayStep]` only — a stale sleep/sport hint
+        // left over from a churn that happened to land during the prime must not inject a channel
+        // the prime deliberately excludes (#119).
+        let primePlan = [HistoryDrainPlan.allDayStep]
+        XCTAssertEqual(labels(HistoryDrainPlan.resuming(HistoryDrainPlan.sleepStep, in: primePlan)),
+                       ["all-day"])
+        XCTAssertEqual(labels(HistoryDrainPlan.resuming(HistoryDrainPlan.sportStep, in: primePlan)),
+                       ["all-day"])
+    }
+
     /// PARITY: re-implements the exact inline logic this type replaced and compares over the whole
     /// input space, so the extraction cannot silently drift from shipped behaviour.
     func testMatchesTheReplacedInlineLogicForEveryInput() {

--- a/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HistorySyncAssessmentTests.swift
+++ b/ios/OpenCircuitKit/Tests/OpenCircuitKitTests/HistorySyncAssessmentTests.swift
@@ -152,4 +152,35 @@ final class HistorySyncAssessmentTests: XCTestCase {
         XCTAssertEqual(HistoryChannelOutcome.linkDown.rawValue, "linkDown")
         XCTAssertEqual(HistoryChannelExitReason.linkUnusable.rawValue, "linkUnusable")
     }
+
+    // MARK: .cancelled — interrupted by OUR OWN session teardown, not a ring-side signal
+
+    func testCancelledMidWaitIsNotMisreportedAsNoAck() {
+        // A BLE session replacement cancels whatever channel is mid-wait. Before this outcome had
+        // no `.cancelled` branch, so a channel cut off before any ring response fell through to
+        // `.noAck` — indistinguishable from a live link the ring genuinely never answered on. That
+        // conflation is exactly what let session-churn starvation misdiagnose as "the ring stayed
+        // silent" (2026-09-04 tester export: `all-day`/`sport` `noAck` on nearly every cycle, only
+        // `sleep` — first in the foreground plan — occasionally winning the race).
+        var trace = HistoryChannelTrace(label: "all-day", channel: 0x03)
+        trace.exitReason = .cancelled
+        XCTAssertEqual(trace.outcome, .cancelled)
+        XCTAssertFalse(trace.outcome.allowsSleepCommit)
+    }
+
+    func testRealEvidenceOutranksACancelledExitReason() {
+        // If pages or an ACK arrived before the cancellation landed, that's real evidence the
+        // cancel must not erase — same precedence rule as the `.linkDown` write-failure flag.
+        var acked = HistoryChannelTrace(label: "all-day", channel: 0x03)
+        acked.sawSyncAck = true
+        acked.exitReason = .cancelled
+        XCTAssertEqual(acked.outcome, .empty)
+
+        var paged = HistoryChannelTrace(label: "sleep", channel: 0x00)
+        paged.page4CCount = 2
+        paged.endMarkerCount = 1
+        paged.exitReason = .cancelled
+        XCTAssertEqual(paged.outcome, .complete)
+        XCTAssertTrue(paged.outcome.allowsSleepCommit)
+    }
 }


### PR DESCRIPTION
## Summary

Reported symptoms (2026-09-04 diagnostics bundle, build 51):
1. Automatic workout detection never fires despite the ring showing an elevated HR while inactive.
2. Step undercount of ~75% (~20,000 real steps vs. ~5,000 recorded).

Diagnostics evidence: the sync activity log is dominated by `session replaced — no drain ran`, the `all-day` and `sport` history-drain channels report `outcome=empty` / `noAck ... added=0` on nearly every cycle, only `sleep` occasionally completes, and HR itself captures fine (713 readings) — so the ring/notify pipe is healthy; only the multi-second drain handshake is affected.

**Root cause, confirmed with code evidence:**

- `RingScanner.teardownSession()` (`RingScanner.swift:444`) cancels the session's `syncTask` on *every* session replacement — not just user-initiated disconnects, but every reconnect after any BLE drop (`didConnect`, `willRestoreState`, `didDisconnectPeripheral` all route through it).
- `HistoryDrainPlan.steps` always tries `sleep` first in the foreground (`HistoryDrainPlan.swift:114`, `RingSession.swift:3342`). So when churn lands mid-drain, `sleep` — first in line — has the best chance of finishing before the next churn event, while `all-day`/`sport`, queued behind it, are disproportionately the ones cut off. This matches "sleep occasionally completes, all-day/sport almost never do."
- The interruption was invisible in diagnostics: `HistoryChannelTrace.outcome` (`HistorySyncAssessment.swift`, pre-fix) had no branch for `exitReason == .cancelled`. A channel cut off mid-wait (no pages, no ack yet — exactly what a churn interruption looks like) fell through to `.noAck`, indistinguishable from "the ring is connected and genuinely never answered." This is precisely the signal-conflation `HistoryDrainPlan.swift`'s own 2026-07-27 investigation comment warned about ("a cancelled channel classifies `.noAck`") when it rejected a naive reorder-on-failure heuristic — the conflation itself was never fixed at the source, only worked around for the `.linkDown` (write-never-sent) case.
- Consequences of `all-day`/`sport` starvation:
  - `sport` (0x02) carries the 10-second HR+step samples `AutomaticWorkoutDetector` needs to reconstruct a ≥10-minute candidate (`AutomaticWorkoutDetection.swift`). It's foreground-only and always last in the plan, so it almost never gets a turn ⇒ automatic detection never fires even with a real HR spike.
  - Steps come from the ring's onboard counter, which is a **quarter-hour bucket** read via the live keepalive `fetch` descriptor (`RingSession.swift:4367`): "what it can never do is recover a quarter nobody was connected for." Frequent session churn means the app spends much of the day reconnecting/re-authenticating rather than `ready`+connected, so many 15-minute windows never get a successful read — consistent with a ~75% loss.

Both symptoms trace to the same root (excessive session churn), via two different mechanisms — one through the drain queue, one through reduced live keepalive coverage.

## Fix

Checked `fix/history-sync-cursor`, `fix/overnight-quiet-drain-119`, `fix/bg-store-wipe-131`, and `agent/fix-workout-reconnect-and-sleep-windows` for precedent — all four are already merged into `master`. `WorkoutSessionManager.adoptReconnectedSession` already solves the analogous problem for a *manual, active* workout (re-arm native sport on the replacement session); this extends the same reconnect-resume idea to the *automatic* history-drain path, which had no equivalent.

1. **`HistorySyncAssessment.swift`** — add `HistoryChannelOutcome.cancelled`, checked after every "we heard something" branch (same precedence rule as `.linkDown`) so a channel cut off by our own teardown is no longer misreported as `.noAck`.
2. **`HistoryDrainPlan.swift`** — add a pure `resuming(_:in:)` helper that moves one already-scheduled step to the front of a plan. This is *not* the standing reorder-by-history heuristic this file explicitly prototyped and rejected in 2026-07-27 (that signal was polluted by user Measure-cancels and the `allDayOnly` prime, and recomputing it every pass would thrash). This is a one-shot resume driven by a single precise, first-hand fact, consumed once regardless of outcome.
3. **`RingSession.swift`** — `interruptedDrainChannel` reads, synchronously and before any cancellation, which channel (if any) is actively mid-wait; `resumeChannelHint` is the one-shot hint a replacement session consumes on its first `performHistoryDrain`.
4. **`RingScanner.swift`** — `teardownSession()` captures `interruptedDrainChannel` from the outgoing session *before* calling `invalidate()` (cancellation is cooperative and asynchronous, so this is the only reliable read point) into `pendingDrainResume`, which is handed to whichever session eventually replaces it (`didConnect` / `willRestoreState`).

This cannot make things worse: it only ever reorders steps already in a given plan (verified by test — the `allDayOnly` workout-prime plan, which must never include `sleep`, per #119, is untouched by a stale hint), and it's scoped to actual session teardown only — a user tapping Measure cancels `syncTask` in place (`RingSession.swift:960`) without going through `teardownSession()`, so it can't pollute the hint the way the rejected heuristic could.

## Test plan

- [x] `swift test` in `ios/OpenCircuitKit` — full suite, 1669 tests, 0 failures (11 pre-existing environment-gated corpus skips, unrelated).
- [x] New tests: `HistorySyncAssessmentTests.testCancelledMidWaitIsNotMisreportedAsNoAck`, `testRealEvidenceOutranksACancelledExitReason`; `HistoryDrainPlanTests.testResumingMovesTheHintedStepToTheFront`, `testResumingIsANoOpWhenTheHintedStepIsAlreadyFirst`, `testResumingIsANoOpWhenTheHintedStepIsNotInThePlan` (regression guard for #119).
- [x] `xcodebuild build` for the `OpenCircuit` scheme (iOS Simulator destination) — builds clean, confirming `RingSession.swift`/`RingScanner.swift` compile.
- [ ] Needs an on-device smoke test in a genuinely churny link environment (Juan's own ring) to confirm the diagnostics log shows `.cancelled` outcomes where it used to show `.noAck`, and that `all-day`/`sport` start completing more often across a real day.